### PR TITLE
Draft - Steel Noon Speed Up - Bugged

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/steel.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/steel.dm
@@ -84,8 +84,6 @@
 	var/timesShot = 0
 	//Times shot required before activating the speed up.
 	var/shotRequirement = 5
-	//Test var. Delete later.
-	var/timesActivated = 0
 
 /mob/living/simple_animal/hostile/ordeal/steel_dawn/steel_noon/AttackingTarget(atom/attacked_target)
 	adjustBruteLoss(-10)
@@ -99,21 +97,19 @@
 	..()
 //Activates the speed up.
 /mob/living/simple_animal/hostile/ordeal/steel_dawn/steel_noon/handle_automated_action()
-	if(timesShot >= shotRequirement || world.time + noAttackTime >= lastAttack)
+	if(timesShot >= shotRequirement || lastAttack + noAttackTime >= world.time)
 		if(world.time >= speedUpCooldown)
 			visible_message(span_warning("[src] starts to move faster!"))
+			say("+RAAAGH!!+")
 			var/speedUpDuration = 3 SECONDS
 			TemporarySpeedChange(-1.2, speedUpDuration)
-			//Resets the requirements to make sure it doesn't activate 500 times.
 			lastAttack = world.time
-			timesShot = 0
 			speedUpCooldown = world.time + speedUpCooldownDuration
-			//Test variable.
-			timesActivated = timesActivated + 1
 //Measures how many times the Steel Noon was shot.
 /mob/living/simple_animal/hostile/ordeal/steel_dawn/steel_noon/bullet_act()
 	timesShot = timesShot + 1
-
+	if(timesShot >= shotRequirement)
+		timesShot = 0
 /mob/living/simple_animal/hostile/ordeal/steel_dawn/steel_noon/proc/DeathExplosion()
 	if(QDELETED(src))
 		return

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/steel.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/steel.dm
@@ -27,6 +27,7 @@
 	butcher_results = list(/obj/item/food/meat/slab/buggy = 2)
 	silk_results = list(/obj/item/stack/sheet/silk/steel_simple = 1)
 
+
 /mob/living/simple_animal/hostile/ordeal/steel_dawn/Initialize()
 	. = ..()
 	attack_sound = "sound/effects/ordeals/steel/gcorp_attack[pick(1,2,3)].ogg"
@@ -62,21 +63,56 @@
 	maxHealth = 1000	//Effectively have 750 HP
 	health = 1000		//Effectively have 750 HP
 	rapid_melee = 2
-	damage_coeff = list(RED_DAMAGE = 0.8, WHITE_DAMAGE = 1, BLACK_DAMAGE = 0.8, PALE_DAMAGE = 0.8)
+	move_to_delay = 3
+	damage_coeff = list(RED_DAMAGE = 1, WHITE_DAMAGE = 1.5, BLACK_DAMAGE = 1, PALE_DAMAGE = 1.5)
 	attack_verb_continuous = "slashes"
 	attack_verb_simple = "slash"
 	death_sound = 'sound/voice/mook_death.ogg'
 	butcher_results = list(/obj/item/food/meat/slab/buggy = 2)
 	silk_results = list(/obj/item/stack/sheet/silk/steel_simple = 2, /obj/item/stack/sheet/silk/steel_advanced = 1)
 
+	//Cooldown for the speed up.
+	var/speedUpCooldown = 0
+	//Duration of the cooldown for the speed up.
+	var/speedUpCooldownDuration = 10 SECONDS
+	//Vars for activating the speed up.
+	//Measures when the last attack was.
+	var/lastAttack = 0
+	//Time required not attacking before
+	var/noAttackTime = 15 SECONDS
+	//Time shot, self-explanatory.
+	var/timesShot = 0
+	//Times shot required before activating the speed up.
+	var/shotRequirement = 5
+	//Test var. Delete later.
+	var/timesActivated = 0
+
 /mob/living/simple_animal/hostile/ordeal/steel_dawn/steel_noon/AttackingTarget(atom/attacked_target)
 	adjustBruteLoss(-10)
+	//Measures when the Steel Noon last attacked.
+	lastAttack = world.time
 	if(health <= maxHealth * 0.25 && stat != DEAD && prob(75))
 		walk_to(src, 0)
 		say("FOR G CORP!!!")
 		animate(src, transform = matrix()*1.8, color = "#FF0000", time = 15)
 		addtimer(CALLBACK(src, PROC_REF(DeathExplosion)), 15)
 	..()
+//Activates the speed up.
+/mob/living/simple_animal/hostile/ordeal/steel_dawn/steel_noon/handle_automated_action()
+	if(timesShot >= shotRequirement || world.time + noAttackTime >= lastAttack)
+		if(world.time >= speedUpCooldown)
+			visible_message(span_warning("[src] starts to move faster!"))
+			var/speedUpDuration = 3 SECONDS
+			TemporarySpeedChange(-1.2, speedUpDuration)
+			//Resets the requirements to make sure it doesn't activate 500 times.
+			lastAttack = world.time
+			timesShot = 0
+			speedUpCooldown = world.time + speedUpCooldownDuration
+			//Test variable.
+			timesActivated = timesActivated + 1
+//Measures how many times the Steel Noon was shot.
+/mob/living/simple_animal/hostile/ordeal/steel_dawn/steel_noon/bullet_act()
+	timesShot = timesShot + 1
 
 /mob/living/simple_animal/hostile/ordeal/steel_dawn/steel_noon/proc/DeathExplosion()
 	if(QDELETED(src))
@@ -108,6 +144,8 @@
 		Z.screech_windup = 3 SECONDS
 
 	gib()
+
+
 
 //flying varient trades movement and attack speed for a sweeping attack.
 /mob/living/simple_animal/hostile/ordeal/steel_dawn/steel_noon/flying


### PR DESCRIPTION
## About The Pull Request
The Steel Noons should gain a speed up after not attacking for 15 seconds or being shot 5 or more times, the speed up has a cooldown of 10 seconds.
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the Steel Noons more of a threat.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
code: Updated steel.dm.
/:cl:
<!--
Tags:
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
