### PR TITLE
Replaces one of the two Clerks with Assistinator

### DIFF
--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -139,5 +139,5 @@ GLOBAL_LIST_EMPTY(spawned_clerks)
 	alt_titles = list("Safety Department Clerk", "Information Department Clerk",
 			"Training Department Clerk",)
 	senior_title = "Extraction Department Clerk"
-	ultra_senior_title = "Architecture Department Clerk"
+	ultra_senior_title = "Assistinator"
 	clerk_belts = /obj/item/storage/belt/clerk/facility


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaces one of the two ultra-senior clerks with Assistinator.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It caused bugs when both of the Clerk ultra-seniors used the same outfit.
This changes one of them
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Replaced one of the two ultrasenior clerks with assistinator 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
