### PR TITLE
Core Suppressions for Manager-less shifts

### DIFF
--- a/ModularLobotomy/lc13_obj/lc13_computers/abnormality_auxiliary.dm
+++ b/ModularLobotomy/lc13_obj/lc13_computers/abnormality_auxiliary.dm
@@ -138,7 +138,7 @@
 				to_chat(usr, span_warning("A core suppression is already in the progress!"))
 				selected_core_type = null
 				return FALSE
-			if(usr.mind.assigned_role != "Manager")
+			if(usr.mind.assigned_role != "Manager" && !SSlobotomy_corp.core_selection_restriction_lifted)
 				to_chat(usr, span_warning("Only the Manager can start a Core Suppression!"))
 				playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
 				return FALSE
@@ -416,7 +416,7 @@
 				return
 			if(istype(SSlobotomy_corp.core_suppression))
 				CRASH("[src] has attempted to activate a core suppression via TGUI whilst its not possible!")
-			if(usr.mind.assigned_role != "Manager")
+			if(usr.mind.assigned_role != "Manager" && !SSlobotomy_corp.core_selection_restriction_lifted)
 				to_chat(usr, span_warning("Only the Manager can start a Core Suppression!"))
 				playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
 				return

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -368,9 +368,10 @@ SUBSYSTEM_DEF(ticker)
 			iter_human.hardcore_survival_score *= 2 //Double for antags
 		to_chat(iter_human, "<span class='notice'>You will gain [round(iter_human.hardcore_survival_score)] hardcore random points if you survive this round!</span>")
 
-	// Gamespeed vote for LobCorp gamemodes.
+	// Gamespeed vote and no-Manager Core Suppression selection override for LobCorp gamemodes.
 	if((SSmaptype.maptype in SSmaptype.lc_maps) || SSmaptype.maptype == "mini")
 		addtimer(CALLBACK(src, PROC_REF(DoGamespeedVote)), 10 SECONDS)
+		addtimer(CALLBACK(SSlobotomy_corp, TYPE_PROC_REF(/datum/controller/subsystem/lobotomy_corp, LiftCoreSelectionRestriction)), SSlobotomy_corp.core_selection_restriction_lift_timer)
 
 //These callbacks will fire after roundstart key transfer
 /datum/controller/subsystem/ticker/proc/OnRoundstart(datum/callback/cb)

--- a/code/modules/jobs/job_types/manager.dm
+++ b/code/modules/jobs/job_types/manager.dm
@@ -45,6 +45,9 @@
 	secsensor.add_hud_to(outfit_owner)
 	medsensor.add_hud_to(outfit_owner)
 
+	// foolish Agent, only I MAY SET THE CORE SUPPRESSIONS...!!!!
+	SSlobotomy_corp.core_selection_restriction_lifted = FALSE
+
 /datum/outfit/job/manager
 	name = "Manager"
 	jobtype = /datum/job/manager

--- a/code/modules/ordeals/_ordeal.dm
+++ b/code/modules/ordeals/_ordeal.dm
@@ -97,6 +97,9 @@
 	if(level == 4 && start_time <= (CONFIG_GET(number/suppression_time_limit) + (GetFacilityUpgradeValue(UPGRADE_MELTDOWN_INCREASE) * 20 MINUTES)))
 		// Extra cores, and announced!
 		addtimer(CALLBACK(SSlobotomy_corp, TYPE_PROC_REF(/datum/controller/subsystem/lobotomy_corp, PickPotentialSuppressions), TRUE, TRUE), 15 SECONDS)
+		// Check to see if we have a Manager at this point, 'cause if we don't, we should at least allow the Agents to try an Extra on their own if they want.
+		// A check for this is also done by ticker.dm a while after roundstart, but a Manager could've died/cryo'd since then.
+		addtimer(CALLBACK(SSlobotomy_corp, TYPE_PROC_REF(/datum/controller/subsystem/lobotomy_corp, LiftCoreSelectionRestriction)), 20 SECONDS)
 	/// If it was a dusk - we end running core suppression
 	else if(level == 3 && istype(SSlobotomy_corp.core_suppression))
 		addtimer(CALLBACK(SSlobotomy_corp.core_suppression, TYPE_PROC_REF(/datum/suppression, End)), 5 SECONDS)


### PR DESCRIPTION
## About The Pull Request
This PR makes it so the restriction which makes it so that only Managers can start Core Suppressions gets disabled, if there isn't a Manager at certain points in the round.

Default behaviour: Only Manager can start Cores & Extra Cores.
15 minutes into the round, there will be a check for a living Manager. If there isn't one, the restriction is lifted. At that point, anyone can start a Core Suppression.

If a Manager joins after the restriction has been lifted, the restriction will be activated again.

If Extra Cores are unlocked, there will be another check for a Manager, and if there isn't one, the restrictions will be lifted again.

tl;dr: you can do core suppressions without a manager, if one doesn't show up
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes runs without Managers have the possibility of doing Cores, but Managers still retain control over the feature IF they exist. The 15min window for a Manager to join should help prevent lone agents from unleashing the horrors of Records core upon everyone else.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
tweak: Core Suppression Restriction is lifted when no Manager is present, and re-enabled when they show up
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
