### PR TITLE
Nerfs Ardor Blossom Star

### DIFF
--- a/ModularLobotomy/ego_weapons/ranged/ego_bullets/he.dm
+++ b/ModularLobotomy/ego_weapons/ranged/ego_bullets/he.dm
@@ -161,7 +161,7 @@
 	name = "ardor blossom star"
 	icon_state = "gaussstrong"
 	damage_type = RED_DAMAGE
-	damage = 85
+	damage = 70
 	projectile_piercing = PASSMOB
 
 /obj/projectile/ego_bullet/ego_squeak

--- a/ModularLobotomy/ego_weapons/ranged/he.dm
+++ b/ModularLobotomy/ego_weapons/ranged/he.dm
@@ -323,9 +323,9 @@
 	projectile_path = /obj/projectile/ego_bullet/ardor_star
 	weapon_weight = WEAPON_HEAVY
 	fire_sound = 'sound/weapons/gun/sniper/shot.ogg'
-	fire_delay = 10
+	fire_delay = 15
 	shotsleft = 4
-	reloadtime = 2.1 SECONDS
+	reloadtime = 3.5 SECONDS
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 40
 							)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
ABS was heavily overbuffed.

Here's what this PR does:
- Lowers the damage from 85 > 70
- Increases Reload from 2.1 > 3.5
- Increases Fire Delay from 10 > 15
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ardor Blossom Star was overbuffed. It is supposed to be an AMR rifle, and it is, with piercing, but before it just overshined Magic Bullet. This PR nerfs ABS.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced Ardor Blossom Star
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
