### PR TITLE
Add: Ping on Discord if player number meets or exceeds a new config value

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -529,6 +529,13 @@
 	min_val = 0.0
 	max_val = 1.0
 
+/datum/config_entry/number/high_pop_ping_threshold
+	config_entry_value = 7
+	integer = TRUE
+
+/datum/config_entry/string/high_pop_ping_roleid
+	config_entry_value = null
+
 // If midnight has started by this time - upon finishing it, the core suppression will be available
 // In 1/10 of a second
 /datum/config_entry/number/suppression_time_limit

--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -52,6 +52,9 @@ SUBSYSTEM_DEF(discord)
 	/// Is TGS enabled (If not we won't fire because otherwise this is useless)
 	var/enabled = FALSE
 
+	/// Did we give a high-pop ping yet?
+	var/high_pop_pinged = FALSE
+
 /datum/controller/subsystem/discord/Initialize(start_timeofday)
 	common_words = world.file2list("strings/1000_most_common.txt")
 	reverify_cache = list()
@@ -78,6 +81,13 @@ SUBSYSTEM_DEF(discord)
 		return // Dont do shit if its disabled
 	if(notify_members == notify_members_cache)
 		return // Dont re-write the file
+	// If we need to ping people for high pop
+	if(!high_pop_pinged)
+		if(CONFIG_GET(string/high_pop_ping_roleid) != null)
+			var/player_count = get_active_player_count(alive_check=TRUE, afk_check=TRUE)
+			if(player_count >= CONFIG_GET(number/high_pop_ping_threshold))
+				send2chat("<@[CONFIG_GET(string/high_pop_ping_roleid)]> - We have reached [player_count] players, come join!", CONFIG_GET(string/chat_announce_new_game))
+				high_pop_pinged = TRUE
 	// If we are all clear
 	write_notify_file()
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -545,6 +545,14 @@ DEFAULT_VIEW_SQUARE 15x15
 ## Add the ID of the role you want assigning here
 #DISCORD_ROLEID 000000000000000000
 
+#### OTHER DISCORD STUFF ####
+
+## Add the role ID of the role you wish to ping for high pop, leave commented out to disable high pop role pings
+#HIGH_POP_PING_ROLEID 000000000000000000
+
+## Uncomment to change the number of active players needed for a Discord ping to be sent
+#HIGH_POP_PING_THRESHOLD 7
+
 ##Amount of time required for senior job titles in minutes
 SENIOR_TIMELOCK 600
 


### PR DESCRIPTION
## About The Pull Request
Adds code that allows pings to be sent via TGS should `HIGH_POP_PING_THRESHOLD` (default 7) config is met or exceeded by alive, non-afk players.

The check currently includes things like admins in test mobs or players in control of monsters. If instead only personnel on the manifest should be considered, please comment & I'll see what's possible in that regard.

<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows people to be notified for populated rounds thus incentivizing people to join for those rounds.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here
N/A
<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?
Tests 2 to 5 skipped due to difficulty testing without a local mock of TGS et cetera which I can't be bothered to set up

* [X] This PR compiles
* [ ] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution
N/A
<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
add: You can now be pinged if there are people in the round!
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
