### PR TITLE
Adds Gamespeed and Station Trait to the Stat Panel

### DIFF
--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -20,7 +20,10 @@ SUBSYSTEM_DEF(statpanels)
 			"Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]",
 			"Round Time: [round_time > MIDNIGHT_ROLLOVER ? "[round(round_time/MIDNIGHT_ROLLOVER)]:[gameTimestamp("hh:mm:ss", round_time)]" : gameTimestamp("hh:mm:ss", round_time)]",
 			"Station Time: [station_time_timestamp()]",
-			"Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)"
+			"Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)",
+			"", // This is here to space out Station Trait and Gamespeed from the other entries
+			"Game Speed: [SSlobotomy_corp.gamespeed ? SSlobotomy_corp.gamespeed.player_facing_name : "ERROR: NO GAMESPEED DATUM"]",
+			"Station Trait: [SSmaptype.chosen_trait]",
 		)
 
 		if(SSshuttle.emergency)

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -21,10 +21,11 @@ SUBSYSTEM_DEF(statpanels)
 			"Round Time: [round_time > MIDNIGHT_ROLLOVER ? "[round(round_time/MIDNIGHT_ROLLOVER)]:[gameTimestamp("hh:mm:ss", round_time)]" : gameTimestamp("hh:mm:ss", round_time)]",
 			"Station Time: [station_time_timestamp()]",
 			"Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)",
-			"", // This is here to space out Station Trait and Gamespeed from the other entries
-			"Game Speed: [SSlobotomy_corp.gamespeed ? SSlobotomy_corp.gamespeed.player_facing_name : "ERROR: NO GAMESPEED DATUM"]",
-			"Station Trait: [SSmaptype.chosen_trait]",
 		)
+		if((SSmaptype.maptype in SSmaptype.lc_maps) || SSmaptype.maptype == "mini") // Display Station Trait and Gamespeed on Facility Modes
+			global_data += "" // This is here to space out Station Trait and Gamespeed from the other entries
+			global_data += "Game Speed: [SSlobotomy_corp.gamespeed ? SSlobotomy_corp.gamespeed.player_facing_name : "ERROR: NO GAMESPEED DATUM"]"
+			global_data += "Station Trait: [SSmaptype.chosen_trait]"
 
 		if(SSshuttle.emergency)
 			var/ETA = SSshuttle.emergency.getModeStr()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -224,6 +224,7 @@
 
 /mob/living/carbon/human/get_status_tab_items()
 	. = ..()
+	. += ""
 	. += "Intent: [a_intent]"
 	. += "Move Mode: [m_intent]"
 	if (internal)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Now displays Game Speed and Station Trait in the Stat Panel. Station Trait is already an OOC-knowledge thing you can check in our discord, and Game Speed shouldn't be a secret thing, it is literally voted on at round start.

They will only be displayed on Facility modes.

Note: yes this PR edits human.dm, it adds an empty string before displaying intent and movement mode in the stat panel. This is so it doesn't look weird. If I add the empty string in statpanel.dm it will look bad when viewing it as a ghost or in the lobby.

> Examples of how the stat panel looks now:

- Alive as a human:
<img width="335" height="208" alt="image" src="https://github.com/user-attachments/assets/a071e804-e206-48e7-90ae-24469c7916c5" />

- Alive as an Abno:
<img width="277" height="200" alt="image" src="https://github.com/user-attachments/assets/1bc6d1fe-9cb1-47f9-a517-7eda811f2c21" />

- In the Lobby:
<img width="318" height="244" alt="image" src="https://github.com/user-attachments/assets/55dcc3ab-5364-4ed9-bf2b-3b668a62e23e" />

- Observer:
<img width="296" height="198" alt="image" src="https://github.com/user-attachments/assets/a6772977-6c82-4ef8-8454-e0767e5edacf" />





<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This is information that should be available to everyone. Station Traits are already available in our discord, Gamespeed is something that will be useful to know for people who joined after the vote.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Statpanel now displays Game Speed and Station Trait.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
