### PR TITLE
Quenches the unending thirst of Dipsia E.G.O. weapon

### DIFF
--- a/ModularLobotomy/ego_weapons/melee/abnormality/waw.dm
+++ b/ModularLobotomy/ego_weapons/melee/abnormality/waw.dm
@@ -986,7 +986,7 @@
 	if(!CanUseEgo(user))
 		return
 	if(siphoning)
-		to_chat(user,span_warning("You cease siphoning with the [src] sword."))
+		to_chat(user,span_warning("You cease siphoning with [src] sword."))
 		siphoning = FALSE
 		filters = null
 		user.playsound_local(user, 'sound/effects/bleed.ogg', 25, TRUE)
@@ -994,7 +994,7 @@
 	var/datum/component/bloodfeast/bloodfeast = GetComponent(/datum/component/bloodfeast)
 	siphoning = TRUE
 	user.playsound_local(user, 'sound/effects/bleed_apply.ogg', 25, TRUE)
-	to_chat(user,span_warning("You begin siphoning with the [src] sword."))
+	to_chat(user,span_warning("You begin siphoning with [src] sword."))
 	if(bloodfeast.blood_amount < 100)
 		to_chat(user,span_warning("The sword drains your blood to fuel itself!"))
 		user.adjustBruteLoss(20)
@@ -1004,15 +1004,16 @@
 	addtimer(CALLBACK(src, PROC_REF(SiphonDrain), user), siphon_time)
 
 /obj/item/ego_weapon/dipsia/proc/SiphonDrain(mob/user)
-	var/datum/component/bloodfeast/bloodfeast = GetComponent(/datum/component/bloodfeast)
-	AdjustThirst(-10)
-	if(bloodfeast.blood_amount < 1)
-		siphoning = FALSE
-		filters = null
-		if(user)
-			to_chat(user,span_warning("Your [src] sword shuts off due to a lack of blood!"))
-			return
-	addtimer(CALLBACK(src, PROC_REF(SiphonDrain), user), siphon_time)
+	if(siphoning)
+		var/datum/component/bloodfeast/bloodfeast = GetComponent(/datum/component/bloodfeast)
+		AdjustThirst(-10)
+		if(bloodfeast.blood_amount < 1)
+			siphoning = FALSE
+			filters = null
+			if(user)
+				to_chat(user,span_warning("Your [src.name] sword shuts off due to a lack of blood!"))
+				return
+		addtimer(CALLBACK(src, PROC_REF(SiphonDrain), user), siphon_time)
 
 /obj/item/ego_weapon/dipsia/attack(mob/living/target, mob/living/carbon/human/user)
 	if(!CanUseEgo(user))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fix PR that makes Dipsia not keep draining blood reserves after it shuts off.
Also fixes "The the dipsia sword" in two instances.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfix is good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes Dipsia E.G.O. weapon permanent blood drain
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
