### PR TITLE
Readds visual work result overlays to Shock Centipede

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/shock_centipede.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/shock_centipede.dm
@@ -142,6 +142,7 @@
 
 /* Success Effect */
 /mob/living/simple_animal/hostile/abnormality/shock_centipede/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
+	. = ..()
 	if (!CheckQliphoth(user, work_type, pe))
 		return
 	if(datum_reference?.qliphoth_meter == 2)
@@ -153,6 +154,7 @@
 
 /* Neutral Effect */
 /mob/living/simple_animal/hostile/abnormality/shock_centipede/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
+	. = ..()
 	if (!CheckQliphoth(user, work_type, pe))
 		return
 	if(datum_reference?.qliphoth_meter == 2)
@@ -166,6 +168,7 @@
 
 /* Failure Effect */
 /mob/living/simple_animal/hostile/abnormality/shock_centipede/FailureEffect(mob/living/carbon/human/user, work_type, pe)
+	. = ..()
 	if (!CheckQliphoth(user, work_type, pe))
 		return
 	datum_reference.qliphoth_change(-1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Did you know Shock Centipede is missing work result visual overlays? No? You don't take it? Well, it's been bothering me for months.
Why was it missing them? Someone did an override on the SuccessEffect, NeutralEffect and FailureEffect but forgot to call the parent proc.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes Shock Centipede work result overlays
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
