### PR TITLE
Fixes mobs maintaining patrol while timestop'd

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
@@ -317,7 +317,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/mountain/CanStartPatrol()
 	if(phase <= 1) // Still phase one, we need corpses and can't really fight
-		return !(status_flags & GODMODE)
+		return (AIStatus != AI_OFF && !(status_flags & GODMODE))
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/mountain/patrol_reset()

--- a/code/modules/mob/living/simple_animal/abnormality/he/better_memories.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/better_memories.dm
@@ -303,7 +303,7 @@
 
 /mob/living/simple_animal/hostile/better_memories_minion/CanStartPatrol()
 	if(!fleeing_now)
-		return !(status_flags & GODMODE)
+		return (AIStatus != AI_OFF && !(status_flags & GODMODE))
 	return ..()
 
 //Prevents accumulation of hate when actively fleeing.

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -1325,7 +1325,7 @@ GLOBAL_LIST_EMPTY(marked_players)
 	patrol_cooldown = world.time + patrol_cooldown_time
 
 /mob/living/simple_animal/hostile/proc/patrol_move(dest)
-	if(client || target || status_flags & GODMODE)
+	if(client || target || status_flags & GODMODE || AIStatus == AI_OFF)
 		patrol_reset()
 		return FALSE
 	if(!dest || !patrol_path || !patrol_path.len) //A-star failed or a path/destination was not set.

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/indigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/indigo.dm
@@ -97,7 +97,7 @@
 
 //Stolen MOSB patrol code
 /mob/living/simple_animal/hostile/ordeal/indigo_midnight/CanStartPatrol()
-	return !(status_flags & GODMODE) && !target
+	return (AIStatus != AI_OFF && !(status_flags & GODMODE)) && !target
 
 /mob/living/simple_animal/hostile/ordeal/indigo_midnight/patrol_reset()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Adds an AI_state check to the patrol_move proc so that hostile mobs stop patrolling once timestop'd (since timestop turns off the AI of affected mobs)

Also slightly modifies MoSB patrol code (its a special case) and derivatives to take into account AI_state.

The PR does not _truly_ work as intended, as sometimes mobs will manage to take one step after being timestop'd before it comes into effect. I suspect that this is due to the fact that if the mob switches from patrol movement to aggro movement quickly enough after stepping onto the timestop field it might queue a step before the timestop procs come into effect. I await the generalized can_act/can_move variables as they would fix this issue by disallowing the act of movement directly.

For now, this PR only explicitly prevents patrol behaviour to continue after a hostile mob is timestop'd

## Why It's Good For The Game

MoSB will no longer use the power of anime and friendship to forcefully break out of timestop and chomp on agent's heads.
Also patrolling mobs will no longer skip a timestop field entirely.

### Put your cool images here

N/A

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution
N/A

## Changelog
:cl:
fix: Makes patrol behaviour stops once a mob is timestop'd
/:cl:

