### PR TITLE
Deepscanner now shows original resistances pre-shred on the first scan

### DIFF
--- a/ModularTegustation/tegu_items/gadgets/unpowered.dm
+++ b/ModularTegustation/tegu_items/gadgets/unpowered.dm
@@ -322,6 +322,7 @@
 	if(!do_after(user, 2 SECONDS, target, IGNORE_USER_LOC_CHANGE | IGNORE_TARGET_LOC_CHANGE, TRUE, CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(can_see), user, target, 7)))
 		return
 	check1e = FALSE
+	var/should_apply_debuff = FALSE
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		var/suit = H.get_item_by_slot(ITEM_SLOT_OCLOTHING)
@@ -353,10 +354,7 @@
 			check1e = H.job
 	else
 		var/mob/living/simple_animal/mon = target
-		if(!(mon.status_flags & GODMODE))
-			if(!mon.HasDamageMod(/datum/dc_change/scanned))
-				mon.AddModifier(/datum/dc_change/scanned)
-				to_chat(user, span_nicegreen("[mon]'s weakness was analyzed!"))
+		should_apply_debuff = TRUE
 		check1a = mon.damage_coeff.getCoeff(RED_DAMAGE)
 		check1b = mon.damage_coeff.getCoeff(WHITE_DAMAGE)
 		check1c = mon.damage_coeff.getCoeff(BLACK_DAMAGE)
@@ -375,7 +373,12 @@
 	to_chat(user, span_notice("[output]"))
 	deep_scan_log = output
 	playsound(get_turf(target), 'sound/misc/box_deploy.ogg', 5, 0, 3)
-
+	if(should_apply_debuff)
+		var/mob/living/simple_animal/mon = target
+		if(!(mon.status_flags & GODMODE))
+			if(!mon.HasDamageMod(/datum/dc_change/scanned))
+				mon.AddModifier(/datum/dc_change/scanned)
+				to_chat(user, span_nicegreen("[mon]'s weakness was analyzed!"))
 
 //General Invitation
 /obj/item/invitation //intended for ordeals


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The Deepscanner will now show the scanned target's resistances BEFORE applying the shred onto them. A little sloppily implemented but it shouldn't have any adverse effect. It will still show the modified resists if you scan it again.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Will give newer players better information on the weaknesses of whatever they're scanning. It'll be less confusing since there won't be weird values like 2.2.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Deepscanner now shows resistances pre-shred
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
