### PR TITLE
Health Code Refactor

### DIFF
--- a/code/__DEFINES/attributes.dm
+++ b/code/__DEFINES/attributes.dm
@@ -12,10 +12,10 @@
 
 
 /// The max human health is adjusted to default define + fortitude points * this modifier
-#define FORTITUDE_MOD 1
+#define FORTITUDE_MOD (SSmaptype.chosen_trait == FACILITY_TRAIT_XP_MOD ? 1.7 : 1)
 
 /// Same as above, but for sanity and prudence
-#define PRUDENCE_MOD 1
+#define PRUDENCE_MOD (SSmaptype.chosen_trait == FACILITY_TRAIT_XP_MOD ? 1.7 : 1)
 
 /// What the temperance scaling modifier is. Roughly, this is the temperance at infinite temperance. Higher is better.
 #define TEMPERANCE_SUCCESS_MOD 40

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -73,6 +73,10 @@
 #define DEFAULT_HUMAN_MAX_HEALTH 100
 /// Maximum sanity of a human mob, without prudence
 #define DEFAULT_HUMAN_MAX_SANITY 100
+/// Maximum health of a human mob, without fortitude
+#define DEFAULT_HUMAN_MAX_HEALTH_XP 40
+/// Maximum sanity of a human mob, without prudence
+#define DEFAULT_HUMAN_MAX_SANITY_XP 40
 
 #define HUMAN_MAX_OXYLOSS 3
 #define HUMAN_CRIT_MAX_OXYLOSS (SSmobs.wait/30)

--- a/code/controllers/subsystem/maptype.dm
+++ b/code/controllers/subsystem/maptype.dm
@@ -132,3 +132,16 @@ SUBSYSTEM_DEF(maptype)
 					GLOB.rcorp_objective = "payload_rcorp"
 				if(5)
 					GLOB.rcorp_objective = "payload_abno"
+
+/datum/controller/subsystem/maptype/vv_edit_var(var_name, var_value)
+	. = ..()
+	switch(var_name)
+		if(NAMEOF(src, chosen_trait))
+			for(var/mob/living/carbon/human/probably_agent in GLOB.mob_living_list)
+				if(!LAZYLEN(probably_agent.attributes))
+					continue
+				var/datum/attribute/fortitude/fort = probably_agent.attributes[FORTITUDE_ATTRIBUTE]
+				var/datum/attribute/prudence/prud = probably_agent.attributes[PRUDENCE_ATTRIBUTE]
+				fort.on_update(probably_agent)
+				prud.on_update(probably_agent)
+				probably_agent.updatehealth()

--- a/code/datums/attributes/_attribute.dm
+++ b/code/datums/attributes/_attribute.dm
@@ -43,10 +43,10 @@ GLOBAL_LIST_INIT(attribute_types, list(
 // Used in show_attributes() human proc
 // Returns current level + initial_stat_value, placed next to information such as modifiers
 // Mainly used by fortitude & prudence
-/datum/attribute/proc/get_printed_level_bonus(mob/living/carbon/refrence_user)
+/datum/attribute/proc/get_printed_level_bonus()
 	return round(level) + initial_stat_value
 
-/datum/attribute/proc/on_update(mob/living/carbon/user)
+/datum/attribute/proc/on_update(mob/living/carbon/human/user)
 	return
 
 /datum/attribute/proc/adjust_level(mob/living/carbon/human/user, addition)
@@ -107,6 +107,15 @@ GLOBAL_LIST_INIT(attribute_types, list(
 	if(!istype(atr))
 		return 0
 	return max(0, atr.get_modified_level())
+
+// Gets the printed level bonus, useful for max HP and SP
+/proc/get_attribute_printed_level_bonus(mob/living/carbon/human/user, attribute)
+	if(!istype(user) || !attribute)
+		return 0
+	var/datum/attribute/atr = user.attributes[attribute]
+	if(!istype(atr))
+		return 0
+	return max(0, atr.get_printed_level_bonus())
 
 //Getting raw level, mostly for tools.
 /proc/get_raw_level(mob/living/carbon/human/user, attribute)

--- a/code/datums/attributes/fortitude.dm
+++ b/code/datums/attributes/fortitude.dm
@@ -4,15 +4,13 @@
 	affected_stats = list("Max Health")
 	initial_stat_value = DEFAULT_HUMAN_MAX_HEALTH
 
-/datum/attribute/fortitude/get_printed_level_bonus(mob/living/carbon/refrence_user)
-	var/modifier = (SSmaptype.chosen_trait == FACILITY_TRAIT_XP_MOD ? 1.7 : FORTITUDE_MOD)
-	if(refrence_user)
-		return refrence_user.getRawMaxHealth() + round(level * modifier)
-	return round(level * modifier) + initial_stat_value
+/datum/attribute/fortitude/get_printed_level_bonus()
+	return round(level * (FORTITUDE_MOD ? FORTITUDE_MOD : 1)) + initial_stat_value
 
-/datum/attribute/fortitude/on_update(mob/living/carbon/user)
+/datum/attribute/fortitude/on_update(mob/living/carbon/human/user)
 	if(!istype(user))
 		return FALSE
+	initial_stat_value = SSmaptype.chosen_trait == FACILITY_TRAIT_XP_MOD ? DEFAULT_HUMAN_MAX_HEALTH_XP : DEFAULT_HUMAN_MAX_HEALTH
 	user.death_threshold = HEALTH_THRESHOLD_DEAD - round((level + level_buff) * 0.5)
 	user.hardcrit_threshold = HEALTH_THRESHOLD_FULLCRIT - round((level + level_buff) * 0.25)
 	return TRUE

--- a/code/datums/attributes/prudence.dm
+++ b/code/datums/attributes/prudence.dm
@@ -4,8 +4,9 @@
 	affected_stats = list("Max Sanity")
 	initial_stat_value = DEFAULT_HUMAN_MAX_SANITY
 
-/datum/attribute/prudence/get_printed_level_bonus(mob/living/carbon/refrence_user)
-	var/modifier = (SSmaptype.chosen_trait == FACILITY_TRAIT_XP_MOD ? 1.7 : PRUDENCE_MOD)
-	if(refrence_user)
-		return refrence_user.getRawMaxSanity() + round(level * modifier)
-	return round(level * modifier) + initial_stat_value
+/datum/attribute/prudence/get_printed_level_bonus()
+	return round(level * (PRUDENCE_MOD ? PRUDENCE_MOD : 1)) + initial_stat_value
+
+/datum/attribute/prudence/on_update(mob/living/carbon/human/user)
+	. = ..()
+	initial_stat_value = SSmaptype.chosen_trait == FACILITY_TRAIT_XP_MOD ? DEFAULT_HUMAN_MAX_SANITY_XP : DEFAULT_HUMAN_MAX_SANITY

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1352,10 +1352,3 @@
 		return species.attack_type
 	return ..()
 
-//Max Health that is not effected by attributes.
-/mob/living/carbon/proc/getRawMaxHealth()
-	//If no attributes dont even worry about it.
-	return initial(maxHealth)
-
-/mob/living/carbon/proc/getRawMaxSanity()
-	return initial(maxSanity)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -98,11 +98,7 @@
 		for(var/stat in atr.affected_stats)
 			.["stats"] += stat
 			.[stat + "name"] = stat
-			//If not max health or max sanity do not add level buff
-			if(stat == "Max Health" || stat == "Max Sanity")
-				.[stat + "base"] = atr.get_printed_level_bonus()
-			else
-				.[stat + "base"] = atr.get_printed_level_bonus() + atr.get_level_buff()
+			.[stat + "base"] = atr.get_printed_level_bonus() + atr.get_level_buff()
 			.[stat + "bonus"] = round(atr.get_stat_bonus())
 
 /mob/living/carbon/human/ui_interact(mob/user, datum/tgui/ui)
@@ -1320,14 +1316,8 @@
 
 /mob/living/carbon/human/updatehealth()
 	if(LAZYLEN(attributes))
-		maxHealth = max(1, DEFAULT_HUMAN_MAX_HEALTH + round(get_attribute_level(src, FORTITUDE_ATTRIBUTE) * FORTITUDE_MOD + get_stat_bonus(src, FORTITUDE_ATTRIBUTE, no_neg = FALSE)))
-		maxSanity = max(1, DEFAULT_HUMAN_MAX_SANITY + round(get_attribute_level(src, PRUDENCE_ATTRIBUTE) * PRUDENCE_MOD + get_stat_bonus(src, PRUDENCE_ATTRIBUTE, no_neg = FALSE)))
-
-		//Shit way of doing this.
-		if(SSmaptype.chosen_trait == FACILITY_TRAIT_XP_MOD)
-			maxHealth = max(1, 40 + round(get_attribute_level(src, FORTITUDE_ATTRIBUTE) * 1.7 + get_stat_bonus(src, FORTITUDE_ATTRIBUTE, no_neg = FALSE)))
-			maxSanity = max(1, 40 + round(get_attribute_level(src, PRUDENCE_ATTRIBUTE) * 1.7 + get_stat_bonus(src, PRUDENCE_ATTRIBUTE, no_neg = FALSE)))
-
+		maxHealth = max(1, get_attribute_printed_level_bonus(src, FORTITUDE_ATTRIBUTE) + round(get_stat_bonus(src, FORTITUDE_ATTRIBUTE, no_neg = FALSE)))
+		maxSanity = max(1, get_attribute_printed_level_bonus(src, PRUDENCE_ATTRIBUTE) + get_stat_bonus(src, PRUDENCE_ATTRIBUTE, no_neg = FALSE))
 	. = ..()
 	dna?.species.spec_updatehealth(src)
 	sanityhealth = maxSanity - sanityloss

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -254,13 +254,3 @@
 	destination.socks = socks
 	destination.jumpsuit_style = jumpsuit_style
 
-//Max Health that is not effected by attributes.
-/mob/living/carbon/human/getRawMaxHealth()
-	if(LAZYLEN(attributes))
-		return SSmaptype.chosen_trait == FACILITY_TRAIT_XP_MOD ? 40 : DEFAULT_HUMAN_MAX_HEALTH
-	return ..()
-
-/mob/living/carbon/human/getRawMaxSanity()
-	if(LAZYLEN(attributes))
-		return SSmaptype.chosen_trait == FACILITY_TRAIT_XP_MOD ? 40 : DEFAULT_HUMAN_MAX_SANITY
-	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Refactors health and sanity calculation without actually changing anything player-side. 
Fortitude and Prudence HP/SP modifiers are now baked into the define, with handling for the station trait changing mid-round due to admeme.
Fortitude and Prudence base stats update automatically if it changes mid shift.
"De-shittifies" /mob/living/carbon/human/updatehealth()
Adds `get_attribute_printed_level_bonus()` which is used by updatehealth(); There wasn't a simply way to do this before without redundant looping, and "get_printed_level_bonus()" already does the Health and Sanity math for us.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Code Improvement.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: `get_attribute_printed_level_bonus()`
code: Refactors `FORTITUDE_MOD` and `PRUDENCE_MOD`, defines `DEFAULT_HUMAN_MAX_HEALTH_XP` and `DEFAULT_HUMAN_MAX_SANITY_XP`
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
