### PR TITLE
Armor Equipment Update

### DIFF
--- a/code/modules/clothing/suits/ego_gear/_ego_gear.dm
+++ b/code/modules/clothing/suits/ego_gear/_ego_gear.dm
@@ -11,7 +11,7 @@
 	w_class = WEIGHT_CLASS_BULKY								//No more stupid 10 egos in bag
 	allowed = list(/obj/item/gun, /obj/item/ego_weapon, /obj/item/melee)
 	drag_slowdown = 1
-	var/equip_slowdown = 3 SECONDS
+	var/equip_slowdown = 7 SECONDS
 
 	var/obj/item/clothing/head/ego_hat/hat = null // Hat type, see clothing/head/_ego_head.dm
 	var/obj/item/clothing/neck/ego_neck/neck = null // Neckwear, see clothing/neck/_neck.dm
@@ -38,6 +38,14 @@
 	if(slot_flags & slot) // Equipped to right slot, not just in hands
 		if(!CanUseEgo(H))
 			return FALSE
+		for(var/obj/machinery/computer/ego_purchase/A in range(6, equipper))
+			return ..()
+
+		for(var/obj/machinery/smartfridge/extraction_storage/ego_armor/A in range(6, equipper))
+			return ..()
+
+
+
 		if(equip_slowdown > 0 && (M == equipper || !equipper))
 			if(!do_after(H, equip_slowdown, target = H))
 				return FALSE

--- a/code/modules/clothing/suits/ego_gear/_ego_gear.dm
+++ b/code/modules/clothing/suits/ego_gear/_ego_gear.dm
@@ -70,18 +70,6 @@
 			return
 		neckwear.Destroy()
 
-/obj/item/clothing/suit/armor/ego_gear/pickup(mob/user)
-	. = ..()
-	if(!user.has_movespeed_modifier(/datum/movespeed_modifier/too_many_armors) && ishuman(user))
-		var/obj/item/clothing/suit/armor/ego_gear/equipped_armor = user.get_item_by_slot(ITEM_SLOT_OCLOTHING)
-		if(istype(equipped_armor))
-			if((SSmaptype.maptype in SSmaptype.citymaps) || (SSmaptype.maptype in SSmaptype.combatmaps))
-				return
-			else
-				var/list/slowdown_free_roles = list("Clerk", "Agent Support Clerk", "Facility Support Clerk", "Extraction Officer")
-				if(!(user.mind.assigned_role in slowdown_free_roles))
-					user.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/too_many_armors)
-
 /obj/item/clothing/suit/armor/ego_gear/dropped(mob/user)
 	. = ..()
 	if(hat)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Armor now takes 7 seconds to equip.
Armor equips instantly near an EGO console or armor fridge.
Holding multiple EGO armor now no longer slows you.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I want to make minor changes to the armor equip system.
This makes you want to equip EGO at extraction, instead of just on the fly.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced equipping EGO
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
