### PR TITLE
Prevents Big Bird from having extra range from him attacking while moving

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
@@ -129,6 +129,9 @@
 			return FALSE
 	return ..()
 
+/mob/living/simple_animal/hostile/abnormality/big_bird/MovedTryAttack() //To prevent BB from practically having 2 range
+	return FALSE
+
 /mob/living/simple_animal/hostile/abnormality/big_bird/AttackingTarget(atom/attacked_target)
 	if(ishuman(attacked_target))
 		if(bite_cooldown > world.time)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
What the title says. It prevents Big Bird chomping midwalk so it should avoid the accidental 2 range.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less unfair deaths
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed BB range
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
