### PR TITLE
Adds the Ordeal Fast-Track button.

### DIFF
--- a/code/__DEFINES/facility_upgrades.dm
+++ b/code/__DEFINES/facility_upgrades.dm
@@ -26,6 +26,7 @@
 #define UPGRADE_ABNO_QUEUE_COUNT "Abnormality Extraction Amount"
 #define UPGRADE_ABNO_MELT_TIME "Abnormality Meltdown Bonus Duration"
 #define UPGRADE_ABNO_ARRIVAL "Instant Abnormality Arrival"
+#define UPGRADE_ORDEAL_SPEED "Ordeal Fast-Track"
 
 // Higher-Up Specialization upgrades
 #define UPGRADE_DISCIPLINARY_1 "Disciplinary Specialization  Level 1"

--- a/code/datums/facility_upgrade.dm
+++ b/code/datums/facility_upgrade.dm
@@ -227,6 +227,21 @@
 	SSabnormality_queue.SpawnAbno()
 	. = ..()
 
+//Move to just before the next Ordeal
+/datum/facility_upgrade/ordeal_speed
+	name = UPGRADE_ORDEAL_SPEED
+	category = "Facility"
+	value = 1
+	max_value = 2
+	info = " - This upgrade causes the meltdown counter to move just before the next <b>Ordeal</b>.."
+
+/datum/facility_upgrade/ordeal_speed/Upgrade()
+	SSlobotomy_corp.qliphoth_state = SSlobotomy_corp.next_ordeal_time - 2
+	SSlobotomy_corp.QliphothEvent()
+	message_admins("The Manager has caused the meltdown counter to move before the next ordeal.")
+	to_chat(world, span_danger("<b>The manager has requested that this be the last meltdown before the ordeal!</b>"))
+	. = ..()
+
 /datum/facility_upgrade/regnenerator_healing
 	name = UPGRADE_REGENERATOR_HEALING
 	category = "Facility"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds in the Ordeal Fast Track button, a way for managers to force the next ordeal.
If it's before the timelock, then it will activate on the next meltdown after the timelock.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Some people want the game to be faster. This PR does just that, for a small cost.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added Ordeal Fast-Track
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
