### PR TITLE
Bugfixes Lust Peccatula ranged immunity and bugfixes all known issues with Association skills

### DIFF
--- a/ModularTegustation/tegu_items/associations/skills/liu/associate.dm
+++ b/ModularTegustation/tegu_items/associations/skills/liu/associate.dm
@@ -66,6 +66,8 @@
 			//this stuff is important for what youre about to do
 			var/burn_holder = fuel.getFireLoss() //storing burn memories of fuel
 			var/white_holder = fuel.sanityloss //storing sanity memories of fuel
+			if (fuel == owner)
+				continue
 			fuel.adjustSanityLoss(-1000)
 			fuel.adjustFireLoss(-1000)
 			fuel.adjustFireLoss(white_holder)

--- a/ModularTegustation/tegu_items/associations/skills/liu/director.dm
+++ b/ModularTegustation/tegu_items/associations/skills/liu/director.dm
@@ -16,6 +16,8 @@
 	for(var/mob/living/carbon/human/fuel in view(range, get_turf(src)))
 		if(locate(/obj/structure/turf_fireliu) in fuel.loc)
 			//this stuff is important for what youre about to do
+			if (fuel == owner)
+				continue
 			var/burn_holder = fuel.getFireLoss() //storing burn memories of fuel
 			fuel.adjustFireLoss(burn_holder)
 	owner.visible_message(span_warning("[owner] fans the flames, scorching those within!"))

--- a/ModularTegustation/tegu_items/associations/skills/seven/associate.dm
+++ b/ModularTegustation/tegu_items/associations/skills/seven/associate.dm
@@ -7,6 +7,8 @@
 	button_icon_state = "healthhud_on"
 	var/datum/atom_hud/medsensor = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
 	medsensor.add_hud_to(owner)
+	ADD_TRAIT(owner, TRAIT_THERMAL_VISION, src)
+	owner.update_sight()
 	active = TRUE
 	UpdateButtonIcon()
 
@@ -15,6 +17,8 @@
 	button_icon_state = "healthhud_off"
 	var/datum/atom_hud/medsensor = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
 	medsensor.remove_hud_from(owner)
+	REMOVE_TRAIT(owner, TRAIT_THERMAL_VISION, src)
+	owner.update_sight()
 	active = FALSE
 	UpdateButtonIcon()
 
@@ -59,8 +63,8 @@
 	//increase speed
 	if (ishuman(owner))
 		var/mob/living/carbon/human/human = owner
-		human.add_movespeed_modifier(/datum/movespeed_modifier/retreat)
-		addtimer(CALLBACK(human, TYPE_PROC_REF(/mob, remove_movespeed_modifier), /datum/movespeed_modifier/retreat), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+		human.add_movespeed_modifier(/datum/movespeed_modifier/getaway)
+		addtimer(CALLBACK(human, TYPE_PROC_REF(/mob, remove_movespeed_modifier), /datum/movespeed_modifier/getaway), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 		human.physiology.red_mod *= 1.5
 		human.physiology.white_mod *= 1.5
 		human.physiology.black_mod *= 1.5
@@ -80,3 +84,7 @@
 	human.physiology.white_mod /= 1.5
 	human.physiology.black_mod /= 1.5
 	human.physiology.pale_mod /= 1.5
+
+/datum/movespeed_modifier/getaway
+	variable = TRUE
+	multiplicative_slowdown = -0.3

--- a/ModularTegustation/tegu_items/associations/skills/seven/director.dm
+++ b/ModularTegustation/tegu_items/associations/skills/seven/director.dm
@@ -23,27 +23,45 @@
 		StartCooldown()
 
 /datum/action/cooldown/exploitgap/proc/GapSpotted()
-	owner.say("You're full of gaps.")
-	for(var/mob/living/carbon/human/human in view(range, get_turf(src)))
-		if (human.stat == DEAD)
+	for(var/mob/living/L in view(range, owner))
+		if(L.stat == DEAD)
 			continue
-		if (human == owner && !affect_self)
+		if (L == owner && !affect_self)
+			owner.say("	Tch... I’ve rusted all too soon, haven't I?.")
 			continue
-		human.physiology.red_mod *= 1.2
-		human.physiology.white_mod *= 1.2
-		human.physiology.black_mod *= 1.2
-		human.physiology.pale_mod *= 1.2
-		affected+= human
+		owner.say("You're full of gaps.")
+		L.apply_status_effect(/datum/status_effect/rend_sevendirector)
 
-	addtimer(CALLBACK(src, PROC_REF(Recall)), 30 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 
-/datum/action/cooldown/exploitgap/proc/Recall()
-	for(var/mob/living/carbon/human/human in affected)
-		human.physiology.red_mod /= 1.2
-		human.physiology.white_mod /= 1.2
-		human.physiology.black_mod /= 1.2
-		human.physiology.pale_mod /= 1.2
-		affected-= human
+/datum/status_effect/rend_sevendirector
+	id = "seven director rend armor"
+	status_type = STATUS_EFFECT_UNIQUE
+	duration = 300 //30 seconds
+	alert_type = null
+
+/datum/status_effect/rend_sevendirector/on_apply()
+	. = ..()
+	if(ishuman(owner))
+		var/mob/living/carbon/human/L = owner
+		L.physiology.red_mod *= 1.2
+		L.physiology.white_mod *= 1.2
+		L.physiology.black_mod *= 1.2
+		L.physiology.pale_mod *= 1.2
+		return
+	var/mob/living/simple_animal/M = owner
+	M.AddModifier(/datum/dc_change/sevendirector)
+
+/datum/status_effect/rend_sevendirector/on_remove()
+	. = ..()
+	if(ishuman(owner))
+		var/mob/living/carbon/human/L = owner
+		L.physiology.red_mod /= 1.2
+		L.physiology.white_mod /= 1.2
+		L.physiology.black_mod /= 1.2
+		L.physiology.pale_mod /= 1.2
+		return
+	var/mob/living/simple_animal/M = owner
+	M.RemoveModifier(/datum/dc_change/sevendirector)
 
 /datum/movespeed_modifier/exploitgap
 	variable = TRUE

--- a/ModularTegustation/tegu_items/associations/skills/seven/director.dm
+++ b/ModularTegustation/tegu_items/associations/skills/seven/director.dm
@@ -20,6 +20,7 @@
 		owner.add_movespeed_modifier(/datum/movespeed_modifier/exploitgap)
 		addtimer(CALLBACK(owner, TYPE_PROC_REF(/mob, remove_movespeed_modifier), /datum/movespeed_modifier/exploitgap), 2 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 		addtimer(CALLBACK(src, PROC_REF(GapSpotted)), 2 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+		StartCooldown()
 
 /datum/action/cooldown/exploitgap/proc/GapSpotted()
 	owner.say("You're full of gaps.")

--- a/ModularTegustation/tegu_items/associations/skills/seven/veteran.dm
+++ b/ModularTegustation/tegu_items/associations/skills/seven/veteran.dm
@@ -20,7 +20,7 @@
 		if (L == owner && !affect_self)
 			continue
 		L.apply_status_effect(/datum/status_effect/rend_seven)
-		owner.say("	I've analyzed the enemy's behavior.")
+	owner.say("	I've analyzed the enemy's behavior.")
 	StartCooldown()
 	return ..()
 
@@ -34,10 +34,7 @@
 	. = ..()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/L = owner
-		L.physiology.red_mod *= 1.4
-		L.physiology.white_mod *= 1.4
 		L.physiology.black_mod *= 1.4
-		L.physiology.pale_mod *= 1.4
 		return
 	var/mob/living/simple_animal/M = owner
 	M.AddModifier(/datum/dc_change/seven)
@@ -46,10 +43,7 @@
 	. = ..()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/L = owner
-		L.physiology.red_mod /= 1.4
-		L.physiology.white_mod /= 1.4
 		L.physiology.black_mod /= 1.4
-		L.physiology.pale_mod /= 1.4
 		return
 	var/mob/living/simple_animal/M = owner
 	M.RemoveModifier(/datum/dc_change/seven)

--- a/ModularTegustation/tegu_items/associations/skills/seven/veteran.dm
+++ b/ModularTegustation/tegu_items/associations/skills/seven/veteran.dm
@@ -20,7 +20,7 @@
 		if (L == owner && !affect_self)
 			continue
 		L.apply_status_effect(/datum/status_effect/rend_seven)
-	owner.say("	I've analyzed the enemy's behavior.")
+	owner.say("I've analyzed the enemy's behavior.")
 	StartCooldown()
 	return ..()
 

--- a/ModularTegustation/tegu_items/associations/skills/zwei/director.dm
+++ b/ModularTegustation/tegu_items/associations/skills/zwei/director.dm
@@ -24,7 +24,7 @@
 		if(target.maxHealth >= skilluser.maxHealth)
 			new /obj/effect/temp_visual/slice(get_turf(target))
 			target.adjustBruteLoss(target.maxHealth*0.3, TRUE, TRUE)
-		target.add_movespeed_modifier(/datum/movespeed_modifier/retreat)
+		target.add_movespeed_modifier(/datum/movespeed_modifier/flexsuppress)
 		addtimer(CALLBACK(target, TYPE_PROC_REF(/mob, remove_movespeed_modifier), /datum/movespeed_modifier/flexsuppress), 3 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 
 	owner.visible_message(span_userdanger("[owner] in a instant applies a precision strike pinning down their opponent!"), span_warning("You pin down your opponent masterfully!"))

--- a/code/modules/mob/living/simple_animal/dc_changes.dm
+++ b/code/modules/mob/living/simple_animal/dc_changes.dm
@@ -72,6 +72,11 @@
 	potency = 1.4
 	damage_type = BLACK_DAMAGE
 
+// x1.2 modifiers, used by Exploit the Gap skill
+/datum/dc_change/sevendirector
+	potency = 1.2
+	damage_type = list(RED_DAMAGE, WHITE_DAMAGE, BLACK_DAMAGE, PALE_DAMAGE)
+
 /// 1.2x modifiers, used by Qliphoth Shredder
 /datum/dc_change/qliphothshred
 	potency = 1.2

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/brown/dawn.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/brown/dawn.dm
@@ -404,7 +404,7 @@
 	if(prob(25))
 		visible_message(span_userdanger("[P] is blocked by [src]!"))
 		P.Destroy()
-	return
+	return ..()
 
 /mob/living/simple_animal/hostile/ordeal/sin_lust/attacked_by(obj/item/I, mob/living/user)
 	var/checkdir = check_target_facings(user, src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lust Peccatula were meant to have only a 25% chance to block projectiles, however they did not call their parent proc for projectiles so they just ignored everything, also fixes all Assoc Skill bugs and ties Thermals to Analysis
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Seven require Thermals without X-Ray to viably use their smoke in combat, Lust Peccatula being entirely ranged immune is not intended behaviour and bugs are bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked "Analysis" Seven skill to give passive Thermals
fix: fixed bugs related to assoc skills
fix: fixed lust peccatula having complete ranged immunity
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
