### PR TITLE
Mini Col Update: BPU Update

### DIFF
--- a/ModularTegustation/lc13_machinery.dm
+++ b/ModularTegustation/lc13_machinery.dm
@@ -389,7 +389,7 @@
 	if(SSmaptype.maptype == "office")
 		public_use = TRUE
 		clone_delay_seconds = 60
-		revival_attribute_penalty = -2
+		revival_attribute_penalty = 0
 		cost_multiplier = 2
 
 /obj/machinery/body_preservation_unit/attackby(obj/item/I, mob/user, params)
@@ -423,7 +423,7 @@
 	dat += "<b>FUNDS: [stored_money]</b><br>----------------------<br>"
 
 	if (!public_use && !(user?.mind?.assigned_role in usable_roles))
-		dat += "<b>Only civilians can use this machine</b><br>"
+		dat += "<b>You are unable to use this BPU!</b><br>"
 	else
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user

--- a/ModularTegustation/lc13_machinery.dm
+++ b/ModularTegustation/lc13_machinery.dm
@@ -720,6 +720,7 @@
 	cost_multiplier = 10
 	usable_roles = list("Association Section Director", "Association Veteran", "Association Fixer")
 
+//Was planned to help out the clinic in CoL, now it is here for admin events.
 /obj/item/kquick_revive
 	name = "k-corp quickfix ampule"
 	desc = "A syringe of kcorp healing nanobots. This one fixes any fallen bodies."
@@ -727,10 +728,15 @@
 	icon_state = "kcorp_syringe2"
 	slot_flags = ITEM_SLOT_POCKETS
 	w_class = WEIGHT_CLASS_SMALL
+	var/usable_roles = list("Doctor")
 	var/heal_cooldown
 	var/heal_cooldown_time = 5 SECONDS
 
 /obj/item/kquick_revive/attack(mob/living/M, mob/user)
+	if(!(user?.mind?.assigned_role in usable_roles))
+		to_chat(user, span_danger("You cannot use this item."))
+		return
+
 	if(M.stat != DEAD)
 		to_chat(user, span_notice("This syringe only works on dead humans!"))
 		return

--- a/ModularTegustation/lc13_machinery.dm
+++ b/ModularTegustation/lc13_machinery.dm
@@ -719,3 +719,25 @@
 	revival_attribute_penalty = 0
 	cost_multiplier = 10
 	usable_roles = list("Association Section Director", "Association Veteran", "Association Fixer")
+
+/obj/item/kquick_revive
+	name = "k-corp quickfix ampule"
+	desc = "A syringe of kcorp healing nanobots. This one fixes any fallen bodies."
+	icon = 'ModularTegustation/Teguicons/teguitems.dmi'
+	icon_state = "kcorp_syringe2"
+	slot_flags = ITEM_SLOT_POCKETS
+	w_class = WEIGHT_CLASS_SMALL
+	var/heal_cooldown
+	var/heal_cooldown_time = 5 SECONDS
+
+/obj/item/kquick_revive/attack(mob/living/M, mob/user)
+	if(M.stat != DEAD)
+		to_chat(user, span_notice("This syringe only works on dead humans!"))
+		return
+
+	if(heal_cooldown <= world.time)
+		heal_cooldown = world.time + heal_cooldown_time
+		to_chat(user, span_nicegreen("You inject the syringe."))
+		M.adjustBruteLoss(-400, FALSE)
+	else
+		to_chat(user, span_warning("This syringe has not recharged yet!"))

--- a/ModularTegustation/lc13_machinery.dm
+++ b/ModularTegustation/lc13_machinery.dm
@@ -378,7 +378,7 @@
 	var/revival_attribute_penalty = -4
 	var/list/stored_bodies = list()
 	var/clone_delay_seconds = 120
-	var/cost_multiplier = 5
+	var/cost_multiplier = 2
 	var/list/usable_roles = list("Civilian", "Office Director", "Office Fixer",
 		"Subsidary Office Director", "Fixer")
 	resistance_flags = INDESTRUCTIBLE

--- a/ModularTegustation/lc13_machinery.dm
+++ b/ModularTegustation/lc13_machinery.dm
@@ -375,10 +375,12 @@
 	var/public_use = FALSE
 	var/stored_money = 0
 	//var/preservation_fee = 500
-	var/revival_attribute_penalty = -6
+	var/revival_attribute_penalty = -4
 	var/list/stored_bodies = list()
 	var/clone_delay_seconds = 120
 	var/cost_multiplier = 5
+	var/list/usable_roles = list("Civilian", "Office Director", "Office Fixer",
+		"Subsidary Office Director", "Fixer")
 	resistance_flags = INDESTRUCTIBLE
 	max_integrity = 1000000
 
@@ -387,7 +389,7 @@
 	if(SSmaptype.maptype == "office")
 		public_use = TRUE
 		clone_delay_seconds = 60
-		revival_attribute_penalty = -4
+		revival_attribute_penalty = -2
 		cost_multiplier = 2
 
 /obj/machinery/body_preservation_unit/attackby(obj/item/I, mob/user, params)
@@ -420,7 +422,7 @@
 	dat += "<b>Body Preservation Unit</b><br>"
 	dat += "<b>FUNDS: [stored_money]</b><br>----------------------<br>"
 
-	if (!public_use && !(user?.mind?.assigned_role in list("Civilian")))
+	if (!public_use && !(user?.mind?.assigned_role in usable_roles))
 		dat += "<b>Only civilians can use this machine</b><br>"
 	else
 		if(ishuman(user))
@@ -701,3 +703,19 @@
 		if(O.real_name == real_name)
 			return O
 	return null
+
+/obj/machinery/body_preservation_unit/clinic
+	name = "clinic body preservation unit"
+	desc = "A high-tech machine that can store a digital copy of your body and attributes. In case of death, it can revive you. This one can only be used by the clinic."
+	clone_delay_seconds = 60
+	revival_attribute_penalty = 0
+	cost_multiplier = 0
+	usable_roles = list("Doctor", "Surgeon", "Nurse", "Paramedic", "Medical Fixer Assistant", "Prosthetics Surgeon")
+
+/obj/machinery/body_preservation_unit/association
+	name = "association body preservation unit"
+	desc = "A high-tech machine that can store a digital copy of your body and attributes. In case of death, it can revive you. This one can only be used by the association."
+	clone_delay_seconds = 60
+	revival_attribute_penalty = 0
+	cost_multiplier = 10
+	usable_roles = list("Association Section Director", "Association Veteran", "Association Fixer")

--- a/code/modules/jobs/job_types/city/doctor.dm
+++ b/code/modules/jobs/job_types/city/doctor.dm
@@ -144,5 +144,5 @@
 	uniform = /obj/item/clothing/under/rank/medical/paramedic
 	head = /obj/item/clothing/head/soft/paramedic
 	suit =  /obj/item/clothing/suit/toggle/labcoat/paramedic
-	backpack_contents = list(/obj/item/pinpointer/crew=1)
+	backpack_contents = list(/obj/item/pinpointer/crew=1, /obj/item/kquick_revive=1)
 	l_hand = /obj/item/ego_weapon/ranged/pistol/kcorp

--- a/code/modules/jobs/job_types/city/doctor.dm
+++ b/code/modules/jobs/job_types/city/doctor.dm
@@ -62,7 +62,7 @@
 	satchel = /obj/item/storage/backpack/satchel/med
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
 	box = /obj/item/storage/box/survival/medical
-	backpack_contents = list(/obj/item/kquick_revive=1)
+	backpack_contents = list()
 
 
 //Doctor assistants

--- a/code/modules/jobs/job_types/city/doctor.dm
+++ b/code/modules/jobs/job_types/city/doctor.dm
@@ -62,7 +62,7 @@
 	satchel = /obj/item/storage/backpack/satchel/med
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
 	box = /obj/item/storage/box/survival/medical
-
+	backpack_contents = list(/obj/item/kquick_revive=1)
 
 
 //Doctor assistants
@@ -144,5 +144,5 @@
 	uniform = /obj/item/clothing/under/rank/medical/paramedic
 	head = /obj/item/clothing/head/soft/paramedic
 	suit =  /obj/item/clothing/suit/toggle/labcoat/paramedic
-	backpack_contents = list(/obj/item/pinpointer/crew=1, /obj/item/kquick_revive=1)
+	backpack_contents = list(/obj/item/pinpointer/crew=1)
 	l_hand = /obj/item/ego_weapon/ranged/pistol/kcorp


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A Small PR which adds a clinic and association based BPU, along with a small tool for admin events.

1. The only roles that work in the Clinic are able to sign up to the clinic BPU, which is free and does not reduces attributes on clone.
2. Same for the association and their BPU, however that one is not free.
3. The tool is a reusable k-corp ampule which heals all brute damage from dead bodies.

## Why It's Good For The Game

1. The clinic is an important role which NEEDs some way of coming back to life if they are killed, due to them being the only ones who can revive fixers.
2. Association Fixers have attribute requirements for their gear and if they are gibbed and are given a cheap body, they will lose access to all of their skills and their gear. This BPU will allow a simple way of keeping their skills after getting gibbed.
3. Sometimes, Admin events can get a bit bloody, and the doc needs a faster way of bringing fixers back.

## Changelog
:cl:
add: clinic and association bpu, also k-corp quickfix
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
