### PR TITLE
Facility Rank will no longer show up if you don't have one

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -295,7 +295,8 @@
 	mode.set_round_result()
 
 	send2adminchat("Server", "Round just ended.")
-	send2chat("Round Complete! Facility Rank: [SSticker.rating_achieved]!", CONFIG_GET(string/chat_announce_new_game))
+	if((SSlobotomy_corp.goal_boxes < 100) && SSticker.rating_achieved == "D"))	// If you have less than 100 boxes and a D rating don't say it in chat.
+		send2chat("Round Complete! Facility Rank: [SSticker.rating_achieved]!", CONFIG_GET(string/chat_announce_new_game))
 
 	if(length(CONFIG_GET(keyed_list/cross_server)))
 		send_news_report()

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -295,7 +295,7 @@
 	mode.set_round_result()
 
 	send2adminchat("Server", "Round just ended.")
-	if((SSlobotomy_corp.goal_boxes < 100) && SSticker.rating_achieved == "D"))	// If you have less than 100 boxes and a D rating don't say it in chat.
+	if((SSlobotomy_corp.goal_boxes < 100) && (SSticker.rating_achieved == "D"))	// If you have less than 100 boxes and a D rating don't say it in chat.
 		send2chat("Round Complete! Facility Rank: [SSticker.rating_achieved]!", CONFIG_GET(string/chat_announce_new_game))
 
 	if(length(CONFIG_GET(keyed_list/cross_server)))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If it's too early in the round (sub 100 PE generated) or it's not LC13, the facility rank will not show up.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
There's no need for it on rounds where it's impossible to get better ranks!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Facility Rank no longer shows as D when there's no PE generated
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
