### PR TITLE
Docile Abno Event

### DIFF
--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -76,6 +76,10 @@
 	//Check for Neutral abnormalities
 	var/good_hater = FALSE
 
+	///Variables that should only be switched on and off from events or other uncommon effects.
+	///The abnormality will give 75% less stats and 75% more PE
+	var/docile = FALSE
+
 /datum/abnormality/New(obj/effect/landmark/abnormality_spawn/new_landmark, mob/living/simple_animal/hostile/abnormality/new_type = null)
 	if(!istype(new_landmark))
 		CRASH("Abnormality datum was created without reference to landmark.")
@@ -186,6 +190,8 @@
 		if(user_attribute) //To avoid runtime if it's a custom work type like "Release".
 			var/user_attribute_level = max(1, user_attribute.level)
 			attribute_given = clamp(((maximum_attribute_level / (user_attribute_level * 0.25)) * (0.25 + (pe / max_boxes))), 0, 16)
+			if(docile)
+				attribute_given *= clamp(0.25, 0, 16)
 			if((user_attribute_level + attribute_given + 1) >= maximum_attribute_level) // Already/Will/Should be at maximum.
 				attribute_given = max(0, maximum_attribute_level - user_attribute_level)
 				//This player trait gives you a +1 to each work
@@ -216,7 +222,10 @@
 			UpdateUnderstanding(10, pe)
 		else
 			UpdateUnderstanding(5, pe)
-	stored_boxes += round(pe * SSlobotomy_corp.box_work_multiplier)
+	var/additional_boxes = round(pe * SSlobotomy_corp.box_work_multiplier)
+	if(docile)
+		additional_boxes = round(additional_boxes * 1.75)
+	stored_boxes += additional_boxes
 	overload_chance[user.ckey] = max(overload_chance[user.ckey] + overload_chance_amount, overload_chance_limit)
 
 /datum/abnormality/proc/UpdateUnderstanding(percent, pe)

--- a/code/modules/events/abno_events/docile.dm
+++ b/code/modules/events/abno_events/docile.dm
@@ -1,0 +1,63 @@
+/datum/round_event_control/lc13/docile_abno
+	name = "Docile Abnormality"
+	typepath = /datum/round_event/docile_abno
+	max_occurrences = 3
+	weight = 10
+	earliest_start = 20 MINUTES // We want it to happen when there's at least *some* abnos.
+
+/datum/round_event/docile_abno
+	announceWhen = 1
+	endWhen = 600
+	var/list/affected_abnos = list()
+	var/abno_names_string = ""
+	var/max_abno_hit = 4 //Maybe make it scale with pop or the current number of abnos? 4 sounds like an okay number for now.
+
+
+/datum/round_event/docile_abno/announce()
+	priority_announce("[abno_names_string] have become uncharacteristically docile, \
+	severely increasing their ego and energy production. \
+	However, this docility makes them trivial to work with, and will make for subpar agent training. \
+	The abnormalities are expected to go back to their regular behavior in 6 minutes.",
+	sound = 'sound/misc/notice2.ogg',
+	sender_override = "HQ Central Command")
+
+/datum/round_event/docile_abno/start()
+	var/list/valid_abno_list = list()
+	var/highest_threat_level = ZAYIN_LEVEL
+	var/highest_threat_amount = 0
+	var/datum/abnormality/highest_abno_threat
+	for(var/mob/living/simple_animal/hostile/abnormality/abno in GLOB.abnormality_mob_list)
+		if(!abno.can_spawn) //We don't consider unspawnable abnos like rabbit and tutorial ones.
+			continue
+		var/datum/abnormality/abno_datum = abno.datum_reference
+		if(!abno_datum)
+			continue
+		if(abno_datum.docile)
+			continue
+		if(abno_datum.threat_level > highest_threat_level)
+			highest_abno_threat = abno_datum
+			highest_threat_amount = 0
+		highest_threat_amount++
+		valid_abno_list += abno_datum
+
+	if(highest_abno_threat && highest_threat_amount < 2)
+		valid_abno_list -= highest_abno_threat //If the highest threat abno is the only one, we remove them as a valid target so that they still have something to train on.
+
+	var/wanted_abno_hit = rand(2, max_abno_hit) //We want to hit at least two abnos.
+	var/list/abno_name_list = list()
+	for(var/abno_hit = 1 to wanted_abno_hit)
+		if(!valid_abno_list.len)
+			break
+		var/datum/abnormality/abno_datum = pick(valid_abno_list)
+		valid_abno_list -= abno_datum
+		affected_abnos += abno_datum
+		abno_name_list += abno_datum.name
+		abno_datum.docile = TRUE
+	abno_names_string = jointext(abno_name_list, ", ")
+
+/datum/round_event/docile_abno/end()
+	for(var/datum/abnormality/abno_datum in affected_abnos)
+		abno_datum.docile = FALSE
+	priority_announce("All docile abnormalities are now back to their regular behavior, making them apt for training once again.",
+	sound = 'sound/misc/notice2.ogg',
+	sender_override = "HQ Central Command")

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -2192,6 +2192,7 @@
 #include "code\modules\events\sephirah_helpful_roll.dm"
 #include "code\modules\events\sephirah_yellow_roll.dm"
 #include "code\modules\events\wisdom_cow.dm"
+#include "code\modules\events\abno_events\docile.dm"
 #include "code\modules\events\holiday\halloween.dm"
 #include "code\modules\events\holiday\vday.dm"
 #include "code\modules\events\holiday\xmas.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds an event that makes abnormality produce 75% more PE but make you gain 75% less stats for working them.
The event will not hit the highest threat abnormality if it's alone, just in case it's the only trainer available. The effect lasts for about 6 minutes, and is meant to shake up how easy it is to train on an abno or obtain its ego.

## Why It's Good For The Game

I think events adding more variety to what's optimal to work on at any given moment would be nice, it's an event that can be good or bad depending on the situation, which is what events should be.

## Changelog
:cl:
add: Docile abno event. Abnormalities will produce more PE but give you less stats for working them for the event's duration.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
