### PR TITLE
Port/Adapt: tgstation/mothblocks "Move auto changelog generation into… ee568cd  … its own workflow (#70652)

### DIFF
--- a/.github/workflows/auto_changelog.yml
+++ b/.github/workflows/auto_changelog.yml
@@ -1,0 +1,26 @@
+# Creates an entry in html/changelogs automatically, to eventually be compiled by compile_changelogs
+name: Auto Changelog
+on:
+  push:
+    branches:
+      - master
+  pull_request_target:
+    types:
+      - closed
+    branches:
+      - master
+permissions:
+  contents: write
+jobs:
+  auto_changelog:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '[cl skip]') && (github.event_name != 'pull_request' || github.event.pull_request.merged == true) }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Run auto changelog
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const { processAutoChangelog } = await import('${{ github.workspace }}/tools/pull_request_hooks/autoChangelog.js')
+          await processAutoChangelog({ github, context })

--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -9,48 +9,34 @@ jobs:
   compile:
     name: "Compile changelogs"
     runs-on: ubuntu-24.04
+    if: github.repository == 'Lobotomy-Corporation-13/lc13' # Do not run on forks
     steps:
-      - name: "Check for CHANGELOG_ENABLER secret and pass true to output if it exists to be checked by later steps"
-        id: value_holder
-        env:
-          CHANGELOG_ENABLER: ${{ secrets.CHANGELOG_ENABLER }}
-        run: |
-          unset SECRET_EXISTS
-          if [ -n $CHANGELOG_ENABLER ]; then SECRET_EXISTS='true' ; fi
-          echo ::set-output name=CL_ENABLED::${SECRET_EXISTS}
       - name: "Setup python"
-        if: steps.value_holder.outputs.CL_ENABLED
         uses: actions/setup-python@v1
         with:
           python-version: '3.x'
       - name: "Install deps"
-        if: steps.value_holder.outputs.CL_ENABLED
         run: |
           python -m pip install --upgrade pip
           python -m pip install pyyaml
           sudo apt-get install  dos2unix
       - name: "Checkout"
-        if: steps.value_holder.outputs.CL_ENABLED
         uses: actions/checkout@v1
         with:
           fetch-depth: 25
       - name: "Compile"
-        if: steps.value_holder.outputs.CL_ENABLED
         run: |
           python tools/ss13_genchangelog.py html/changelog.html html/changelogs
       - name: "Convert Lineendings"
-        if: steps.value_holder.outputs.CL_ENABLED
         run: |
           unix2dos html/changelogs/.all_changelog.yml
       - name: Commit
-        if: steps.value_holder.outputs.CL_ENABLED
         run: |
-          git config --local user.email "${{ secrets.BOT_EMAIL }}"
-          git config --local user.name "${{ secrets.BOT_NAME }}"
+          git config user.name "Cupax3Bot"
+          git config user.email "85813370+Cupax3Bot@users.noreply.github.com"
           git pull origin master
           git commit -m "Automatic changelog compile [ci skip]" -a || true
       - name: "Push"
-        if: steps.value_holder.outputs.CL_ENABLED
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.BOT_TOKEN }}

--- a/tools/pull_request_hooks/autoChangelog.js
+++ b/tools/pull_request_hooks/autoChangelog.js
@@ -1,0 +1,60 @@
+import { parseChangelog } from "./changelogParser.js";
+
+const safeYml = (string) =>
+	string.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+
+export function changelogToYml(changelog, login) {
+	const author = changelog.author || login;
+	const ymlLines = [];
+
+	ymlLines.push(`author: "${safeYml(author)}"`);
+	ymlLines.push(`delete-after: True`);
+	ymlLines.push(`changes:`);
+
+	for (const change of changelog.changes) {
+		ymlLines.push(
+			`  - ${change.type.changelogKey}: "${safeYml(change.description)}"`
+		);
+	}
+
+	return ymlLines.join("\n");
+}
+
+export async function processAutoChangelog({ github, context }) {
+	let changelog, userlogin, commitnumber, commitstring
+	switch (context.eventName) {
+		case "pull_request":
+			changelog = parseChangelog(context.payload.pull_request.body)
+			userlogin = context.payload.pull_request.user.login
+			commitnumber = `pr-${context.payload.pull_request.number}`
+			commitstring = `PR #${context.payload.pull_request.number}`
+			break;
+		case "push":
+			changelog = parseChangelog(context.payload.head_commit.message)
+			userlogin = context.payload.head_commit.author.username
+			commitnumber = `commit-${context.sha}`
+			commitstring = `Commit SHA${context.sha}`
+			break;
+		default:
+			console.log("unsupported event type")
+			return;
+	}
+
+	if (!changelog || changelog.changes.length === 0) {
+		console.log("no changelog found");
+		return;
+	}
+
+	const yml = changelogToYml(
+		changelog,
+		userlogin
+	);
+
+	github.rest.repos.createOrUpdateFileContents({
+		owner: context.repo.owner,
+		repo: context.repo.repo,
+		path: `html/changelogs/AutoChangeLog-${commitnumber}.yml`,
+		message: `Automatic changelog for ${commitstring} [ci skip]`,
+		content: Buffer.from(yml).toString("base64"),
+	});
+}

--- a/tools/pull_request_hooks/autoChangelog.test.js
+++ b/tools/pull_request_hooks/autoChangelog.test.js
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { changelogToYml } from "./autoChangelog.js";
+import { parseChangelog } from "./changelogParser.js";
+
+assert.equal(
+	changelogToYml(
+		parseChangelog(`
+			My cool PR!
+			:cl: DenverCoder9
+			add: Adds new stuff
+			add: Adds more stuff
+			/:cl:
+		`)
+	),
+
+	`author: "DenverCoder9"
+delete-after: True
+changes:
+  - rscadd: "Adds new stuff"
+  - rscadd: "Adds more stuff"`
+);

--- a/tools/pull_request_hooks/changelogConfig.js
+++ b/tools/pull_request_hooks/changelogConfig.js
@@ -1,0 +1,127 @@
+/**
+ * A map of changelog phrases to meta-information.
+ *
+ * The first entry in the list is used in the changelog YML file as the key when
+ * used, but other than that all entries are equivalent.
+ *
+ * placeholders - The default messages, if the changelog has this then we pretend it
+ * doesn't exist.
+ */
+export const CHANGELOG_ENTRIES = [
+	[
+		["rscadd", "add", "adds"],
+		{
+			placeholders: [
+				"Added new mechanics or gameplay changes",
+				"Added more things",
+			],
+		},
+	],
+
+	[
+		["bugfix", "fix", "fixes"],
+		{
+			placeholders: ["fixed a few things"],
+		},
+	],
+
+	[
+		["rscdel", "del", "dels"],
+		{
+			placeholders: ["Removed old things"],
+		},
+	],
+
+	[
+		["qol"],
+		{
+			placeholders: ["made something easier to use"],
+		},
+	],
+
+	[
+		["soundadd"],
+		{
+			placeholders: ["added a new sound thingy"],
+		},
+	],
+
+	[
+		["sounddel"],
+		{
+			placeholders: ["removed an old sound thingy"],
+		},
+	],
+
+	[
+		["imageadd"],
+		{
+			placeholders: ["added some icons and images"],
+		},
+	],
+
+	[
+		["imagedel"],
+		{
+			placeholders: ["deleted some icons and images"],
+		},
+	],
+
+	[
+		["spellcheck", "typo"],
+		{
+			placeholders: ["fixed a few typos"],
+		},
+	],
+
+	[
+		["balance"],
+		{
+			placeholders: ["rebalanced something"],
+		},
+	],
+
+	[
+		["code_imp", "code"],
+		{
+			placeholders: ["changed some code"],
+		},
+	],
+
+	[
+		["refactor"],
+		{
+			placeholders: ["refactored some code"],
+		},
+	],
+
+	[
+		["config"],
+		{
+			placeholders: ["changed some config setting"],
+		},
+	],
+
+	[
+		["admin"],
+		{
+			placeholders: ["messed with admin stuff"],
+		},
+	],
+
+	[
+		["server"],
+		{
+			placeholders: ["something server ops should know"],
+		},
+	],
+];
+
+// Valid changelog openers
+export const CHANGELOG_OPEN_TAGS = [":cl:", "??"];
+
+// Valid changelog closers
+export const CHANGELOG_CLOSE_TAGS = ["/:cl:", "/ :cl:", ":/cl:", "/??", "/ ??"];
+
+// Placeholder value for an author
+export const CHANGELOG_AUTHOR_PLACEHOLDER_NAME = "optional name here";

--- a/tools/pull_request_hooks/changelogParser.js
+++ b/tools/pull_request_hooks/changelogParser.js
@@ -1,0 +1,80 @@
+import * as changelogConfig from "./changelogConfig.js";
+
+const REGEX_CHANGELOG_LINE = /^(\w+): (.+)$/;
+
+const CHANGELOG_KEYS_TO_ENTRY = {};
+for (const [types, entry] of changelogConfig.CHANGELOG_ENTRIES) {
+	const entryWithChangelogKey = {
+		...entry,
+		changelogKey: types[0],
+	};
+
+	for (const type of types) {
+		CHANGELOG_KEYS_TO_ENTRY[type] = entryWithChangelogKey;
+	}
+}
+
+function parseChangelogBody(lines, openTag) {
+	const [changelogOpening] = lines.splice(0, 1);
+
+	const author =
+		changelogOpening.substring(openTag.length).trim() || undefined;
+
+	const changelog = {
+		author,
+		changes: [],
+	};
+
+	for (const line of lines) {
+		if (line.trim().length === 0) {
+			continue;
+		}
+
+		for (const closeTag of changelogConfig.CHANGELOG_CLOSE_TAGS) {
+			if (line.startsWith(closeTag)) {
+				return changelog;
+			}
+		}
+
+		const match = line.match(REGEX_CHANGELOG_LINE);
+		if (match) {
+			const [_, type, description] = match;
+
+			const entry = CHANGELOG_KEYS_TO_ENTRY[type];
+
+			if (entry.placeholders.includes(description)) {
+				continue;
+			}
+
+			if (entry) {
+				changelog.changes.push({
+					type: entry,
+					description,
+				});
+			}
+		} else {
+			const lastChange = changelog.changes[changelog.changes.length - 1];
+			if (lastChange) {
+				lastChange.description += `\n${line}`;
+			}
+		}
+	}
+
+	return changelog;
+}
+
+export function parseChangelog(text) {
+	const lines = text.split("\n").map((line) => line.trim());
+
+	for (let index = 0; index < lines.length; index++) {
+		const line = lines[index];
+
+		for (const openTag of changelogConfig.CHANGELOG_OPEN_TAGS) {
+			if (line.startsWith(openTag)) {
+				return parseChangelogBody(lines.slice(index), openTag);
+			}
+		}
+	}
+
+	return undefined;
+}

--- a/tools/pull_request_hooks/changelogParser.test.js
+++ b/tools/pull_request_hooks/changelogParser.test.js
@@ -1,0 +1,72 @@
+import { strict as assert } from "node:assert";
+import { parseChangelog } from "./changelogParser.js";
+
+// Basic test
+const basicChangelog = parseChangelog(`
+	My cool PR!
+	:cl: DenverCoder9
+	add: Adds new stuff
+	/:cl:
+`);
+
+assert.equal(basicChangelog.author, "DenverCoder9");
+assert.equal(basicChangelog.changes.length, 1);
+assert.equal(basicChangelog.changes[0].type.changelogKey, "rscadd");
+assert.equal(basicChangelog.changes[0].description, "Adds new stuff");
+
+// Multi-line test
+const multiLineChangelog = parseChangelog(`
+	My cool PR!
+	:cl:
+	add: Adds new stuff
+	to the game
+	/:cl:
+`);
+
+assert.equal(multiLineChangelog.author, undefined);
+assert.equal(multiLineChangelog.changes.length, 1);
+assert.equal(multiLineChangelog.changes[0].type.changelogKey, "rscadd");
+assert.equal(
+	multiLineChangelog.changes[0].description,
+	"Adds new stuff\nto the game"
+);
+
+// Placeholders
+const placeholderChangelog = parseChangelog(`
+	My cool PR!
+	:cl:
+	add: Added new mechanics or gameplay changes
+	/:cl:
+`);
+
+assert.equal(placeholderChangelog.changes.length, 0);
+
+// No changelog
+const noChangelog = parseChangelog(`
+	My cool PR!
+`);
+
+assert.equal(noChangelog, undefined);
+
+// No /:cl:
+
+const noCloseChangelog = parseChangelog(`
+	My cool PR!
+	:cl:
+	add: Adds new stuff
+`);
+
+assert.equal(noCloseChangelog.changes.length, 1);
+assert.equal(noCloseChangelog.changes[0].type.changelogKey, "rscadd");
+assert.equal(noCloseChangelog.changes[0].description, "Adds new stuff");
+
+// :cl: with arbitrary text
+
+const arbitraryTextChangelog = parseChangelog(`
+	My cool PR!
+	:cl:
+	Adds new stuff
+	/:cl:
+`);
+
+assert.equal(arbitraryTextChangelog.changes.length, 0);

--- a/tools/pull_request_hooks/package.json
+++ b/tools/pull_request_hooks/package.json
@@ -1,0 +1,3 @@
+{
+	"type": "module"
+}


### PR DESCRIPTION
## About The Pull Request
Ports Mothblocks' GitHub Workflow-based changelog generation & compilation system from tgstation, because I vastly prefer porting & adapting work than to go through setting up a webhook system again, once was annoying enough :weary:

Adds the [cl skip] tag. If added to the head commit of a PR or push, no CL file is autogenerated. This is intended to be used for multi-collaborator PRs where multiple people may need to be added to a manual changelog file or where a manual file is, for whatever reason, preferable.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Changelogs work again! Hooray!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Attribution
PR is based on https://github.com/tgstation/tgstation/pull/70652 by Mothblocks

## Changelog
:cl:
fix: The changelog system works again, hopefully!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
