### PR TITLE
Minor City Update: Migo buff/Ruined Town nerf

### DIFF
--- a/_maps/Quests/ruined_town.dmm
+++ b/_maps/Quests/ruined_town.dmm
@@ -831,7 +831,10 @@
 "fd" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/lootcrate/hana,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /turf/open/floor/wood,
 /area/city)
 "fe" = (
@@ -7541,7 +7544,10 @@
 /obj/structure/table{
 	color = "#875300"
 	},
-/obj/structure/lootcrate/hana,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /turf/open/floor/plating/rust,
 /area/city/shop)
 "Wd" = (
@@ -17572,7 +17578,7 @@ gO
 Vr
 oY
 Vr
-aq
+fd
 fk
 en
 aq
@@ -18403,7 +18409,7 @@ ka
 ka
 ka
 HV
-vx
+xR
 tU
 vx
 ka

--- a/_maps/Quests/ruined_town.dmm
+++ b/_maps/Quests/ruined_town.dmm
@@ -2069,11 +2069,6 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/rust,
 /area/city)
-"nA" = (
-/obj/structure/lootcrate/hana,
-/obj/structure/lootcrate/hana,
-/turf/open/floor/plating/asteroid/basalt/wasteland,
-/area/city)
 "nD" = (
 /obj/structure/table/anvil{
 	pixel_y = 17;
@@ -17577,7 +17572,7 @@ gO
 Vr
 oY
 Vr
-fd
+aq
 fk
 en
 aq
@@ -18408,7 +18403,7 @@ ka
 ka
 ka
 HV
-nA
+vx
 tU
 vx
 ka

--- a/code/modules/mob/living/simple_animal/hostile/netherworld.dm
+++ b/code/modules/mob/living/simple_animal/hostile/netherworld.dm
@@ -91,8 +91,8 @@
 	name = "mi-go"
 	desc = "A pinkish, fungoid crustacean-like creature with numerous pairs of clawed appendages and a head covered with waving antennae."
 	speak_emote = list("screams", "clicks", "chitters", "barks", "moans", "growls", "meows", "reverberates", "roars", "squeaks", "rattles", "exclaims", "yells", "remarks", "mumbles", "jabbers", "stutters", "seethes")
-	health = 250
-	maxHealth = 250
+	health = 300
+	maxHealth = 300
 	icon_state = "mi-go"
 	icon_living = "mi-go"
 	icon_dead = "mi-go-dead"
@@ -101,7 +101,7 @@
 	speed = -0.5
 	rapid_melee = 4
 	melee_damage_type = WHITE_DAMAGE
-	melee_damage_lower = 1
+	melee_damage_lower = 3
 	melee_damage_upper = 3
 	damage_coeff = list(RED_DAMAGE = 1, WHITE_DAMAGE = 1.5, BLACK_DAMAGE = 1, PALE_DAMAGE = 1)
 	butcher_results = list(/obj/item/food/meat/slab/fruit = 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This just reduces the number of hana crates in the Ruined Town Quest to 3 in the migo area, changes the other crates into money crates and buffs the migos to have +50 HP, and deal 3 WHITE damage on hit. (Used to be 1-3 WHITE damage)

## Why It's Good For The Game

Makes that area a bit more challenging, which makes the new prize for beating that area make more sense.

## Changelog
:cl:
balance: ruined town migos
balance: replaced some hana crates with ahn crates in the migo area.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
