### PR TITLE
There is no ModularTegustation in Ba Sing Se

### DIFF
--- a/ACHIEVEMENT_IDEAS.md
+++ b/ACHIEVEMENT_IDEAS.md
@@ -4,7 +4,7 @@
 - ✅ **IMPLEMENTED** - Obtain silk from mobs 120 times
     - `code\game\objects\items\stacks\sheets\silk.dm`, make the silkweaver track the number of times it has been used.
 - ✅ **IMPLEMENTED** - Forge 50 weapons as a workshop attendant on City of Light
-    - `ModularTegustation\tegu_items\workshop\forging.dm`
+    - `ModularLobotomy/workshop/forging.dm`
 - ✅ **IMPLEMENTED** - Feed a plushie to Basilisoup
     - `code/modules/mob/living/simple_animal/abnormality/he/basilisoup.dm`
 - Collect the golden bough in ER
@@ -14,7 +14,7 @@
 
 ## City of Light Specific
 - ✅ **IMPLEMENTED** - Max out a workshop weapon in City of Light
-    - `ModularTegustation/tegu_items/workshop/_templates.dm`
+    - `ModularLobotomy/workshop/_templates.dm`
 - Trip on a landmine in one of the COL starter rooms
     - *Needs investigation for landmine/trap files*
 
@@ -33,7 +33,7 @@
     - `code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm`
     - `code/modules/mob/living/simple_animal/abnormality/waw/red_riding_mercenary.dm`
 - ✅ **IMPLEMENTED** - Use Fell Bullet's shotgun interaction
-    - `ModularTegustation\ego_weapons\ranged\waw.dm`
+    - `ModularLobotomy/ego_weapons/ranged/waw.dm`
 - ✅ **IMPLEMENTED** - Experience the special interaction between SWA and a person with her EGO gift
     - `code\modules\mob\living\simple_animal\abnormality\waw\snow_whites_apple.dm`
 - ✅ **IMPLEMENTED** - Breach Golden Apple with a Yuri plushie
@@ -61,7 +61,7 @@
 - Re-sane 8 agents in the same round
     - *Needs investigation for how to track re-sanes*
 - ❌ **TOO COMPLEX** - Have 5 abno kills as records officer
-    - `ModularTegustation\ego_weapons\_ego_weapon.dm`, just check the mind of the user, and give them a counter.
+    - `ModularLobotomy/ego_weapons/_ego_weapon.dm`, just check the mind of the user, and give them a counter.
 - Beat midnight on B12
     - *Needs investigation for specific midnight files*
 - Beat Abno Blitz (Purple Rare achievement)
@@ -95,11 +95,11 @@
 - Have at least 2 tool abno ego weapons and 1 tool abno ego armour
     - `code/modules/mob/living/simple_animal/abnormality/_tools/`
 - Get a Level 5, 10, 15 and 20 fishing hat respectively
-    - `ModularTegustation\fishing\code\fishing_items\fishing_hat.dm`
+    - `ModularLobotomy/fishing/code/fishing_items/fishing_hat.dm`
 - "Dumbass" - Hit yourself with boomerang weapon.
     - *Needs investigation for boomerang weapon files*
 - ❌ **TOO COMPLEX** - "This is my fixer OC, donut steel." - Have all color fixer weapons on you + Twilight suit.
-    - `ModularTegustation/ego_weapons/melee/non_abnormality/color_fixer.dm`, just check if the player is holding "/obj/item/ego_weapon/city/pt/slash, /obj/item/ego_weapon/black_silence_gloves, /obj/item/ego_weapon/mimicry/kali, /obj/item/ego_weapon/city/reverberation"
+    - `ModularLobotomy/ego_weapons/melee/city/color_fixer.dm`, just check if the player is holding "/obj/item/ego_weapon/city/pt/slash, /obj/item/ego_weapon/black_silence_gloves, /obj/item/ego_weapon/mimicry/kali, /obj/item/ego_weapon/city/reverberation"
 
 ## Special/Easter Eggs
 - ✅ **IMPLEMENTED** - Say "uwu" on the radio achievement
@@ -137,7 +137,7 @@
 
 ## Resource Management
 - ✅ **IMPLEMENTED** - Refine 100 PE boxes (now player-specific)
-    - `ModularTegustation\tegu_items\refinery\refinery.dm`
+    - `ModularLobotomy/refinery/refinery.dm`
 
 ## Death Achievements
 - ✅ **IMPLEMENTED** - Get killed by friendly breach Queen of Hatred
@@ -176,7 +176,7 @@
 
 ## Combat Challenges
 - ✅ **IMPLEMENTED** - Kill Claw (already exists as WhiteMidnight achievement)
-    - `ModularTegustation/tegu_mobs/the_claw.dm`
+    - `ModularLobotomy/extra_mobs/the_claw.dm`
 - ✅ **IMPLEMENTED** - Damage PBird
     - `code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm`
 - ✅ **IMPLEMENTED** - Kill PBird (separate achievement)
@@ -190,7 +190,7 @@
 
 ## Role-Specific
 - ✅ **IMPLEMENTED** - As a clerk role, use a weapon that isn't ZAYIN or TETH
-    - `ModularTegustation\ego_weapons\_ego_weapon.dm`, just check if the weapon has requirments, and if the mind is of a clerk
+    - `ModularLobotomy/ego_weapons/_ego_weapon.dm`, just check if the weapon has requirments, and if the mind is of a clerk
 
 ---
 *Note: More achievement ideas to be added. Files marked with "Needs investigation" require further searching to locate the appropriate implementation files.*

--- a/IMPLEMENTED_ACHIEVEMENTS.md
+++ b/IMPLEMENTED_ACHIEVEMENTS.md
@@ -8,7 +8,7 @@ This file lists all achievements implemented in this session, with space to add 
 **Title:** the Legend of the Silksong
 
 ### Forge 50 weapons as a workshop attendant
-**File:** `ModularTegustation/tegu_items/workshop/_templates.dm`
+**File:** `ModularLobotomy/workshop/_templates.dm`
 **Name:** Respectable Workshop, Workshop Meister
 **Title:** a Workshop Meister
 
@@ -18,12 +18,12 @@ This file lists all achievements implemented in this session, with space to add 
 **Title:** a Plushie Chef
 
 ### Refine 100 PE boxes
-**File:** `ModularTegustation/tegu_items/refinery/refinery.dm`  
+**File:** `ModularLobotomy/refinery/refinery.dm`  
 **Name:** Don't forget to do your dailies
 **Title:** Refina-Junkie
 
 ### Max out a workshop weapon
-**File:** `ModularTegustation/tegu_items/workshop/_templates.dm`  
+**File:** `ModularLobotomy/workshop/_templates.dm`  
 **Name:** Weapon of mass Fixer-ation, S-Class Workshop Meister
 **Title:** an S-Class Workshop Meister
 
@@ -49,7 +49,7 @@ This file lists all achievements implemented in this session, with space to add 
 **Title:** being In Sheep's Clothing
 
 ### Use Fell Bullet's shotgun interaction
-**File:** `ModularTegustation/ego_weapons/ranged/waw.dm`  
+**File:** `ModularLobotomy/ego_weapons/ranged/waw.dm`  
 **Name:** "Bullet drenched with blood of ally.", FireIShallFire
 **Title:** Memory Burner
 
@@ -214,6 +214,6 @@ This file lists all achievements implemented in this session, with space to add 
 **Title:** being Egoism Incarnate
 
 ### Clerk using non-ZAYIN/TETH weapon
-**File:** `ModularTegustation/ego_weapons/_ego_weapon.dm`  
+**File:** `ModularLobotomy/ego_weapons/_ego_weapon.dm`  
 **Name:** Breaking the limits
 **Title:** a Limit Breaker

--- a/ModularLobotomy/ego_weapons/melee/city/cinqwest_selfiestick_complete_implementation.md
+++ b/ModularLobotomy/ego_weapons/melee/city/cinqwest_selfiestick_complete_implementation.md
@@ -5,7 +5,7 @@
 All phases have been successfully implemented and the code compiles without errors!
 
 ### Files Created/Modified:
-- ✅ Created: `/ModularTegustation/ego_weapons/melee/non_abnormality/cinqwest_selfiestick.dm`
+- ✅ Created: `/ModularLobotomy/ego_weapons/melee/city/cinqwest_selfiestick.dm`
 - ✅ Modified: `/code/game/objects/items/devices/PDA/PDA.dm`
 
 ## Overview
@@ -33,7 +33,7 @@ Add a new weapon `/obj/item/ego_weapon/city/cinqwest_selfiestick` that allows PD
 
 ## File Modifications Required
 
-### 1. ModularTegustation/ego_weapons/melee/non_abnormality/cinqwest_selfiestick.dm ✅ CREATED
+### 1. ModularLobotomy/ego_weapons/melee/city/cinqwest_selfiestick.dm ✅ CREATED
 
 Created the complete selfie stick weapon with streaming and chat features:
 

--- a/_maps/RandomRooms/backstreetlayout/outskirts.dmm
+++ b/_maps/RandomRooms/backstreetlayout/outskirts.dmm
@@ -792,7 +792,7 @@
 	icon_state = "wishwell";
 	name = "well";
 	density = 1;
-	icon = 'ModularTegustation/Teguicons/toolabnormalities.dmi';
+	icon = 'ModularLobotomy/_Lobotomyicons/toolabnormalities.dmi';
 	pixel_y = -3
 	},
 /turf/open/floor/plating/dirt/jungle/wasteland,
@@ -811,7 +811,7 @@
 	icon_state = "wishwell";
 	name = "well";
 	density = 1;
-	icon = 'ModularTegustation/Teguicons/toolabnormalities.dmi';
+	icon = 'ModularLobotomy/_Lobotomyicons/toolabnormalities.dmi';
 	pixel_y = -3
 	},
 /turf/open/floor/plating/ironsand,

--- a/_maps/RandomRooms/backstreets/connector/jumpscare.dmm
+++ b/_maps/RandomRooms/backstreets/connector/jumpscare.dmm
@@ -160,7 +160,7 @@
 "LV" = (
 /obj/structure/statue/sandstone/venus{
 	desc = "To know and manipulate all the secrets of the world; that is the privilege of the Head, the Eye, and the Claws. It is their honor and absolute power.";
-	icon = 'ModularTegustation/Teguicons/tegumobs.dmi';
+	icon = 'ModularLobotomy/_Lobotomyicons/tegumobs.dmi';
 	icon_state = "fixer_p";
 	name = "statue of a tax collector";
 	pixel_y = null

--- a/_maps/RandomRooms/backstreets/resurgence_village.dmm
+++ b/_maps/RandomRooms/backstreets/resurgence_village.dmm
@@ -444,7 +444,7 @@
 	icon_state = "wishwell";
 	name = "well";
 	density = 1;
-	icon = 'ModularTegustation/Teguicons/toolabnormalities.dmi';
+	icon = 'ModularLobotomy/_Lobotomyicons/toolabnormalities.dmi';
 	pixel_y = -3
 	},
 /turf/open/floor/plating/dirt/jungle/wasteland,
@@ -681,7 +681,7 @@
 	icon_state = "wishwell";
 	name = "well";
 	density = 1;
-	icon = 'ModularTegustation/Teguicons/toolabnormalities.dmi';
+	icon = 'ModularLobotomy/_Lobotomyicons/toolabnormalities.dmi';
 	pixel_y = -3
 	},
 /turf/open/floor/plating/ironsand,

--- a/_maps/map_files/Event/fixer_office.dmm
+++ b/_maps/map_files/Event/fixer_office.dmm
@@ -6602,7 +6602,7 @@
 /obj/structure/fluff/arc{
 	desc = "A humanoid creature wearing metallic armor. It has bloodied hooks in its hands.";
 	dir = 8;
-	icon = 'ModularTegustation/Teguicons/tegumobs.dmi';
+	icon = 'ModularLobotomy/_Lobotomyicons/tegumobs.dmi';
 	icon_state = "sweeper_1";
 	name = "sweeper statue";
 	pixel_x = -3
@@ -8567,7 +8567,7 @@
 /obj/effect/turf_decal/box,
 /obj/structure/fluff/arc{
 	desc = "A slim robot with a spear in place of its hand.";
-	icon = 'ModularTegustation/Teguicons/32x48.dmi';
+	icon = 'ModularLobotomy/_Lobotomyicons/32x48.dmi';
 	icon_state = "green_bot";
 	name = "spear bot statue";
 	dir = 8
@@ -9173,7 +9173,7 @@
 /obj/effect/turf_decal/box,
 /obj/structure/fluff/arc{
 	desc = "A insect augmented employee of the fallen Gene corp. Word on the street says that they banded into common backstreet gangs after the Smoke War.";
-	icon = 'ModularTegustation/Teguicons/32x32.dmi';
+	icon = 'ModularLobotomy/_Lobotomyicons/32x32.dmi';
 	icon_state = "gcorp1";
 	name = "gene corp remnant statue";
 	dir = 8
@@ -10170,7 +10170,7 @@
 /obj/structure/fluff/arc{
 	desc = "A tiny worm-like creature with tough chitin and a pair of sharp claws.";
 	dir = 8;
-	icon = 'ModularTegustation/Teguicons/tegumobs.dmi';
+	icon = 'ModularLobotomy/_Lobotomyicons/tegumobs.dmi';
 	icon_state = "amber_bug";
 	name = "worm statue"
 	},

--- a/_maps/map_files/_Archive/Xi/xicommand.dmm
+++ b/_maps/map_files/_Archive/Xi/xicommand.dmm
@@ -18323,7 +18323,7 @@
 "Uj" = (
 /obj/structure/statue/sandstone/venus{
 	desc = "To know and manipulate all the secrets of the world; that is the privilege of the Head, the Eye, and the Claws. It is their honor and absolute power.";
-	icon = 'ModularTegustation/Teguicons/tegumobs.dmi';
+	icon = 'ModularLobotomy/_Lobotomyicons/tegumobs.dmi';
 	icon_state = "fixer_p";
 	name = "statue of a tax collector";
 	pixel_y = null

--- a/_maps/map_files/generic/Tutorial_Zone.dmm
+++ b/_maps/map_files/generic/Tutorial_Zone.dmm
@@ -116,7 +116,7 @@
 /obj/structure/fluff/arc{
 	desc = "An angelic creature wearing white and golden armor with a cannon-like weapon.";
 	dir = 8;
-	icon = 'ModularTegustation/Teguicons/32x48.dmi';
+	icon = 'ModularLobotomy/_Lobotomyicons/32x48.dmi';
 	icon_state = "fixer_w";
 	name = "White Fixer statue"
 	},
@@ -344,7 +344,7 @@
 /obj/structure/fluff/arc{
 	desc = "A humanoid creature wearing metallic armor. It has bloodied hooks in its hands.";
 	dir = 4;
-	icon = 'ModularTegustation/Teguicons/tegumobs.dmi';
+	icon = 'ModularLobotomy/_Lobotomyicons/tegumobs.dmi';
 	icon_state = "sweeper_1";
 	name = "sweeper statue";
 	pixel_x = -3
@@ -918,7 +918,7 @@
 /obj/structure/fluff/arc{
 	desc = "A round purple creature. It is constantly leaking mind-damaging gas.";
 	dir = 4;
-	icon = 'ModularTegustation/Teguicons/48x32.dmi';
+	icon = 'ModularLobotomy/_Lobotomyicons/48x32.dmi';
 	icon_state = "violet_fruit";
 	name = "fruit of understanding statue";
 	pixel_x = -8
@@ -1156,7 +1156,7 @@
 /obj/structure/fluff/arc{
 	desc = "A tiny worm-like creature with tough chitin and a pair of sharp claws.";
 	dir = 4;
-	icon = 'ModularTegustation/Teguicons/tegumobs.dmi';
+	icon = 'ModularLobotomy/_Lobotomyicons/tegumobs.dmi';
 	icon_state = "amber_bug";
 	name = "complete food statue"
 	},
@@ -1290,7 +1290,7 @@
 "MH" = (
 /obj/structure/fluff/arc{
 	desc = "A tiny humanoid creature in jester's attire.";
-	icon = 'ModularTegustation/Teguicons/tegumobs.dmi';
+	icon = 'ModularLobotomy/_Lobotomyicons/tegumobs.dmi';
 	icon_state = "crimson_clown";
 	name = "cheers for the start statue"
 	},
@@ -1348,7 +1348,7 @@
 "Pp" = (
 /obj/structure/fluff/arc{
 	desc = "A slim robot with a spear in place of its hand.";
-	icon = 'ModularTegustation/Teguicons/32x48.dmi';
+	icon = 'ModularLobotomy/_Lobotomyicons/32x48.dmi';
 	icon_state = "green_bot";
 	name = "doubt statue"
 	},

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -48,7 +48,7 @@ const taskDm = new Task('dm')
   .depends('tgui/public/tgui.html')
   .depends('tgui/public/*.bundle.*')
   .depends('tgui/public/*.chunk.*')
-  .depends('ModularTegustation/**') // LOBOTOMYCORPORATION ADDITION ensure it also checks for updates in modular code
+  .depends('ModularLobotomy/**') // LOBOTOMYCORPORATION ADDITION ensure it also checks for updates in modular code
   .depends('lobotomy-corp13.dme')
   .provides('lobotomy-corp13.dmb')
   .provides('lobotomy-corp13.rsc')


### PR DESCRIPTION
## About The Pull Request

Removes most remaining references to ModularTegustation and replaces them with their respective ModularLobotomy paths, including some broken icons and our dear build tool (which was also broken)

## Why It's Good For The Game

ModularTegustation is no longer real and cannot hurt us anymore.
Also its good thing to fix sprite bugs and keep our tools functional.

### Put your cool images here

N/A

### Did you test this PR?

* [X] This PR compiles
* [x] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [x] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

N/A

## Changelog
:cl:
fix: Removes most of remaining references to ModularTegustation. Fixes our build tool.
/:cl: