### PR TITLE
Fires are Extinguishable Now [Seems to Work]

### DIFF
--- a/ModularLobotomy/associations/skills/liu/associate.dm
+++ b/ModularLobotomy/associations/skills/liu/associate.dm
@@ -39,7 +39,7 @@
 	//Burn people around you
 	for(var/mob/living/fuel in view(range, get_turf(src)))
 		if(fuel.stat != DEAD && fuel!=owner)
-			new /obj/structure/turf_fireliu(get_turf(fuel))
+			new /obj/effect/turf_fire/liu(get_turf(fuel))
 	owner.visible_message(span_warning("Through masterful flow [owner] sets those around him alight!"))
 
 	StartCooldown()
@@ -60,7 +60,7 @@
 		return FALSE
 
 	for(var/mob/living/carbon/human/fuel in view(range, get_turf(src)))
-		if(locate(/obj/structure/turf_fireliu) in fuel.loc)
+		if(locate(/obj/effect/turf_fire/liu) in fuel.loc)
 			if(fuel.sanity_lost) //Please for the love of god do not put this at the end or the proc bursts into flames
 				fuel.death()
 			//this stuff is important for what youre about to do
@@ -76,39 +76,20 @@
 
 	StartCooldown()
 
-/obj/structure/turf_fireliu
-	gender = PLURAL
-	name = "fire"
+/obj/effect/turf_fire/liu
 	desc = "a flower of iron."
-	icon = 'icons/effects/effects.dmi'
-	icon_state = "turf_fire"
-	anchored = TRUE
-	density = FALSE
 	layer = BELOW_OPEN_DOOR_LAYER
-	plane = FLOOR_PLANE
-	base_icon_state = "turf_fire"
+	burn_time = 10 SECONDS
 
-/obj/structure/turf_fireliu/Initialize()
-	. = ..()
-	QDEL_IN(src, 10 SECONDS)
-	for(var/mob/living/fuel in src.loc)
-		if(!ishuman(fuel))
-			fuel.apply_damage(5, FIRE, null, fuel.run_armor_check(null, FIRE), spread_damage = TRUE)
-		fuel.apply_damage(5, FIRE, null, fuel.run_armor_check(null, FIRE), spread_damage = TRUE)
-		fuel.adjust_fire_stacks(1)
-		fuel.IgniteMob()
-		to_chat(fuel, "<span class='danger'>You are singed as flames ignite around you!</span>")
-
-/obj/structure/turf_fireliu/Crossed(atom/movable/AM)
-	. = ..()
-	if(ismob(AM))
-		var/mob/living/fuel = AM
-		if(!ishuman(fuel))
-			fuel.apply_damage(10, FIRE, null, fuel.run_armor_check(null, FIRE), spread_damage = TRUE)
+/obj/effect/turf_fire/liu/DoDamage(mob/living/fuel)
+	if(!ishuman(fuel))
 		fuel.apply_damage(10, FIRE, null, fuel.run_armor_check(null, FIRE), spread_damage = TRUE)
-		fuel.adjust_fire_stacks(2)
-		fuel.IgniteMob()
+	fuel.apply_damage(10, FIRE, null, fuel.run_armor_check(null, FIRE), spread_damage = TRUE)
+	fuel.adjust_fire_stacks(2)
+	fuel.IgniteMob()
+	return TRUE
 
+// status effect
 /datum/status_effect/flamekissed
 	id = "flamekissed"
 	alert_type = null

--- a/ModularLobotomy/associations/skills/liu/director.dm
+++ b/ModularLobotomy/associations/skills/liu/director.dm
@@ -14,7 +14,7 @@
 		return FALSE
 
 	for(var/mob/living/carbon/human/fuel in view(range, get_turf(src)))
-		if(locate(/obj/structure/turf_fireliu) in fuel.loc)
+		if(locate(/obj/effect/turf_fire/liu) in fuel.loc)
 			//this stuff is important for what youre about to do
 			if (fuel == owner)
 				continue

--- a/ModularLobotomy/associations/skills/liu/veteran.dm
+++ b/ModularLobotomy/associations/skills/liu/veteran.dm
@@ -15,10 +15,10 @@
 
 	//Burn everything around
 	for(var/turf/open/T in view(range, get_turf(src)))
-		if(locate(/obj/structure/turf_fireliu) in T)
-			for(var/obj/structure/turf_fireliu/fire in T)
+		if(locate(/obj/effect/turf_fire/liu) in T)
+			for(var/obj/effect/turf_fire/liu/fire in T)
 				qdel(fire)
-		new /obj/structure/turf_fireliu(T)
+		new /obj/effect/turf_fire/liu(T)
 	owner.visible_message(span_warning("[owner] unleashes a wave of flames!"))
 	StartCooldown()
 

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -1132,12 +1132,18 @@
 	consumed_on_threshold = FALSE
 	var/new_stack = FALSE
 	var/safety = TRUE
+	var/extinguishable = TRUE
 
 /atom/movable/screen/alert/status_effect/lc_burn
 	name = "Burning"
 	desc = "You're on fire!"
 	icon = 'ModularLobotomy/_Lobotomyicons/status_sprites.dmi'
 	icon_state = "lc_burn"
+
+/datum/status_effect/stacking/lc_burn/on_apply()
+	. = ..()
+	if(extinguishable)
+		RegisterSignal(owner, COMSIG_LIVING_EXTINGUISHED, PROC_REF(Extinguished))
 
 /datum/status_effect/stacking/lc_burn/can_have_status()
 	return (owner.stat != DEAD || !(owner.status_flags & GODMODE))
@@ -1162,6 +1168,12 @@
 			Update_Burn_Overlay(owner)
 		else
 			qdel(src)
+
+//Being extinguished with a fire extinguisher removes 3 stacks.
+/datum/status_effect/stacking/lc_burn/proc/Extinguished()
+	SIGNAL_HANDLER
+
+	stacks -= 3
 
 /datum/status_effect/stacking/lc_burn/proc/DealDamage()
 	owner.apply_damage(stacks, FIRE, null, owner.run_armor_check(null, FIRE))
@@ -1407,6 +1419,7 @@
 /datum/status_effect/stacking/lc_burn/dark_flame
 	id = "dark_flame"
 	alert_type = /atom/movable/screen/alert/status_effect/dark_flame
+	extinguishable = FALSE
 
 /atom/movable/screen/alert/status_effect/dark_flame
 	name = "Dark Flame"

--- a/code/game/objects/effects/abnormality.dm
+++ b/code/game/objects/effects/abnormality.dm
@@ -258,6 +258,7 @@
 /obj/effect/sled/proc/FadeOut()
 	animate(src, alpha = 0, time = 5)
 	QDEL_IN(src, 5)
+
 /obj/effect/titania_aura
 	name = "titania"
 	desc = "A gargantuan fairy."
@@ -281,3 +282,65 @@
 	layer = POINT_LAYER
 	alpha = 150
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+/*
+* Turf Fire
+* subtypes used by Ardor Moth and Liu
+* Commonly used as a attack effect.
+*/
+/obj/effect/turf_fire
+	gender = PLURAL
+	name = "fire"
+	desc = "a burning pyre."
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "turf_fire"
+	anchored = TRUE
+	layer = TURF_LAYER
+	plane = FLOOR_PLANE
+	base_icon_state = "turf_fire"
+	var/damaging = FALSE
+	//Lifespan of the fire effect.
+	var/burn_time = 30 SECONDS
+	//Fire check timer and how long until we check again.
+	var/fire_turf_check_timer
+	var/fire_turf_check_time = 4
+	//Total health only used in reaction to getting extinguished
+	var/fire_health = 4
+
+/obj/effect/turf_fire/Initialize()
+	. = ..()
+	QDEL_IN(src, burn_time)
+	Burn()
+
+//Red and not burn, burn is a special damage type.
+/obj/effect/turf_fire/Crossed(atom/movable/AM)
+	. = ..()
+	if(isliving(AM))
+		Burn()
+
+/obj/effect/turf_fire/proc/Burn()
+	//return is the number of burnt mobs
+	var/burned_entities = 0
+	for(var/mob/living/H in get_turf(src))
+		if(!H)
+			continue
+		//arbitrary max fire damage so corpses still get burned
+		if(H.getFireLoss() < 1000 && H.stat != DEAD)
+			if(DoDamage(H))
+				. += 1
+	//If burned entities present and the timer no longer exists, check again.
+	if(burned_entities >= 1 && !TIMER_COOLDOWN_CHECK(src, fire_turf_check_timer))
+		//Im not sure if this will lag.
+		fire_turf_check_timer = addtimer(CALLBACK(src, PROC_REF(DoDamage)), fire_turf_check_time)
+
+//If this doesnt return true then the entity will not be counted towards the next check for burning.
+/obj/effect/turf_fire/proc/DoDamage(mob/living/fuel)
+	fuel.adjust_fire_stacks(2)
+	fuel.IgniteMob()
+	return TRUE
+
+//Overridable proc for special inextinguishable fires.
+/obj/effect/turf_fire/proc/WaterReact()
+	fire_health -= 1
+	if(fire_health <= 0)
+		qdel(src)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1629,7 +1629,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 				new /obj/effect/temp_visual/damage_effect/red(get_turf(H)) // Since bodypart damage bypasses bruteloss, we just make vfx here.
 			else//no bodypart, we deal damage with a more general method.
 				H.adjustBruteLoss(damage_amount)
-		if(FIRE, FIRE, LASER, ENERGY, RAD)
+		if(FIRE, LASER, ENERGY, RAD)
 			H.damageoverlaytemp = 20
 			var/damage_amount = forced ? damage : damage * hit_percent * burnmod * H.physiology.burn_mod
 			if(BP)
@@ -2048,15 +2048,9 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 		if(thermal_protection >= FIRE_IMMUNITY_MAX_TEMP_PROTECT && !no_protection)
 			return
-	////////////////////////////////////////
-	//Fire raising temperature is disabled//
-	////////////////////////////////////////
-/*
-		if(thermal_protection >= FIRE_SUIT_MAX_TEMP_PROTECT && !no_protection)
-			H.adjust_bodytemperature(11)
-		else
-			H.adjust_bodytemperature(BODYTEMP_HEATING_MAX + (H.fire_stacks * 12))
-*/
+
+		if(thermal_protection <= FIRE_SUIT_MAX_TEMP_PROTECT || no_protection)
+			H.deal_damage(4, FIRE)
 
 /datum/species/proc/CanIgniteMob(mob/living/carbon/human/H)
 	if(HAS_TRAIT(H, TRAIT_NOFIRE))

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -112,8 +112,10 @@
 	if(!G.gases[/datum/gas/oxygen] || G.gases[/datum/gas/oxygen][MOLES] < 1)
 		extinguish_mob() //If there's no oxygen in the tile we're on, put out the fire
 		return TRUE
+	/* Removed to prevent weirdness due to atmos being turned off.
 	var/turf/location = get_turf(src)
 	location.hotspot_expose(700, 50, 1)
+	*/
 
 /**
  * Get the fullness of the mob

--- a/code/modules/mob/living/simple_animal/abnormality/he/ardor_blossom_moth.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/ardor_blossom_moth.dm
@@ -94,6 +94,10 @@
 	light_on = FALSE
 	update_light()
 
+/mob/living/simple_animal/hostile/abnormality/ardor_moth/Destroy(force)
+	deltimer(stoke_timer)
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/ardor_moth/Move()
 	..()
 	for(var/turf/open/T in range(1, src))

--- a/code/modules/mob/living/simple_animal/abnormality/he/ardor_blossom_moth.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/ardor_blossom_moth.dm
@@ -97,51 +97,19 @@
 /mob/living/simple_animal/hostile/abnormality/ardor_moth/Move()
 	..()
 	for(var/turf/open/T in range(1, src))
-		if(locate(/obj/effect/turf_fire) in T)
-			for(var/obj/effect/turf_fire/floor_fire in T)
+		if(locate(/obj/effect/turf_fire/ardor) in T)
+			for(var/obj/effect/turf_fire/ardor/floor_fire in T)
 				qdel(floor_fire)
-		new /obj/effect/turf_fire(T)
+		new /obj/effect/turf_fire/ardor(T)
 
 /mob/living/simple_animal/hostile/abnormality/ardor_moth/spawn_gibs()
 	return new /obj/effect/decal/cleanable/ash(drop_location(), src)
 
-// Turf Fire
-/obj/effect/turf_fire
-	gender = PLURAL
-	name = "fire"
-	desc = "a burning pyre."
-	icon = 'icons/effects/effects.dmi'
-	icon_state = "turf_fire"
-	anchored = TRUE
-	layer = TURF_LAYER
-	plane = FLOOR_PLANE
-	base_icon_state = "turf_fire"
-	var/damaging = FALSE
+/obj/effect/turf_fire/ardor
+	burn_time = 30 SECONDS
 
-/obj/effect/turf_fire/Initialize()
-	. = ..()
-	QDEL_IN(src, 30 SECONDS)
-
-//Red and not burn, burn is a special damage type.
-/obj/effect/turf_fire/Crossed(atom/movable/AM)
-	. = ..()
-	if(!damaging)
-		damaging = TRUE
-		DoDamage()
-
-/obj/effect/turf_fire/proc/DoDamage()
-	var/dealt_damage = FALSE
-	for(var/mob/living/L in get_turf(src))
-		if(ishuman(L))
-			var/mob/living/carbon/human/H = L
-			H.deal_damage(4, FIRE)
-			H.apply_lc_burn(2)
-			dealt_damage = TRUE
-	if(!dealt_damage)
-		damaging = FALSE
-		return
-	addtimer(CALLBACK(src, PROC_REF(DoDamage)), 4)
-
-/mob/living/simple_animal/hostile/abnormality/ardor_moth/Destroy(force)
-	deltimer(stoke_timer)
-	return ..()
+/obj/effect/turf_fire/ardor/DoDamage(mob/living/fuel)
+	if(ishuman(fuel))
+		fuel.deal_damage(4, FIRE)
+		fuel.apply_lc_burn(2)
+		return TRUE

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -172,6 +172,10 @@
 			air.react(src)
 			qdel(hotspot)
 
+	var/obj/effect/turf_fire/t_fire = (locate(/obj/effect/turf_fire) in exposed_turf)
+	if(t_fire)
+		t_fire.WaterReact()
+
 /*
  *	Water reaction to an object
  */


### PR DESCRIPTION
## About The Pull Request
Fire effects such as those created by Ardor Blossom Moth, God of the Seasons, and Liu are extinguishable now.
Fire status effect has 3 stacks removed when extinguished. This seems to make sense since fire can apply several stacks when you walk onto it or cross several at the same time.
Dark Flame from magic bullet is not extinguishable due to its abnormal nature.

Unsure how it will actually effect gameplay since burn stacks are not reduced additively but instead divided by 2 each tick. So if you get 10 stacks and get extinguished you would have 7 stacks:
10/5/2.5/1.25 vs 7/3.5/1.75

Base ss13 fire now does damage again because it turns out the damage caused by fire in base SS13 is entirely from temperature increase. Ive changed this to be a flat 4 damage when on fire from normal things.

Also removes a hotspot being created in life.dm handle_fire() because it would mess with turfs atmos.
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes it so that people who take out extinguishers for otherwise mundane fires dont feel foolish.
Also makes the extinguishers in emergency packs useful until they run out of water.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution
<img width="270" height="461" alt="image" src="https://github.com/user-attachments/assets/688631ef-1340-4f53-a8b7-a7b2ffc8fae4" />

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
code: CHANGEME
/:cl:
<!--
Tags:
tweak: turf_fire effect and limbus fire status now react to fire extinguishers
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
