### PR TITLE
Steel Noon Speed Up + Resistance changes

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/steel.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/steel.dm
@@ -110,7 +110,7 @@
 	..()
 //Measures how many times the Steel Noon was shot.
 /mob/living/simple_animal/hostile/ordeal/steel_dawn/steel_noon/bullet_act()
-	timesShot = timesShot++
+	timesShot++
 	if(timesShot >= shotRequirement)
 		shotActive = TRUE
 		timesShot = 0


### PR DESCRIPTION
## About The Pull Request
Gives the Steel Noons a speed up if they're shot too many times or if they did not attack for a while.
Also changes their resistances.
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It makes the Steel Noons more of a threat.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
code: Updated steel.dm.
/:cl:
<!--
Tags:
code: Changed some code.
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
