### PR TITLE
Nerfs Noise and Solitude.

### DIFF
--- a/ModularLobotomy/ego_weapons/ranged/teth.dm
+++ b/ModularLobotomy/ego_weapons/ranged/teth.dm
@@ -62,7 +62,7 @@
 	variance = 20
 	fire_delay = 10
 	shotsleft = 8
-	reloadtime = 1.6 SECONDS
+	reloadtime = 2.1 SECONDS
 	fire_sound = 'sound/weapons/gun/shotgun/shot_auto.ogg'
 
 /obj/item/ego_weapon/ranged/pistol/solitude
@@ -73,9 +73,9 @@
 	force = 8
 	damtype = WHITE_DAMAGE
 	projectile_path = /obj/projectile/ego_bullet/ego_solitude
-	fire_delay = 10
+	fire_delay = 14
 	shotsleft = 5
-	reloadtime = 2 SECONDS
+	reloadtime = 2.7 SECONDS
 	fire_sound = 'sound/weapons/gun/revolver/shot_light.ogg'
 	vary_fire_sound = FALSE
 	fire_sound_volume = 70


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases Reload time for Noise and Solitude
Increases Fire Delay for Solitude
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
While Solitude is a heavy revolver with 5 shots, it has no place doing the insane DPS is currently does.

Changing it to instead deal the same damage with a slower fire rate and shittier reload makes it feel more like a heavy revolver.
Noise got 0.5 more seconds of reload time.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Nerfed Noise and Solitude slightly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
