### PR TITLE
Hammer of Light changes

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
@@ -1,5 +1,7 @@
 // Coded by Coxswain, sprites by Mel, Coxwswain and glowinthedarkmannhandler.
 #define STATUS_EFFECT_EVENING_TWILIGHT /datum/status_effect/evening_twilight
+#define STATUS_EFFECT_DAYBREAK /datum/status_effect/daybreak
+
 /mob/living/simple_animal/hostile/abnormality/hammer_light
 	name = "Hammer of Light"
 	desc = "A white hammer engraved with yellow runic writing."
@@ -42,6 +44,7 @@
 	pet_bonus = "hums" // saves a few lines of code by allowing funpet() to be called by attack_hand()
 	var/sealed = TRUE
 	var/hammer_present = TRUE
+	var/hammer_used = FALSE
 	var/list/spawned_mobs = list()
 	var/list/banned = list()
 	var/mob/living/carbon/human/current_user = null
@@ -91,7 +94,7 @@
 	RegisterSignal(SSdcs, COMSIG_GLOB_ABNORMALITY_BREACH, PROC_REF(Check))
 
 /mob/living/simple_animal/hostile/abnormality/hammer_light/proc/Check() // A lot going on here, but basically we assess how bad the situation in the facility is
-	if((!hammer_present) || usable_cooldown > world.time)
+	if((!hammer_present) || usable_cooldown > world.time || (hammer_used))
 		return
 	points = 0
 	for(var/mob/living/simple_animal/hostile/abnormality/A in GLOB.abnormality_mob_list) // How many breaching abnormalities? How dangerous are they?
@@ -155,6 +158,9 @@
 	if(!hammer_present)
 		to_chat(H, span_warning("The hammer is not there!"))
 		return
+	if(hammer_used)
+		to_chat(H, span_warning("The hammer is not responding, the price has been paid already."))
+		return
 	if(sealed)
 		to_chat(H, span_warning("The hammer is sealed!"))
 		return
@@ -175,15 +181,12 @@
 	banned += user.ckey
 	current_user = user
 	RegisterSignal(current_user, COMSIG_LIVING_DEATH, PROC_REF(UserDeath))
-	user.apply_status_effect(STATUS_EFFECT_EVENING_TWILIGHT)
+	user.apply_status_effect(STATUS_EFFECT_EVENING_TWILIGHT, src)
 	chosen_arms = new /obj/item/ego_weapon/hammer_light(get_turf(user))
 	user.put_in_hands(chosen_arms, forced = TRUE)
 	hammer_present = FALSE
+	hammer_used = TRUE
 	playsound(get_turf(src), "[pick(pickup_sounds)]", 75, 0, -9)
-	ADD_TRAIT(user, TRAIT_COMBATFEAR_IMMUNE, "Abnormality")
-	ADD_TRAIT(user, TRAIT_WORK_FORBIDDEN, "Abnormality")
-	ADD_TRAIT(user, TRAIT_IGNOREDAMAGESLOWDOWN, "Abnormality")
-	ADD_TRAIT(user, TRAIT_NODROP, "Abnormality")
 	user.hairstyle = "Bald"
 	user.update_hair()
 	update_icon()
@@ -195,6 +198,7 @@
 		RecoverHammer()
 
 /mob/living/simple_animal/hostile/abnormality/hammer_light/proc/RecoverHammer()
+	UnregisterSignal(current_user, COMSIG_LIVING_DEATH)
 	qdel(chosen_arms)
 	chosen_arms = null
 	current_user = null
@@ -204,7 +208,6 @@
 	update_icon()
 
 /mob/living/simple_animal/hostile/abnormality/hammer_light/proc/UserDeath(mob/living/carbon/human/user)
-	UnregisterSignal(current_user, COMSIG_LIVING_DEATH)
 	if(!QDELETED(current_user)) // in case they died without being dusted
 		current_user.dust()
 	RecoverHammer()
@@ -378,12 +381,21 @@
 	duration = 5 MINUTES // max duration
 	alert_type = null
 	var/attribute_bonus = 0
+	var/mob/living/simple_animal/hostile/abnormality/hammer_light/parent
+
+/datum/status_effect/evening_twilight/on_creation(mob/living/new_owner, hammer)
+	. = ..()
+	parent = hammer
 
 /datum/status_effect/evening_twilight/on_apply()
 	if(!ishuman(owner))
 		return
 	var/mob/living/carbon/human/status_holder = owner
 	to_chat(status_holder, span_nicegreen("You feel powerful."))
+	ADD_TRAIT(status_holder, TRAIT_COMBATFEAR_IMMUNE, "Abnormality")
+	ADD_TRAIT(status_holder, TRAIT_WORK_FORBIDDEN, "Abnormality")
+	ADD_TRAIT(status_holder, TRAIT_IGNOREDAMAGESLOWDOWN, "Abnormality")
+	ADD_TRAIT(status_holder, TRAIT_NODROP, "Abnormality")
 	status_holder.add_overlay(mutable_appearance('ModularTegustation/Teguicons/32x32.dmi', "hammer_overlay", -ABOVE_MOB_LAYER))
 	status_holder.physiology.red_mod *= 0.3
 	status_holder.physiology.white_mod *= 0.3
@@ -395,8 +407,49 @@
 /datum/status_effect/evening_twilight/on_remove()
 	if(!ishuman(owner))
 		return
-	var/mob/living/status_holder = owner
-	status_holder.dust()
+	parent.RecoverHammer()
+	var/mob/living/carbon/human/status_holder = owner
+	REMOVE_TRAIT(status_holder, TRAIT_COMBATFEAR_IMMUNE, "Abnormality")
+	REMOVE_TRAIT(status_holder, TRAIT_WORK_FORBIDDEN, "Abnormality")
+	REMOVE_TRAIT(status_holder, TRAIT_IGNOREDAMAGESLOWDOWN, "Abnormality")
+	REMOVE_TRAIT(status_holder, TRAIT_NODROP, "Abnormality")
+	status_holder.apply_status_effect(/datum/status_effect/daybreak)
+	return ..()
+
+// Daybreak - Massive debuff applied after you run out of time with the Hammer.
+/datum/status_effect/daybreak
+	id = "daybreak"
+	status_type = STATUS_EFFECT_UNIQUE
+	duration = 10 MINUTES
+	alert_type = null
+
+/datum/status_effect/daybreak/on_apply()
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	playsound(get_turf(owner), 'sound/effects/burn.ogg', 75, FALSE)
+	to_chat(status_holder, span_userdanger("The light leaves your body, taking far more than what it gave. You feel extremely weak."))
+	status_holder.cut_overlay(mutable_appearance('ModularTegustation/Teguicons/32x32.dmi', "hammer_overlay", -ABOVE_MOB_LAYER))
+	status_holder.physiology.red_mod /= 0.3
+	status_holder.physiology.white_mod /= 0.3
+	status_holder.physiology.black_mod /= 0.3
+	status_holder.physiology.pale_mod /= 0.3
+	status_holder.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, -222)
+	status_holder.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, -222)
+	status_holder.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, -222)
+	status_holder.adjust_attribute_buff(JUSTICE_ATTRIBUTE, -222)
+	return ..()
+
+/datum/status_effect/daybreak/on_remove()
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	to_chat(status_holder, span_danger("Your feel whole again, yet also diminished. The searing light has irreparably burnt a part of your soul."))
+	status_holder.adjust_attribute_limit(-10) // It burns some of your potential, permanently.
+	status_holder.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, 222)
+	status_holder.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, 222)
+	status_holder.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, 222)
+	status_holder.adjust_attribute_buff(JUSTICE_ATTRIBUTE, 222)
 	return ..()
 
 // Heroism - A powerful healing effect applied to people at low hp by the work mechanic. Heals 30% of HP/HP over 3 seconds

--- a/code/modules/paperwork/records/info/zayin.dm
+++ b/code/modules/paperwork/records/info/zayin.dm
@@ -110,7 +110,8 @@
 		"When the seal is broken, an employee can simply walk up to the abnormality and pick up the hammer.",
 		"When a level 1 employee tried to pick up the hammer, they were reduced to ashes by its power.",
 		"When agent YumYum picked up the unsealed hammer, they were granted the immense power required to resolve the emergency situation.",
-		"However, once the situation began to settle down, YumYum disappeared.")
+		"However, once the situation began to settle down, YumYum stumbled and collapsed.",
+		"Agent YumYum recovered after a period of extreme weakness, yet subsequent medical examinations revealed a significant reduction in her expected lifespan.")
 
 //Vending Machine and Oceanic Waves
 /obj/item/paper/fluff/info/zayin/oceanic_waves


### PR DESCRIPTION
## About The Pull Request

Changes to the behaviour of Hammer of Light when unsealed:
- Now it can only be used a single time per round.
- After the time is up, the Hammer no longer dusts its wielder but it inflicts them with the "Daybreak" debuff.
- Daybreak reduces all their virtues to practically zero for 10 minutes, and permanently reduces their virtue-cap by 10.

## Why It's Good For The Game

Hammer has gone largely unused for a long time. I believe that this is because the playerbase does not like any guaranteed death mechanics no matter the boons that they might provide (The same problem that Backwards Clock has), therefore let's try to rebalance the Hammer to remove this guaranteed death yet keeping it as a "hail mary" mechanic to make a comeback from a catastrophic situation.

## Changelog
:cl:
tweak: Hammer of Light no longer dusts you after wielding it.
/:cl: