### PR TITLE
Punishing Bird no longer Guarantees Apoc

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
@@ -55,8 +55,8 @@
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
 
 	grouped_abnos = list(
-		/mob/living/simple_animal/hostile/abnormality/big_bird = 3,
-		/mob/living/simple_animal/hostile/abnormality/judgement_bird = 3,
+		/mob/living/simple_animal/hostile/abnormality/big_bird = 1.5,
+		/mob/living/simple_animal/hostile/abnormality/judgement_bird = 1.5,
 	)
 
 	observation_prompt = "A bird stares at you. What is the name of this bird?"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces the multiplier of Punishing Bird to the others from 3x to 1.5x.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Generally, if you pick PBird early game, you are guaranteeing a setup to get BBird and JBird later.
I'm going to make Pbird give less mult, but keep the other 2 the same.

This is so that if you get 2 birds, you're guaranteed the third, but getting Pbird alone will not guarantee BBird and Jbird
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Pbird now gives 1.5x mult to BBird and Jbird
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
