### PR TITLE
Freischütz teleport visible message & louder SFX

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
@@ -366,8 +366,12 @@
 	if(health < (maxHealth / 2)) //50% health or lower
 		already_fled = TRUE
 		animate(src, alpha = 0, time = 0.5 SECONDS)
-		playsound(src, 'sound/abnormalities/freischutz/portal.ogg', 60, 0, 1)
+		playsound(src, 'sound/abnormalities/freischutz/portal.ogg', 75, 0, 5)
+		var/obj/effect/temp_visual/guardian/phase/escape_vfx = new /obj/effect/temp_visual/guardian/phase(get_turf(src))
+		escape_vfx.color = COLOR_ASSEMBLY_BLUE
+		escape_vfx.transform *= 1.5
 		SLEEP_CHECK_DEATH(0.5 SECONDS)
+		visible_message(span_warning("[src] steps through a portal made of dark flame, fleeing the battle!"))
 		TeleportDepartmentCenter()
 		animate(src, alpha = 255, time = 0.5 SECONDS)
 
@@ -385,6 +389,9 @@
 			T = pick(GLOB.department_centers)
 	can_move = FALSE
 	if(T)
+		var/obj/effect/temp_visual/guardian/phase/entry_vfx = new /obj/effect/temp_visual/guardian/phase(T)
+		entry_vfx.color = COLOR_ASSEMBLY_BLUE
+		entry_vfx.transform *= 1.5
 		forceMove(T)
 
 /mob/living/simple_animal/hostile/abnormality/der_freischutz/proc/PortalAssault(mob/living/TargetOverride = null, extended = TRUE)


### PR DESCRIPTION
## About The Pull Request
Freischütz' fleeing teleport SFX is now louder, displays a visible message, and there's a small VFX when he teleports in/out. If we had a real portal sprite for him I'd have used it, at the moment it's just a recoloured KoD teleport VFX.

<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Better visual and audio clarity, to avoid "oh, the tall guy with the gun disappeared, I must've killed him"
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

https://github.com/user-attachments/assets/0889ae9f-ff5f-46fc-9021-ee86c2e87fc7


<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
tweak: Freischütz egress has a visible message, SFX was made louder, now has entry/egress VFX
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
