### PR TITLE
Generic Brand Modelling Clay small rework.

### DIFF
--- a/code/modules/paperwork/records/info/teth.dm
+++ b/code/modules/paperwork/records/info/teth.dm
@@ -434,9 +434,11 @@
 	abno_type = /mob/living/simple_animal/hostile/abnormality/clayman
 	abno_code = "O-04-204"
 	abno_info = list(
-		"Employees who worked on O-04-204 reported no meaningful difference between work types.",
+		"No meaningful difference between work types could be noticed on the first work.",
 		"During work and breaches, the damage type dealt seemed to vary from hit to hit.",
-		"When the work result was Bad, the Qliphoth Counter lowered."
+		"However, each work increased the chances of a successful work on the revelant work by an estimated 10%, with other work being reduced by 5%",
+		"However, should any work type's base success rate reach 100%, O-04-204 would proceed to fall apart, putting all work rates at an equal but very low percentage.",
+		"When the work result was Bad and O-04-204 wasn't falling apart, the Qliphoth Counter lowered."
 	)
 
 //Sirocco


### PR DESCRIPTION
## About The Pull Request

When clay is worked, the relevant work type will gain 10% work chance, and the other work types will lose 5% work chance. Should any work type reach a 100%, ALL work types will go back to 20%, however its counter will not lower on failure until at least one work type is at 50%

## Why It's Good For The Game

Clayman is one of those abnormalities that's cooler in its concept and designs than it is in execution. It rarely ever breach, as its work rates are all equally as generous, and as such it also rarely gets to use or abuse its work damage. Its ego is good, yet not outstanding despite the versatile damage type it has. Generic indeed.

This aims to make generic brand modelling clay fill a unique niche within its TETH tier, all while giving it greater opportunities to deal its random damage, making it more than a filler abnormality. The change is relatively simple, but allows for a lot of player expression.

I tried to stay true to the original design and theme. The abnormality is quite literally being shaped by people working it, if you want it to become a repression abnormality, it can become it if you shape it that way, or you can alternate between two works and make it dual. However of course, the abnormality will *eventually* reach its limit and lose all its personality if you push it too far (which is almost inevitable given enough works). This encourages people to alternate between works, but unlike so many other abnormalities, we let the agents choose what they need at the moment, making it truly adaptable without being too abusable.

As for why I made it that way, there are multiple reasons. The abnormality being shaped by work makes sense (it is clay), but you can also see it as each work type being a fundamental of art and creativity, only trying to focus on one fundamental while neglecting others will inevitably lead to a shoddy piece of art, and so will trying to do everything at once. It can also be a metaphor for shaping yourself as a person, again, I've tried to keep the general theme going.

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
tweak: Generic Brand Modelling Clay's work rates are now affected by the type of work done on it.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
