### PR TITLE
Adds Indigo Noon Variants to CoL

### DIFF
--- a/ModularLobotomy/associations/cityspawners.dm
+++ b/ModularLobotomy/associations/cityspawners.dm
@@ -92,9 +92,12 @@ GLOBAL_VAR_INIT(city_east_enemies, FALSE)
 				spawning = /mob/living/simple_animal/hostile/ordeal/steel_dawn/steel_noon
 
 		if("sweeper")
-			spawning = /mob/living/simple_animal/hostile/ordeal/indigo_noon
-			if(prob(30))
-				spawning = /mob/living/simple_animal/hostile/ordeal/indigo_dawn
+			spawning = pickweight(list(
+				/mob/living/simple_animal/hostile/ordeal/indigo_noon = 54,
+				/mob/living/simple_animal/hostile/ordeal/indigo_dawn = 30,
+				/mob/living/simple_animal/hostile/ordeal/indigo_noon/chunky = 8,
+				/mob/living/simple_animal/hostile/ordeal/indigo_noon/lanky = 8,
+			))
 
 		if("bots")
 			spawning = /mob/living/simple_animal/hostile/ordeal/green_bot
@@ -133,9 +136,12 @@ GLOBAL_VAR_INIT(city_east_enemies, FALSE)
 				spawning = /mob/living/simple_animal/hostile/ordeal/steel_dawn/steel_noon
 
 		if("sweeper")
-			spawning = /mob/living/simple_animal/hostile/ordeal/indigo_noon
-			if(prob(30))
-				spawning = /mob/living/simple_animal/hostile/ordeal/indigo_dawn
+			spawning = pickweight(list(
+				/mob/living/simple_animal/hostile/ordeal/indigo_noon = 54,
+				/mob/living/simple_animal/hostile/ordeal/indigo_dawn = 30,
+				/mob/living/simple_animal/hostile/ordeal/indigo_noon/chunky = 8,
+				/mob/living/simple_animal/hostile/ordeal/indigo_noon/lanky = 8,
+			))
 
 		if("bots")
 			spawning = /mob/living/simple_animal/hostile/ordeal/green_bot
@@ -174,9 +180,12 @@ GLOBAL_VAR_INIT(city_east_enemies, FALSE)
 				spawning = /mob/living/simple_animal/hostile/ordeal/steel_dawn/steel_noon
 
 		if("sweeper")
-			spawning = /mob/living/simple_animal/hostile/ordeal/indigo_noon
-			if(prob(30))
-				spawning = /mob/living/simple_animal/hostile/ordeal/indigo_dawn
+			spawning = pickweight(list(
+				/mob/living/simple_animal/hostile/ordeal/indigo_noon = 54,
+				/mob/living/simple_animal/hostile/ordeal/indigo_dawn = 30,
+				/mob/living/simple_animal/hostile/ordeal/indigo_noon/chunky = 8,
+				/mob/living/simple_animal/hostile/ordeal/indigo_noon/lanky = 8,
+			))
 
 		if("bots")
 			spawning = /mob/living/simple_animal/hostile/ordeal/green_bot

--- a/ModularLobotomy/lc13_spawners.dm
+++ b/ModularLobotomy/lc13_spawners.dm
@@ -188,7 +188,11 @@
 /obj/effect/spawner/mobspawner/indigo_noon
 	name = "sweeper pack spawn"
 	max_spawns = 5
-	mobspawn_table = list(/mob/living/simple_animal/hostile/ordeal/indigo_noon = 1)
+	mobspawn_table = list(
+		/mob/living/simple_animal/hostile/ordeal/indigo_noon = 8,
+		/mob/living/simple_animal/hostile/ordeal/indigo_noon/lanky = 2,
+		/mob/living/simple_animal/hostile/ordeal/indigo_noon/chunky = 1,
+		)
 
 	//Steel Roaches
 /obj/effect/spawner/mobspawner/steel_dawn

--- a/_maps/RandomRooms/backstreets/bossroom/jacques.dmm
+++ b/_maps/RandomRooms/backstreets/bossroom/jacques.dmm
@@ -45,6 +45,10 @@
 "gQ" = (
 /turf/open/indestructible/necropolis/air,
 /area/city/backstreets_room)
+"hr" = (
+/mob/living/simple_animal/hostile/ordeal/indigo_noon/lanky,
+/turf/open/indestructible/necropolis/air,
+/area/city/backstreets_room)
 "ht" = (
 /obj/structure/closet/crate/large,
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
@@ -70,6 +74,13 @@
 /area/city/backstreets_room)
 "mN" = (
 /obj/structure/bookcase/random/religion,
+/turf/open/floor/plasteel/cult,
+/area/city/backstreets_room)
+"nP" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/ordeal/indigo_noon/chunky,
 /turf/open/floor/plasteel/cult,
 /area/city/backstreets_room)
 "qV" = (
@@ -100,6 +111,10 @@
 /obj/item/stack/spacecash/c100,
 /obj/item/stack/spacecash/c100,
 /turf/open/floor/plasteel/cult,
+/area/city/backstreets_room)
+"sR" = (
+/mob/living/simple_animal/hostile/ordeal/indigo_noon/chunky,
+/turf/open/indestructible/necropolis/air,
 /area/city/backstreets_room)
 "us" = (
 /obj/structure/chair/pew/right{
@@ -187,6 +202,10 @@
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 8
 	},
+/turf/open/floor/plasteel/cult,
+/area/city/backstreets_room)
+"BT" = (
+/mob/living/simple_animal/hostile/ordeal/indigo_noon/lanky,
 /turf/open/floor/plasteel/cult,
 /area/city/backstreets_room)
 "Ct" = (
@@ -621,7 +640,7 @@ Bh
 EP
 EP
 EP
-rx
+BT
 EP
 EP
 EP
@@ -727,7 +746,7 @@ xD
 BF
 gQ
 gQ
-OL
+sR
 Am
 YU
 xD
@@ -769,7 +788,7 @@ UT
 zt
 gQ
 gQ
-OL
+hr
 ZT
 gQ
 gQ
@@ -781,7 +800,7 @@ gQ
 gQ
 gQ
 gQ
-OJ
+nP
 EP
 Fy
 "}
@@ -837,7 +856,7 @@ Ku
 SY
 gQ
 gQ
-OL
+sR
 AI
 Eb
 Ku
@@ -908,7 +927,7 @@ HO
 Rb
 EP
 Rb
-rx
+BT
 Rb
 EP
 us

--- a/_maps/RandomRooms/backstreets/connector/mountain_ca.dmm
+++ b/_maps/RandomRooms/backstreets/connector/mountain_ca.dmm
@@ -469,13 +469,11 @@
 /turf/open/floor/plating/dirt/jungle/dark,
 /area/city/backstreets_room)
 "Qf" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_noon{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_x = 18;
 	pixel_y = -6
 	},
+/mob/living/simple_animal/hostile/ordeal/indigo_noon/chunky,
 /turf/open/floor/plating/dirt/jungle/dark,
 /area/city/backstreets_room)
 "Qq" = (

--- a/_maps/RandomRooms/backstreets/medium_east/zwei_office_mea.dmm
+++ b/_maps/RandomRooms/backstreets/medium_east/zwei_office_mea.dmm
@@ -18,8 +18,7 @@
 /turf/open/floor/carpet/blue,
 /area/city/backstreets_room)
 "t" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_noon,
-/mob/living/simple_animal/hostile/ordeal/indigo_noon,
+/mob/living/simple_animal/hostile/ordeal/indigo_noon/chunky,
 /turf/open/floor/carpet/blue,
 /area/city/backstreets_room)
 "v" = (
@@ -31,6 +30,10 @@
 /area/city/backstreets_room)
 "A" = (
 /obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/carpet/blue,
+/area/city/backstreets_room)
+"F" = (
+/mob/living/simple_animal/hostile/ordeal/indigo_noon/lanky,
 /turf/open/floor/carpet/blue,
 /area/city/backstreets_room)
 "H" = (
@@ -120,7 +123,7 @@ W
 x
 S
 o
-v
+F
 s
 P
 t

--- a/_maps/RandomRooms/backstreets/medium_west/sweeper_pen.dmm
+++ b/_maps/RandomRooms/backstreets/medium_west/sweeper_pen.dmm
@@ -61,6 +61,13 @@
 /obj/item/toy/beach_ball/holoball/dodgeball,
 /turf/open/floor/plating/dirt/jungle/dark,
 /area/city/backstreets_room)
+"u" = (
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 3
+	},
+/mob/living/simple_animal/hostile/ordeal/indigo_noon/lanky,
+/turf/open/floor/plating/dirt/jungle/dark,
+/area/city/backstreets_room)
 "v" = (
 /obj/item/toy/beach_ball/holoball/dodgeball,
 /turf/open/floor/plating/dirt/jungle/dark,
@@ -186,7 +193,7 @@ N
 (3,1,1) = {"
 N
 Y
-D
+u
 Y
 s
 Y

--- a/code/controllers/subsystem/city_events.dm
+++ b/code/controllers/subsystem/city_events.dm
@@ -82,7 +82,10 @@ SUBSYSTEM_DEF(cityevents)
 	switch (chosen_event)
 		//Ordeal events
 		if("sweepers")
-			spawnatlandmark(/mob/living/simple_animal/hostile/ordeal/indigo_noon, 20)
+			spawnatlandmark(list(
+				/mob/living/simple_animal/hostile/ordeal/indigo_noon = 75,
+				/mob/living/simple_animal/hostile/ordeal/indigo_noon/chunky = 25,
+				), 20)
 		if("scouts")
 			spawnatlandmark(/mob/living/simple_animal/hostile/ordeal/indigo_dawn, 40)
 		if("bots")
@@ -100,11 +103,11 @@ SUBSYSTEM_DEF(cityevents)
 		if("drones")
 			spawnatlandmark(/mob/living/simple_animal/hostile/kcorp/drone, -10)//extremely low chance
 		if("lovetowneasy")
-			spawnatlandmark(pick(/mob/living/simple_animal/hostile/lovetown/slasher,
-			/mob/living/simple_animal/hostile/lovetown/stabber), 25)
+			spawnatlandmark(list(/mob/living/simple_animal/hostile/lovetown/slasher = 1,
+			/mob/living/simple_animal/hostile/lovetown/stabber = 1), 25)
 		if("lovetownhard")
-			spawnatlandmark(pick(/mob/living/simple_animal/hostile/lovetown/shambler,
-			/mob/living/simple_animal/hostile/lovetown/slumberer), 5)
+			spawnatlandmark(list(/mob/living/simple_animal/hostile/lovetown/shambler = 1,
+			/mob/living/simple_animal/hostile/lovetown/slumberer = 1), 5)
 
 		//Good events
 		if("chickens")
@@ -134,7 +137,13 @@ SUBSYSTEM_DEF(cityevents)
 		JobAddition()
 
 //Spawning Mobs, can spawn up to 3
-/datum/controller/subsystem/cityevents/proc/spawnatlandmark(mob/living/L, chance)
+/datum/controller/subsystem/cityevents/proc/spawnatlandmark(thing_to_spawn, chance)
+	// We will be picking the types to spawn with pickweight(available_mobs). The thing_to_spawn we received will either be a typepath to a single mob,
+	// or a weighted list with the mobs. If we received a list, we'll just use that list, if we received only one type, we will make a list with that type.
+	var/list/available_mobs = list(thing_to_spawn)
+	if(islist(thing_to_spawn))
+		available_mobs = thing_to_spawn
+
 	chance += wavetime*2
 	if(chance > 90)
 		chance = 90
@@ -144,22 +153,24 @@ SUBSYSTEM_DEF(cityevents)
 		new /obj/effect/bloodpool(get_turf(J))
 		sleep(10)
 		//This is less intensive than a loop
-
-		var/mob/living/mob1 = new L (get_turf(J))
+		var/type1 = pickweight(available_mobs)
+		var/mob/living/mob1 = new type1(get_turf(J))
 		if(ishostile(mob1))
 			var/mob/living/simple_animal/hostile/hostilemob1 = mob1
 			hostilemob1.guaranteed_butcher_results[/obj/item/stack/spacecash/c100] = 2
 			active_raiders += hostilemob1
 
 		if(prob(75))
-			var/mob/living/mob2 = new L (get_turf(J))
+			var/type2 = pickweight(available_mobs)
+			var/mob/living/mob2 = new type2(get_turf(J))
 			if(ishostile(mob2))
 				var/mob/living/simple_animal/hostile/hostilemob2 = mob2
 				hostilemob2.guaranteed_butcher_results[/obj/item/stack/spacecash/c100] = 2
 				active_raiders += hostilemob2
 
 		if(prob(50))
-			var/mob/living/mob3 = new L (get_turf(J))
+			var/type3 = pickweight(available_mobs)
+			var/mob/living/mob3 = new type3(get_turf(J))
 			if(ishostile(mob3))
 				var/mob/living/simple_animal/hostile/hostilemob3 = mob3
 				hostilemob3.guaranteed_butcher_results[/obj/item/stack/spacecash/c100] = 2

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/indigo/dusk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/indigo/dusk.dm
@@ -33,6 +33,7 @@
 		/mob/living/simple_animal/hostile/ordeal/indigo_noon = 1,
 		/mob/living/simple_animal/hostile/ordeal/indigo_noon/chunky = 1,
 		/mob/living/simple_animal/hostile/ordeal/indigo_noon/lanky = 1,
+		/mob/living/simple_animal/hostile/ordeal/indigo_dawn = 1, // This should be impossible, right? Well, they spawn on CoL at the same time.
 		)
 	AddComponent(/datum/component/ai_leadership, units_to_add)
 

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/indigo/indigo_shared_procs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/indigo/indigo_shared_procs.dm
@@ -10,7 +10,7 @@ Something for a future refactor?
 /mob/living/simple_animal/hostile/ordeal/proc/SweeperDevour(mob/living/L)
 	if(!L)
 		return FALSE
-	if(SSmaptype.maptype in SSmaptype.citymaps)
+	if(ishuman(L) && (SSmaptype.maptype in SSmaptype.citymaps))
 		return FALSE
 	visible_message(
 		span_danger("[src] devours [L]!"),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds Indigo Noon Variants to City of Light, among some other changes.

### Important unrelated changes
Changes the way City Raiders are spawned in city_events.dm. This is probably the most important thing to look at if you're reviewing this. 

It will no longer spawn 1-3 enemies of the same type: **each enemy can be of a different type.** 

If you give the **spawnatlandmark()** proc a weighted list, it will use it to spawn the enemies according to the weights.
Example: list(A = 90, B = 10) will almost always spawn enemies of type A, but may occassionally spawn enemies of type B as well. Otherwise you can just give it a mob typepath as it worked before, and it will just spawn them as usual.

### Minor Indigo Noon changes
Indigo Noons now have some more of their stuff put into variables, and have a section of their variables which will determine nerfs/buffs applied to them in CoL. This is mostly me preparing for having to balance them in the future if they're a broken mess.

### Changes to all Sweepers (minus Matriarch)
Can now devour non-humans on City mode.

### CoL Nest: Raider Spawns
Chunky sweepers can now spawn in the Nest. They have a weight of 25 compared to the normal Noons' 75, so they are not too common. I chose not to spawn Lankies in the Nest because I don't really want them to be breaking people's ankles and chasing down the clinic doctor inside the Nest, you know?

### CoL Ruins: Hallway Spawns
For sections of the Ruins designated to spawn Sweepers, the spawners now use this weighted list for spawning:
- Indigo Noon: 54
- Indigo Dawn: 30
- Indigo Noon (Chunky): 8
- Indigo Noon (Lanky): 8

Basically you should still primarily see mostly normal Noons and Dawns. There may be some variants out and about.

### CoL Ruins: Random Rooms
Variant sweepers were manually placed into certain rooms. Not all of them, though, especially the smaller ones with only a few sweepers didn't get any variant sweepers added there. You can check the Changed Files section of this PR, any .dmm file in there has had Variant Sweepers added to it.

### Miscellaneous
/obj/effect/spawner/mobspawner/indigo_noon can now pick a Variant Sweeper to spawn.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: City Raiders are no longer necessarily of the same type in each wave. Indigo Noon Variants can now appear on city mode. 
fix: Indigo enemies can now devour on city mode, as long as the target isn't a human
refactor: Indigo Noon has some values put into variables instead of hardcoded
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
