### PR TITLE
Makes big bird's counter more punishing.

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
@@ -180,7 +180,7 @@
 		return FALSE
 	if(!died.mind)
 		return FALSE
-	datum_reference.qliphoth_change(-1) // One death reduces it
+	datum_reference.qliphoth_change(-2) // One death reduces it
 	return TRUE
 
 /mob/living/simple_animal/hostile/abnormality/big_bird/SuccessEffect(mob/living/carbon/human/user, work_type, pe)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes big bird's counter lower by 2 instead of 1 when someone dies. Meaning it takes about only 3 deaths for a breach to occur.

## Why It's Good For The Game

Big bird is a WAW, and while its breach reflects that, it is way too generous in both its work rates and safety net, meaning it will only realistically breach during a meltdown. Big bird will now only need about 3 deaths before it breaches, but considering its counter can be increased on a good work, I think that it can still be handled even during a terrible time for the facility.

## Changelog
:cl:
balance: Big Bird's counter will now drop by 2 on someone's death instead of 1.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
