### PR TITLE
Adds a sounds while Brazen Bull charges.

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/brazen_bull.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/brazen_bull.dm
@@ -138,7 +138,7 @@
 		for(var/obj/vehicle/V in new_hits)
 			V.take_damage(10, RED_DAMAGE, attack_sound)
 			V.visible_message(span_boldwarning("[src] rams [V]!"))
-
+	playsound(src,'sound/effects/bamf.ogg', 70, TRUE, 20)
 	for(var/turf/open/R in range(1, src))
 		new /obj/effect/temp_visual/small_smoke/halfsecond(R)
 	addtimer(CALLBACK(src, PROC_REF(Charge), move_dir, (times_ran + 1)), 2)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
At Kirie's request, I have given the Brazen Bull the same charge attack sound as King of Greed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I think it's nice for it to have a sound while it charges.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Updated brazen_bull.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
