### PR TITLE
Makes Max Sanity and Max Health more Accurate [DONE?]

### DIFF
--- a/code/datums/attributes/_attribute.dm
+++ b/code/datums/attributes/_attribute.dm
@@ -43,7 +43,7 @@ GLOBAL_LIST_INIT(attribute_types, list(
 // Used in show_attributes() human proc
 // Returns current level + initial_stat_value, placed next to information such as modifiers
 // Mainly used by fortitude & prudence
-/datum/attribute/proc/get_printed_level_bonus()
+/datum/attribute/proc/get_printed_level_bonus(mob/living/carbon/refrence_user)
 	return round(level) + initial_stat_value
 
 /datum/attribute/proc/on_update(mob/living/carbon/user)

--- a/code/datums/attributes/fortitude.dm
+++ b/code/datums/attributes/fortitude.dm
@@ -4,8 +4,11 @@
 	affected_stats = list("Max Health")
 	initial_stat_value = DEFAULT_HUMAN_MAX_HEALTH
 
-/datum/attribute/fortitude/get_printed_level_bonus()
-	return round(level * FORTITUDE_MOD) + initial_stat_value
+/datum/attribute/fortitude/get_printed_level_bonus(mob/living/carbon/refrence_user)
+	var/modifier = (SSmaptype.chosen_trait == FACILITY_TRAIT_XP_MOD ? 1.7 : FORTITUDE_MOD)
+	if(refrence_user)
+		return refrence_user.getRawMaxHealth() + round(level * modifier)
+	return round(level * modifier) + initial_stat_value
 
 /datum/attribute/fortitude/on_update(mob/living/carbon/user)
 	if(!istype(user))

--- a/code/datums/attributes/prudence.dm
+++ b/code/datums/attributes/prudence.dm
@@ -4,5 +4,8 @@
 	affected_stats = list("Max Sanity")
 	initial_stat_value = DEFAULT_HUMAN_MAX_SANITY
 
-/datum/attribute/prudence/get_printed_level_bonus()
-	return round(level * PRUDENCE_MOD) + initial_stat_value
+/datum/attribute/prudence/get_printed_level_bonus(mob/living/carbon/refrence_user)
+	var/modifier = (SSmaptype.chosen_trait == FACILITY_TRAIT_XP_MOD ? 1.7 : PRUDENCE_MOD)
+	if(refrence_user)
+		return refrence_user.getRawMaxSanity() + round(level * modifier)
+	return round(level * modifier) + initial_stat_value

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1351,3 +1351,11 @@
 	if (species)
 		return species.attack_type
 	return ..()
+
+//Max Health that is not effected by attributes.
+/mob/living/carbon/proc/getRawMaxHealth()
+	//If no attributes dont even worry about it.
+	return initial(maxHealth)
+
+/mob/living/carbon/proc/getRawMaxSanity()
+	return initial(maxSanity)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -98,7 +98,11 @@
 		for(var/stat in atr.affected_stats)
 			.["stats"] += stat
 			.[stat + "name"] = stat
-			.[stat + "base"] = atr.get_printed_level_bonus() + atr.get_level_buff()
+			//If not max health or max sanity do not add level buff
+			if(stat == "Max Health" || stat == "Max Sanity")
+				.[stat + "base"] = atr.get_printed_level_bonus()
+			else
+				.[stat + "base"] = atr.get_printed_level_bonus() + atr.get_level_buff()
 			.[stat + "bonus"] = round(atr.get_stat_bonus())
 
 /mob/living/carbon/human/ui_interact(mob/user, datum/tgui/ui)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -253,3 +253,14 @@
 	destination.undershirt = undershirt
 	destination.socks = socks
 	destination.jumpsuit_style = jumpsuit_style
+
+//Max Health that is not effected by attributes.
+/mob/living/carbon/human/getRawMaxHealth()
+	if(LAZYLEN(attributes))
+		return SSmaptype.chosen_trait == FACILITY_TRAIT_XP_MOD ? 40 : DEFAULT_HUMAN_MAX_HEALTH
+	return ..()
+
+/mob/living/carbon/human/getRawMaxSanity()
+	if(LAZYLEN(attributes))
+		return SSmaptype.chosen_trait == FACILITY_TRAIT_XP_MOD ? 40 : DEFAULT_HUMAN_MAX_SANITY
+	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I was requested to make the max health and sanity in the attribute window more accurate since before they were calculated from the attributes buff stat and a pre set human health value. Now its displayed as maxHealth - stat_bonus. stat_bonus is shown below this value. 

<img width="781" height="337" alt="image" src="https://github.com/user-attachments/assets/28e50154-13d8-42d5-a029-40ff99de8747" />


I was confused at this
<img width="775" height="396" alt="Screenshot 2025-08-13 230157" src="https://github.com/user-attachments/assets/9f394600-7184-476a-bb58-70bf3ef9bd9b" />
But it turns out the calculation is correct. My current health is 230 - 40 its just visually confusing.

## Why It's Good For The Game
Makes the stat base more accurate.
Visually declutters the attributes window.

## Changelog
:cl:
tweak: get_printed_level_bonus() proc and how max health and sanity appear in the attribute window.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
