### PR TITLE
Fixes unmanifested distortions ripping the resulting egoist apart.

### DIFF
--- a/code/modules/mob/living/simple_animal/distortion/_distortion.dm
+++ b/code/modules/mob/living/simple_animal/distortion/_distortion.dm
@@ -188,26 +188,15 @@
 			equippable_gear.equip_slowdown = 3
 		else
 			egoist.put_in_hands(new gear(egoist))
-
 	PostUnmanifest(egoist)
-	PollGhosts(egoist)
+	if(key && (!new_egoist || mind)) //A player unmanifested somehow
+		egoist.key = key
+		mind.transfer_to(egoist)
+	else
+		INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(offer_control), egoist, "Civilian")
 	egoist.forceMove(get_turf(src))
 	qdel(src)
 	return
-
-/mob/living/simple_animal/hostile/distortion/proc/PollGhosts(mob/living/carbon/human/egoist)
-	if(!new_egoist || mind) //A player unmanifested somehow
-		egoist.key = key
-		mind.transfer_to(egoist)
-		return
-	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as [egoist.real_name]?", ROLE_PAI, null, FALSE, 100, egoist)
-	if(LAZYLEN(candidates))
-		var/mob/dead/observer/C = pick(candidates)
-		egoist.key = C.key
-		if(C.mind)
-			C.mind.transfer_to(egoist)
-			egoist.mind.assigned_role = "Civilian"
-			return
 
 /mob/living/simple_animal/hostile/distortion/proc/PostUnmanifest(mob/living/carbon/human/egoist)
 	return

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -422,20 +422,21 @@
  *
  * Automatic logging and uses pollCandidatesForMob, how convenient
  */
-/proc/offer_control(mob/M)
+/proc/offer_control(mob/M, set_role = null)
 	to_chat(M, "Control of your mob has been offered to dead players.")
 	if(usr)
 		log_admin("[key_name(usr)] has offered control of ([key_name(M)]) to ghosts.")
 		message_admins("[key_name_admin(usr)] has offered control of ([ADMIN_LOOKUPFLW(M)]) to ghosts")
 	var/poll_message = "Do you want to play as [M.real_name]?"
-	if(M.mind && M.mind.assigned_role)
-		poll_message = "[poll_message] Job:[M.mind.assigned_role]."
-	if(M.mind && M.mind.special_role)
-		poll_message = "[poll_message] Status:[M.mind.special_role]."
-	else if(M.mind)
-		var/datum/antagonist/A = M.mind.has_antag_datum(/datum/antagonist/)
-		if(A)
-			poll_message = "[poll_message] Status:[A.name]."
+	if(M.mind)
+		if(M.mind.assigned_role)
+			poll_message = "[poll_message] Job:[M.mind.assigned_role]."
+		if(M.mind.special_role)
+			poll_message = "[poll_message] Status:[M.mind.special_role]."
+		else
+			var/datum/antagonist/A = M.mind.has_antag_datum(/datum/antagonist/)
+			if(A)
+				poll_message = "[poll_message] Status:[A.name]."
 	var/list/mob/dead/observer/candidates = pollCandidatesForMob(poll_message, ROLE_PAI, null, FALSE, 100, M)
 
 	if(LAZYLEN(candidates))
@@ -445,6 +446,9 @@
 		M.ghostize(0)
 		M.key = C.key
 		M.client?.init_verbs()
+		if(set_role)
+			if(M.mind)
+				M.mind.assigned_role = set_role
 		return TRUE
 	else
 		to_chat(M, "There were no ghosts willing to take control.")


### PR DESCRIPTION
Fixes bug with unmanifesting distortions.

## About The Pull Request

Distortions used to linger 10 whole seconds after "demanifesting" while ghosts were given a poll to possess the resulting egoists, aggroing onto them from their insides. (and ripping them apart if the distortion was powerful enough.)
This PR fixes that, and additionally adds an option in the "offer_control" mob proc so that you can assign a role after the mob is possessed by a ghost. (Many things are role-locked, this is why its good!)

## Why It's Good For The Game

Bugfixes are good.

### Put your cool images here

N/A

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

## Attribution

N/A

## Changelog
:cl:
fix: Fixed distortions not demanifesting when they should.
/:cl:
