### PR TITLE
Violet Midnight Number Change

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/violet.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/violet.dm
@@ -291,7 +291,7 @@
 /mob/living/simple_animal/hostile/ordeal/violet_midnight/red
 	damage_coeff = list(RED_DAMAGE = -1, WHITE_DAMAGE = 0.7, BLACK_DAMAGE = 1.2, PALE_DAMAGE = 1)
 
-	var/attack_damage = 220 // Dealt once if hit
+	var/attack_damage = 270 // Dealt once if hit
 	var/list/been_hit = list()
 	RVP = new(1865)
 
@@ -458,7 +458,7 @@
 	icon_dead = "violet_midnightb_dead"
 	damage_coeff = list(RED_DAMAGE = 1.2, WHITE_DAMAGE = 1, BLACK_DAMAGE = -1, PALE_DAMAGE = 0.7)
 
-	var/attack_damage = 220
+	var/attack_damage = 250
 	var/list/been_hit = list()
 	RVP = new(1000)
 
@@ -550,7 +550,7 @@
 	var/obj/effect/pale_eye/eye = null
 	var/pulsating = FALSE
 	/// Amount of PALE damage dealt across a range on cooldown defined in variables below
-	var/pulse_damage = 40
+	var/pulse_damage = 30
 	/// The range of eye's attack
 	var/pulse_range = 5
 	/// How often it deals damage at the eye's location


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Violet Midnight damage changes.
Red/Black deal slightly more damage (270/250 up from 220)
Pale Eye deals slightly less damage (30 down from 40)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Violet needed a few minor number changes for it to be a bit more fair, Pale eye could trap you, and Red/Black both needed a tiny bit more oomph to them. 
White was unchanged due to hitting entire departments.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Violet Midnight damage has been adjusted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
