### PR TITLE
LC13 Update: Door to Nowhere Cleanup

### DIFF
--- a/_maps/map_files/generic/Abnormality_Z.dmm
+++ b/_maps/map_files/generic/Abnormality_Z.dmm
@@ -2,7 +2,7 @@
 "ao" = (
 /obj/structure/regret_shrine/unspoken,
 /turf/open/indestructible/paper,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "aC" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 5
@@ -33,21 +33,21 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/indestructible/white,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "aR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/tiled/purple,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "aS" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "bd" = (
 /obj/structure/flora/icestalactite{
 	pixel_x = -18;
@@ -88,7 +88,7 @@
 /obj/item/raw_anomaly_core/bluespace,
 /obj/item/clothing/suit/armor/riot/knight/greyscale,
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "bv" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 5
@@ -122,16 +122,16 @@
 "bW" = (
 /obj/item/ammo_casing/caseless/ego_kcorp,
 /turf/open/floor/carpet/green,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "bZ" = (
 /obj/structure/fluff/paper,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "cb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "ci" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -170,7 +170,7 @@
 "cp" = (
 /obj/structure/mineral_door/wood,
 /turf/open/floor/carpet/orange,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "cq" = (
 /mob/living/simple_animal/pet/penguin/baby,
 /turf/open/floor/holofloor/snow,
@@ -178,33 +178,33 @@
 "cH" = (
 /obj/machinery/tape_archive,
 /turf/open/floor/carpet/black,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "cK" = (
 /obj/machinery/door/airlock/hatch,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "cL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/painting/library{
 	pixel_y = 32
 	},
 /turf/open/floor/carpet/orange,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "cN" = (
 /obj/structure/sign/painting/library{
 	pixel_y = -32
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/royalblue,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "cT" = (
 /obj/structure/regret_door{
 	pixel_x = -32
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "dm" = (
 /obj/structure/flora/icestalactite/small,
 /obj/effect/areaflavor_snow,
@@ -231,29 +231,29 @@
 /area/snowqueen)
 "dv" = (
 /turf/open/floor/bronze,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "dw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/carpet/royalblue,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "dz" = (
-/obj/effect/landmark/backrooms_spawn,
+/obj/effect/landmark/repentance_spawn,
 /obj/structure/regret_door{
 	pixel_y = -32
 	},
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "dH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/reinforced,
 /obj/structure/bedsheetbin,
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "dJ" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plating/ironsand,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "dL" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
@@ -281,16 +281,16 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/facility,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "em" = (
 /obj/structure/table/wood,
 /obj/item/mailpaper/junk,
 /turf/open/indestructible/paper,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "ep" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/carpet/black,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "eq" = (
 /obj/structure/chair/snowqueen,
 /obj/effect/areaflavor_snow,
@@ -313,23 +313,23 @@
 /obj/structure/barricade/wooden/crude,
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating/ironsand,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "eA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
 	},
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "eC" = (
 /obj/effect/overlay/light_cone{
 	color = "#E1E17D"
 	},
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "eE" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating/ironsand,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "eG" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -350,10 +350,10 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/black,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "eV" = (
 /turf/open/floor/carpet/blue,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "eY" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -362,7 +362,7 @@
 /area/fishboat)
 "eZ" = (
 /turf/open/floor/carpet/royalblack,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "fa" = (
 /obj/effect/overlay/light_cone{
 	color = "#E1E17D"
@@ -372,7 +372,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "fd" = (
 /obj/structure/flora/icegrave{
 	pixel_x = 22;
@@ -399,15 +399,15 @@
 	color = "#E1E17D"
 	},
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "fl" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/borghypo/borgshaker,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "fy" = (
-/obj/effect/landmark/backrooms_spawn,
+/obj/effect/landmark/repentance_spawn,
 /obj/effect/light_emitter{
 	light_power = 4;
 	light_range = 25;
@@ -419,13 +419,13 @@
 	pixel_x = 32
 	},
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "fz" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /turf/open/floor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "fJ" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 8
@@ -449,7 +449,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/orange,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "fR" = (
 /turf/closed/mineral/snowmountain/cavern{
 	layer = 3.3
@@ -459,12 +459,12 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "gp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/sheet/silk/azure_simple,
 /turf/open/floor/mineral/titanium/tiled/purple,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "gw" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/wood,
@@ -472,13 +472,13 @@
 "gB" = (
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/carpet/black,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "gO" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "gW" = (
 /obj/structure/sign/painting/library{
 	pixel_y = -32
@@ -487,12 +487,12 @@
 /obj/structure/table/wood/fancy/royalblue,
 /obj/item/camera,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "hh" = (
 /obj/item/trash/plate,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/orange,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "hn" = (
 /obj/structure/sign/painting/library{
 	pixel_y = 32
@@ -500,13 +500,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "hp" = (
 /obj/effect/overlay/light_cone{
 	color = "#E1E17D"
 	},
 /turf/closed/indestructible/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "hs" = (
 /turf/closed/indestructible/rock,
 /area/shelter)
@@ -516,12 +516,12 @@
 /obj/item/tape/door_regret/lost_humanity,
 /obj/item/taperecorder/empty,
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "hX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fluff/paper,
 /turf/open/floor/carpet/royalblue,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "iu" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 5
@@ -533,24 +533,24 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/black,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "iC" = (
 /obj/structure/mineral_door/wood,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "iF" = (
 /obj/structure/fluff/paper/stack{
 	dir = 4
 	},
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "iL" = (
 /obj/effect/overlay/light_cone{
 	color = "#E1E17D"
 	},
 /turf/open/floor/carpet/royalblack,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "iO" = (
 /obj/structure/flora/icestalagmite,
 /obj/effect/areaflavor_snow,
@@ -563,7 +563,7 @@
 	},
 /area/snowqueen)
 "iT" = (
-/obj/effect/landmark/backrooms_spawn,
+/obj/effect/landmark/repentance_spawn,
 /obj/effect/light_emitter{
 	light_power = 4;
 	light_range = 25;
@@ -575,7 +575,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "iV" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -596,7 +596,7 @@
 /obj/structure/table/wood/fancy/red,
 /obj/item/toy/plush/gebura,
 /turf/open/floor/carpet/red,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "jf" = (
 /obj/effect/overlay/light_cone{
 	color = "#E1E17D"
@@ -605,7 +605,7 @@
 	dir = 1
 	},
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "jh" = (
 /obj/structure/aquarium,
 /turf/open/floor/wood,
@@ -632,13 +632,13 @@
 /obj/structure/window/reinforced/spawner/north,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "jQ" = (
 /obj/structure/table/wood/fancy/orange,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/taperecorder/empty,
 /turf/open/floor/carpet/orange,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "jS" = (
 /obj/structure/railing{
 	dir = 9;
@@ -658,7 +658,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "ki" = (
 /obj/effect/light_emitter{
 	light_power = 4;
@@ -669,7 +669,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "kj" = (
 /obj/structure/flora/icestalactite{
 	pixel_x = 2;
@@ -680,24 +680,24 @@
 "kq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/white,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "ky" = (
 /obj/structure/chair/comfy/teal{
 	dir = 8
 	},
 /turf/open/floor/carpet/green,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "kC" = (
 /obj/structure/regret_door{
 	pixel_x = -32
 	},
 /obj/structure/stone_tile/surrounding/cracked,
 /turf/open/floor/plating/ironsand,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "kG" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/water/jungle,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "kJ" = (
 /obj/effect/light_emitter{
 	light_power = 4;
@@ -707,21 +707,21 @@
 	light_color = "#E1E17D"
 	},
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "kK" = (
 /obj/effect/overlay/light_cone{
 	color = "#E1E17D"
 	},
 /turf/open/chasm/door_dimension,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "kM" = (
 /obj/structure/stone_tile/surrounding/cracked,
 /turf/open/floor/plating/ironsand,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "kX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "lf" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
@@ -737,12 +737,12 @@
 /area/snowqueen)
 "ll" = (
 /turf/closed/indestructible/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "ly" = (
 /obj/effect/turf_decal,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/ashplanet/rocky,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "lG" = (
 /obj/structure/regret_door{
 	pixel_y = -32
@@ -750,17 +750,17 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "lN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood/fancy/black,
 /obj/item/ego_weapon/ranged/pistol/nightshade,
 /obj/item/clothing/suit/armor/ego_gear/zayin/nightshade,
 /turf/open/floor/holofloor/grass,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "lV" = (
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "lW" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
@@ -782,7 +782,7 @@
 	desc = "A box of ammo. It appears to have anti-healing properties..."
 	},
 /turf/open/floor/mineral/titanium/yellow,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "mf" = (
 /obj/effect/light_emitter{
 	light_power = 4;
@@ -793,12 +793,12 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "ms" = (
 /obj/structure/table/bronze,
 /obj/structure/statue/bronze/marx,
 /turf/open/floor/bronze,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "mt" = (
 /obj/structure/flora/iceshards{
 	pixel_x = 16;
@@ -817,7 +817,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/toy/figure/qm,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "mQ" = (
 /obj/structure/flora/icegrave/alt{
 	pixel_x = 12;
@@ -843,9 +843,9 @@
 "no" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/ashplanet/rocky,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "np" = (
-/obj/effect/landmark/backrooms_spawn,
+/obj/effect/landmark/repentance_spawn,
 /obj/effect/light_emitter{
 	light_power = 4;
 	light_range = 25;
@@ -857,7 +857,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "nz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -879,7 +879,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "nM" = (
 /obj/structure/closet/crate,
 /obj/item/tape,
@@ -891,14 +891,14 @@
 /obj/item/tape,
 /obj/item/tape,
 /turf/open/floor/carpet/black,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "nO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/gibspawner/scrap_metal,
 /obj/item/raw_anomaly_core/bluespace,
 /obj/item/clothing/suit/armor/riot/knight/greyscale,
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "nZ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -933,35 +933,35 @@
 	pixel_y = -32
 	},
 /turf/open/floor/carpet/orange,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "oV" = (
 /obj/structure/mineral_door/paperframe,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "pc" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/gun/ballistic/automatic/pistol,
 /obj/item/tape/door_regret/failed_guardian,
 /turf/open/floor/carpet/green,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "pk" = (
 /obj/effect/overlay/light_cone{
 	color = "#E1E17D"
 	},
 /turf/open/floor/carpet/blue,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "pm" = (
 /obj/structure/table/wood/fancy/royalblack,
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/item/pen/fourcolor,
 /turf/open/floor/carpet/black,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "pv" = (
 /obj/machinery/door/airlock/glass_large,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "pz" = (
 /obj/structure/sign/painting/library{
 	pixel_y = -32
@@ -969,14 +969,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "pA" = (
 /obj/effect/overlay/light_cone{
 	color = "#E1E17D"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "pJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/can{
@@ -989,21 +989,21 @@
 	},
 /obj/item/stack/sheet/silk/azure_simple,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "pK" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/overlay/light_cone{
 	color = "#E1E17D"
 	},
 /turf/open/floor/carpet/orange,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "pM" = (
 /obj/structure/fluff/paper/stack{
 	dir = 1
 	},
 /obj/structure/fluff/paper,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "pS" = (
 /obj/structure/fluff/paper/stack{
 	dir = 4
@@ -1012,12 +1012,12 @@
 	dir = 1
 	},
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "pX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "qd" = (
 /obj/structure/flora/icestalactite{
 	pixel_y = -34
@@ -1049,16 +1049,16 @@
 /obj/item/bedsheet/k_corporation,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/facility,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "qo" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "qq" = (
 /obj/machinery/vending/boozeomat,
 /turf/closed/indestructible/reinforced,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "qw" = (
 /obj/machinery/light/small,
 /obj/effect/shelter_forcefield,
@@ -1070,10 +1070,10 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "qC" = (
 /turf/open/floor/plating/ironsand,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "qF" = (
 /obj/structure/flora/iceslab{
 	pixel_x = -12;
@@ -1091,18 +1091,18 @@
 "qK" = (
 /obj/structure/chess/blackknight,
 /turf/open/floor/plating/ironsand,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "qQ" = (
 /obj/effect/overlay/light_cone{
 	color = "#E1E17D"
 	},
 /turf/open/floor/bronze,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "qW" = (
 /obj/structure/table/bronze,
 /obj/item/toy/clockwork_watch,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "ra" = (
 /obj/structure/flora/icestalagmite,
 /turf/open/floor/holofloor/snow,
@@ -1110,14 +1110,14 @@
 "rh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "rj" = (
 /obj/structure/fluff/paper/stack{
 	dir = 4
 	},
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/carpet/royalblack,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "rl" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 10
@@ -1146,12 +1146,12 @@
 /obj/item/tape/door_regret/final_realization,
 /obj/item/clothing/suit/hooded/cloak/goliath,
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "rs" = (
 /obj/structure/table/wood/fancy/royalblack,
 /obj/item/toy/plush/binah,
 /turf/open/floor/carpet/black,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "rA" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1160,7 +1160,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/bottle/gin,
 /turf/open/floor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "rL" = (
 /obj/structure/flora/icestalactite{
 	pixel_x = 9;
@@ -1176,16 +1176,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/holofloor/grass,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "sc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/wooden/toy,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "sg" = (
 /obj/structure/flora/rock,
 /turf/open/floor/plating/ironsand,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "sx" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 6
@@ -1206,7 +1206,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "sJ" = (
 /obj/structure/flora/iceshards{
 	pixel_x = -3;
@@ -1227,14 +1227,14 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/facility,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "sM" = (
 /obj/structure/regret_door{
 	pixel_y = -32
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "sO" = (
 /obj/structure/flora/iceshards{
 	pixel_x = -3;
@@ -1253,7 +1253,7 @@
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "sS" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 8
@@ -1272,7 +1272,7 @@
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
 	},
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "sZ" = (
 /turf/open/floor/holofloor/snow,
 /area/shelter)
@@ -1295,7 +1295,7 @@
 /obj/structure/table/wood/fancy/purple,
 /obj/item/tape/door_regret/hidden_truth,
 /turf/open/floor/mineral/titanium/tiled/purple,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "to" = (
 /obj/effect/light_emitter{
 	light_power = 4;
@@ -1306,12 +1306,12 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/facility,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "ts" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "tV" = (
 /obj/structure/flora/icestalagmite/small{
 	pixel_x = -8;
@@ -1330,18 +1330,18 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/gibspawner/human/bodypartless,
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "uk" = (
 /turf/closed/indestructible/reinforced,
 /area/shelter)
 "ul" = (
 /obj/item/ammo_casing/caseless/ego_kcorp,
 /turf/open/floor/mineral/titanium/yellow,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "uw" = (
 /obj/structure/fluff/clockwork/blind_eye,
 /turf/open/floor/bronze,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "uU" = (
 /obj/effect/light_emitter{
 	light_power = 4;
@@ -1352,7 +1352,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "uX" = (
 /obj/effect/overlay/light_cone{
 	color = "#E1E17D"
@@ -1360,7 +1360,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/bed/maint,
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "vf" = (
 /obj/effect/landmark/snowqueen_teleport,
 /obj/effect/areaflavor_snow,
@@ -1415,38 +1415,38 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/royalblue,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "vS" = (
 /obj/structure/mineral_door/wood,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "vT" = (
 /turf/open/floor/vault,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "wa" = (
 /obj/machinery/door/airlock/hatch,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/facility,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "wb" = (
 /obj/machinery/libraryscanner,
 /turf/open/floor/carpet/black,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "wd" = (
 /obj/structure/sign/departments/training,
 /turf/closed/indestructible/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "wh" = (
 /obj/structure/regret_shrine/abandoned,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "wq" = (
 /obj/structure/regret_door{
 	pixel_y = 32
 	},
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "wy" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 9
@@ -1496,25 +1496,25 @@
 /obj/structure/table/wood/fancy/black,
 /obj/item/bouquet/sunflower,
 /turf/open/floor/holofloor/grass,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "xv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/toy/figure/scientist,
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
 	},
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "xw" = (
 /obj/structure/table/wood/fancy/orange,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/kitchen/knife,
 /turf/open/floor/carpet/orange,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "xy" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fence,
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "xD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1524,7 +1524,7 @@
 /turf/closed/indestructible/iron{
 	opacity = 1
 	},
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "xG" = (
 /obj/structure/flora/icestalagmite{
 	layer = 3;
@@ -1547,13 +1547,13 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/facility,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "ye" = (
 /obj/effect/overlay/light_cone{
 	color = "#E1E17D"
 	},
 /turf/open/floor/carpet/red,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "yg" = (
 /obj/effect/light_emitter{
 	light_power = 4;
@@ -1578,12 +1578,12 @@
 	desc = "A box of ammo. It appears to have anti-healing properties..."
 	},
 /turf/open/floor/mineral/titanium/yellow,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "yn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "yp" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 5
@@ -1608,7 +1608,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "yu" = (
 /obj/structure/flora/icestalagmite/small{
 	pixel_x = -3;
@@ -1621,18 +1621,18 @@
 /obj/structure/table/wood/fancy/black,
 /obj/item/paper/fluff/joey/letter,
 /turf/open/floor/holofloor/grass,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "yV" = (
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/carpet/black,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "zo" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fence/door{
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "zz" = (
 /obj/structure/flora/iceshards{
 	pixel_y = 15
@@ -1652,10 +1652,10 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "zI" = (
 /turf/closed/indestructible/reinforced/old,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "zS" = (
 /obj/structure/flora/icestalagmite{
 	pixel_x = -9;
@@ -1676,7 +1676,7 @@
 	color = "#E1E17D"
 	},
 /turf/open/floor/carpet/green,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "zV" = (
 /obj/structure/flora/icegrave/alt,
 /obj/structure/flora/iceslab/alt{
@@ -1702,7 +1702,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Aq" = (
 /obj/structure/flora/icestalagmite{
 	pixel_x = 8;
@@ -1723,7 +1723,7 @@
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
 	},
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Au" = (
 /obj/structure/flora/iceshards{
 	pixel_x = -11;
@@ -1741,13 +1741,13 @@
 "Az" = (
 /obj/structure/barricade/wooden/crude/snow,
 /turf/closed/indestructible/fakeglass,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "AE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fluff/paper,
 /obj/structure/filingcabinet/employment,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "AK" = (
 /obj/structure/sign/painting/library{
 	pixel_y = -32
@@ -1756,10 +1756,10 @@
 /obj/structure/table/wood/fancy/royalblue,
 /obj/item/tape/door_regret/false_hope,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "AO" = (
 /turf/open/floor/carpet/orange,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "AP" = (
 /obj/structure/flora/icestalagmite/small{
 	pixel_x = -13;
@@ -1803,11 +1803,11 @@
 /obj/item/reagent_containers/blood/random,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/ashplanet/rocky,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "BB" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "BD" = (
 /obj/effect/overlay/light_cone{
 	color = "#E1E17D"
@@ -1815,7 +1815,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "BZ" = (
 /obj/effect/light_emitter{
 	light_power = 4;
@@ -1828,26 +1828,26 @@
 	pixel_y = -32
 	},
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Cf" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/plating/ironsand,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Cq" = (
 /obj/effect/shelter_forcefield,
 /turf/open/floor/shelter,
 /area/shelter)
 "Cv" = (
 /turf/open/chasm/door_dimension,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "CD" = (
 /obj/structure/mineral_door/wood,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/ashplanet/rocky,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "CE" = (
 /turf/closed/indestructible/reinforced,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "CI" = (
 /obj/effect/turf_decal/weather/snow/corner,
 /obj/effect/areaflavor_snow,
@@ -1863,7 +1863,7 @@
 /obj/item/trash/plate,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "CP" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -1874,17 +1874,17 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fluff/paper,
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Dv" = (
 /turf/open/indestructible/paper,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Dw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/facility,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "DD" = (
 /turf/open/floor/carpet/green,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "DF" = (
 /obj/structure/flora/icegrave/alt{
 	pixel_x = 11;
@@ -1909,14 +1909,14 @@
 	desc = "A core used to power machines of the outskirts... and something powerful..."
 	},
 /turf/open/floor/plating/rust,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "DU" = (
 /obj/structure/regret_door{
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "En" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 10
@@ -1940,7 +1940,7 @@
 	},
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/floor/plating/rust,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Ev" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 5
@@ -1961,17 +1961,17 @@
 "Ey" = (
 /obj/structure/regret_shrine/lost_time,
 /turf/open/floor/bronze,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "EC" = (
 /obj/structure/grille/broken,
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/ironsand,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "EG" = (
 /obj/structure/rack,
 /turf/open/floor/vault,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "EL" = (
 /obj/item/reagent_containers/food/drinks/waterbottle/large,
 /obj/item/reagent_containers/food/drinks/waterbottle/large,
@@ -1989,7 +1989,7 @@
 /area/shelter)
 "EM" = (
 /turf/closed/indestructible/rock,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "EV" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1998,25 +1998,25 @@
 /obj/item/trash/pistachios,
 /obj/item/trash/pistachios,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "EY" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/drinkingglasses,
 /obj/item/storage/box/drinkingglasses,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "EZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/facility,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Fv" = (
 /obj/structure/regret_door{
 	pixel_y = 32
 	},
 /turf/open/floor/carpet/orange,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "FC" = (
 /obj/structure/flora/icestalagmite/small{
 	pixel_x = -13;
@@ -2027,27 +2027,27 @@
 "FF" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/carpet/black,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "FG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/can,
 /obj/item/stack/sheet/silk/azure_simple,
 /obj/item/stack/sheet/silk/azure_simple,
 /turf/open/floor/mineral/titanium/tiled/purple,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "FJ" = (
 /turf/open/floor/carpet/red,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "FV" = (
 /obj/structure/mineral_door/iron,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Gc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/holofloor/grass,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Gd" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 10
@@ -2072,28 +2072,28 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/carpet/royalblue,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Go" = (
 /obj/item/tape/door_regret/coward_friend,
 /turf/open/floor/plating/ironsand,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Gr" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/ego_weapon/city/rats/knife,
 /obj/item/taperecorder/empty,
 /turf/open/floor/carpet/green,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Gx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/drinks,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/facility,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Gz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/toy/figure/wizard,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "GC" = (
 /obj/structure/flora/icestalagmite/small,
 /turf/open/floor/holofloor/snow,
@@ -2103,7 +2103,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/tape/door_regret/protective_prison,
 /turf/open/floor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "GO" = (
 /obj/structure/flora/icechunk/alt{
 	pixel_x = 5;
@@ -2123,20 +2123,20 @@
 	},
 /area/snowqueen)
 "GP" = (
-/obj/effect/landmark/backrooms_spawn,
+/obj/effect/landmark/repentance_spawn,
 /obj/structure/regret_door{
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "GT" = (
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/floor/plating/rust,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "GU" = (
 /turf/closed/wall/mineral/bronze,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Ha" = (
 /obj/structure/flora/icechunk{
 	pixel_x = -8
@@ -2170,7 +2170,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Hk" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2178,19 +2178,19 @@
 /obj/item/clothing/head/ego_hat/wcorp,
 /obj/item/clothing/suit/armor/ego_gear/wcorp,
 /turf/open/floor/facility,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "HH" = (
 /obj/structure/sign/painting/library{
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "HK" = (
 /obj/item/tape/door_regret/vengeance_incomplete,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/ashplanet/rocky,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "HS" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 6
@@ -2202,7 +2202,7 @@
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
 	},
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "HZ" = (
 /obj/effect/light_emitter{
 	light_power = 4;
@@ -2218,7 +2218,7 @@
 	},
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Ib" = (
 /obj/structure/sign/painting/library{
 	pixel_y = 32
@@ -2226,7 +2226,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Ic" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/effect/overlay/light_cone{
@@ -2234,11 +2234,11 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/ashplanet/rocky,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "It" = (
 /obj/machinery/bookbinder,
 /turf/open/floor/carpet/black,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "IC" = (
 /obj/structure/flora/iceshards{
 	pixel_x = -15;
@@ -2260,23 +2260,23 @@
 	},
 /obj/item/storage/book/bible,
 /turf/open/floor/plating/ironsand,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "IR" = (
 /obj/structure/regret_door{
 	pixel_y = -32
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/ashplanet/rocky,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "IX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/royalblue,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "IY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/blackbox_recorder,
 /turf/open/floor/carpet/royalblue,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Ja" = (
 /obj/effect/overlay/light_cone{
 	color = "#E1E17D"
@@ -2284,7 +2284,7 @@
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
 	},
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Jk" = (
 /obj/effect/overlay/light_cone{
 	color = "#E1E17D"
@@ -2293,7 +2293,7 @@
 /obj/structure/bed/maint,
 /obj/effect/gibspawner/human/bodypartless,
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Jm" = (
 /obj/structure/fence,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2301,7 +2301,7 @@
 	color = "#E1E17D"
 	},
 /turf/open/floor/facility,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "JI" = (
 /obj/machinery/door/airlock/snowqueen{
 	pixel_y = -7
@@ -2312,19 +2312,19 @@
 /obj/structure/mineral_door/wood,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "JX" = (
 /obj/structure/table/wood/fancy/royalblack,
 /obj/item/taperecorder/empty,
 /turf/open/floor/carpet/black,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "JZ" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Kd" = (
 /obj/structure/flora/rock/pile/icy{
 	pixel_x = -13
@@ -2348,7 +2348,7 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Kr" = (
 /turf/closed/indestructible/rock/snow/ice/ore,
 /area/shelter)
@@ -2400,26 +2400,26 @@
 	},
 /obj/item/stack/sheet/silk/azure_simple,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "KU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/orange,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "KZ" = (
 /obj/structure/stone_tile/surrounding/cracked{
 	dir = 4
 	},
 /turf/open/floor/plating/ironsand,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Lb" = (
 /obj/structure/fluff/paper/stack,
 /obj/structure/fluff/paper,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Lm" = (
 /obj/structure/window/paperframe,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Lr" = (
 /obj/structure/flora/iceslab{
 	pixel_x = 49;
@@ -2436,13 +2436,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/reagent_containers/food/drinks/bottle/rum,
 /turf/open/floor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "LZ" = (
 /obj/item/toy/figure/mime,
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
 	},
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "MA" = (
 /obj/structure/flora/icechunk{
 	pixel_y = -7
@@ -2530,7 +2530,7 @@
 /obj/structure/window/reinforced/spawner,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Nj" = (
 /obj/structure/flora/icechunk{
 	pixel_x = 12;
@@ -2564,25 +2564,25 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/statue/uranium/nuke,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "NB" = (
 /obj/structure/sign/painting/library{
 	pixel_y = -32
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "NE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/gibspawner/scrap_metal,
 /obj/item/raw_anomaly_core/bluespace,
 /obj/item/clothing/suit/chaplainsuit/nun,
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "NH" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "NP" = (
 /obj/structure/flora/icestalactite/small{
 	pixel_x = -18;
@@ -2601,24 +2601,24 @@
 /obj/item/taperecorder/empty,
 /obj/item/taperecorder/empty,
 /turf/open/floor/carpet/orange,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "OT" = (
 /obj/machinery/door/airlock/regret_archive,
 /turf/open/floor/vault,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Pc" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
 	},
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Pg" = (
 /obj/structure/table/bronze,
 /turf/open/floor/bronze,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Pj" = (
 /obj/item/toy/figure/warden,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Pn" = (
 /obj/item/storage/box/pcorp,
 /obj/item/storage/box/pcorp,
@@ -2653,36 +2653,36 @@
 /obj/item/food/cake/birthday,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/orange,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "PT" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood/fancy/royalblue,
 /obj/item/taperecorder/empty,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "PW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Qe" = (
 /obj/effect/turf_decal/trimline/yellow/line,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/white,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Ql" = (
 /obj/structure/table/bronze,
 /obj/item/toy/clockwork_watch,
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
 	},
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Qq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/overlay/light_cone{
 	color = "#E1E17D"
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Qt" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -2706,7 +2706,7 @@
 	name = "hemorrhage office"
 	},
 /turf/open/floor/mineral/titanium/yellow,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "QY" = (
 /obj/structure/flora/iceshards{
 	pixel_x = -4;
@@ -2725,19 +2725,19 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fluff/paper,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Rh" = (
 /obj/structure/fluff/paper/stack{
 	dir = 4
 	},
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Rv" = (
 /obj/effect/overlay/light_cone{
 	color = "#E1E17D"
 	},
 /turf/open/floor/carpet/orange,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "RB" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2756,7 +2756,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/tape/door_regret/failed_promise,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "RK" = (
 /mob/living/simple_animal/pet/penguin/emperor/shamebrero,
 /turf/open/floor/holofloor/snow,
@@ -2773,19 +2773,19 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/green,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "RW" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
 /turf/open/floor/carpet/black,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Sb" = (
 /obj/effect/turf_decal/trimline/yellow/line,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/indestructible/white,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Sd" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -2801,24 +2801,24 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Sf" = (
 /obj/machinery/door/airlock/vault,
 /turf/open/floor/vault,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Si" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/holofloor/grass,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "St" = (
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Sz" = (
 /obj/machinery/computer/bookmanagement,
 /obj/structure/table/wood/fancy/royalblack,
 /turf/open/floor/carpet/black,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "SH" = (
 /obj/effect/light_emitter{
 	light_power = 4;
@@ -2847,7 +2847,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/carpet/orange,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "SZ" = (
 /obj/effect/gibspawner/human,
 /obj/effect/decal/cleanable/crayon{
@@ -2855,23 +2855,23 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/ashplanet/rocky,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Ta" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/tape/door_regret/traded_life,
 /turf/open/floor/holofloor/grass,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Tc" = (
 /obj/structure/table/bronze,
 /obj/item/toy/clockwork_watch,
 /turf/open/floor/bronze,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Ti" = (
 /obj/structure/regret_door{
 	pixel_y = 32
 	},
 /turf/open/floor/plating/ironsand,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Tl" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -2884,7 +2884,7 @@
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Tz" = (
 /obj/structure/flora/icestalagmite{
 	pixel_x = -12;
@@ -2905,13 +2905,13 @@
 /obj/item/silkknife,
 /obj/item/stack/sheet/silk/azure_masterpiece,
 /turf/open/floor/mineral/titanium/tiled/purple,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "TQ" = (
 /obj/item/toy/talking/owl,
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
 	},
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "TR" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -2925,7 +2925,7 @@
 /obj/item/clothing/suit/chaplainsuit/whiterobe,
 /obj/item/storage/book/bible,
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Uh" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -2937,14 +2937,14 @@
 	pixel_x = -32
 	},
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Uu" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/filingcabinet/lore,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "UA" = (
-/obj/effect/landmark/backrooms_spawn,
+/obj/effect/landmark/repentance_spawn,
 /obj/effect/light_emitter{
 	light_power = 4;
 	light_range = 25;
@@ -2957,7 +2957,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "UF" = (
 /obj/structure/frozensword,
 /obj/effect/areaflavor_snow,
@@ -2974,9 +2974,9 @@
 /obj/item/mailpaper/junk,
 /obj/item/mailpaper/junk,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "UM" = (
-/obj/effect/landmark/backrooms_spawn,
+/obj/effect/landmark/repentance_spawn,
 /obj/effect/light_emitter{
 	light_power = 4;
 	light_range = 25;
@@ -2988,7 +2988,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/carpet/orange,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "UO" = (
 /obj/effect/areaflavor_snow,
 /turf/open/floor/plasteel/dark{
@@ -3004,7 +3004,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/tape/door_regret/child_weapon,
 /turf/open/floor/carpet/orange,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "UX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/can{
@@ -3014,17 +3014,17 @@
 /obj/item/trash/can,
 /obj/item/stack/sheet/silk/azure_simple,
 /turf/open/floor/mineral/titanium/tiled/purple,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "UY" = (
 /obj/structure/fence/door/opened,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/facility,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Vb" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/ashplanet/rocky,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Vh" = (
 /obj/effect/light_emitter{
 	light_power = 4;
@@ -3045,7 +3045,7 @@
 /obj/structure/fence/corner,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/facility,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Vs" = (
 /obj/structure/fluff/paper/stack{
 	dir = 4
@@ -3054,7 +3054,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Vv" = (
 /obj/structure/railing{
 	dir = 4;
@@ -3067,7 +3067,7 @@
 /turf/closed/indestructible/iron{
 	opacity = 1
 	},
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "VJ" = (
 /obj/structure/flora/icegrave,
 /obj/effect/areaflavor_snow,
@@ -3084,7 +3084,7 @@
 /turf/closed/indestructible/iron{
 	opacity = 1
 	},
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "VZ" = (
 /obj/structure/railing{
 	dir = 6;
@@ -3114,7 +3114,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/orange,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "WU" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -3124,7 +3124,7 @@
 "Xa" = (
 /obj/structure/mineral_door/wood,
 /turf/open/floor/holofloor/grass,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Xh" = (
 /obj/structure/regret_door{
 	pixel_x = -32
@@ -3132,7 +3132,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/bed/maint,
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Xt" = (
 /turf/open/floor/wood,
 /area/fishboat)
@@ -3144,7 +3144,7 @@
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
 	},
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "XF" = (
 /obj/structure/sign/painting/library{
 	pixel_y = -32
@@ -3152,7 +3152,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/carpet/royalblue,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "XK" = (
 /obj/structure/railing{
 	dir = 1
@@ -3179,7 +3179,7 @@
 	color = "#E1E17D"
 	},
 /turf/open/floor/stone,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Yh" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -3197,7 +3197,7 @@
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
 	},
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Yl" = (
 /obj/structure/railing{
 	dir = 10;
@@ -3210,12 +3210,12 @@
 /obj/structure/table/wood/fancy/orange,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/orange,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Yv" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Yw" = (
 /obj/structure/flora/icestalagmite/small,
 /obj/effect/areaflavor_snow,
@@ -3243,7 +3243,7 @@
 /area/snowqueen)
 "Yz" = (
 /turf/open/floor/mineral/titanium/yellow,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "YA" = (
 /obj/item/fish_feed,
 /turf/open/floor/wood,
@@ -3255,12 +3255,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "YH" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
 	},
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "YI" = (
 /obj/structure/toolabnormality/shelter/exit,
 /obj/effect/shelter_forcefield,
@@ -3284,7 +3284,7 @@
 /obj/effect/landmark/tape_spawner/door_to_nowhere,
 /obj/structure/table/wood/fancy/royalblack,
 /turf/open/floor/carpet/royalblack,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "Ze" = (
 /obj/structure/flora/icestalagmite{
 	layer = 3;
@@ -3312,7 +3312,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/holofloor/wood,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "ZI" = (
 /obj/effect/areaflavor_snow,
 /turf/open/floor/plasteel/dark{
@@ -3334,7 +3334,7 @@
 /obj/item/toy/plush/chesed,
 /obj/structure/table/wood/fancy/blue,
 /turf/open/floor/carpet/blue,
-/area/fishboat/backrooms)
+/area/fishboat/repentance)
 "ZU" = (
 /turf/closed/mineral/snowmountain/cavern,
 /area/snowqueen)

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -308,8 +308,10 @@
 
 /obj/item/tape/attack_self(mob/user)
 	if(!ruined)
-		to_chat(user, "<span class='notice'>You pull out all the tape!</span>")
-		ruin()
+		to_chat(user, "<span class='notice'>You start pulling out all the tape's wires...</span>")
+		if(do_after(user, 50, src))
+			to_chat(user, "<span class='notice'>You pull out all the tape!</span>")
+			ruin()
 
 
 /obj/item/tape/proc/ruin()

--- a/code/modules/admin/smites/ragdoll_spin.dm
+++ b/code/modules/admin/smites/ragdoll_spin.dm
@@ -1,0 +1,46 @@
+/// Violently spins the target with ragdoll animation
+/datum/smite/ragdoll_spin
+	name = "Ragdoll Spin"
+
+/datum/smite/ragdoll_spin/effect(client/user, mob/living/target)
+	. = ..()
+
+	if(!isliving(target))
+		return
+
+	to_chat(target, span_userdanger("Reality itself rejects your existence, twisting you violently!"), confidential = TRUE)
+	playsound(get_turf(target), 'sound/abnormalities/dinner_chair/ragdoll_effect.ogg', 75, TRUE)
+
+	// Start the violent spinning
+	INVOKE_ASYNC(src, PROC_REF(violent_spin), target)
+
+/datum/smite/ragdoll_spin/proc/violent_spin(mob/living/M)
+	if(!M || QDELETED(M))
+		return
+
+	var/matrix/initial_matrix = matrix(M.transform)
+
+	// 12 seconds of violent spinning
+	for(var/i in 1 to 120)
+		if(!M || QDELETED(M))
+			return
+
+		// Violent rotation
+		initial_matrix = matrix(M.transform)
+		initial_matrix.Turn(rand(45, 180)) // Random violent turns
+
+		// Extreme position changes
+		var/x_shift = rand(-10, 10)
+		var/y_shift = rand(-10, 10)
+		initial_matrix.Translate(x_shift, y_shift)
+
+		animate(M, transform = initial_matrix, time = 1, loop = 0, easing = pick(LINEAR_EASING, SINE_EASING, CIRCULAR_EASING))
+
+		// Rapid direction changes
+		M.setDir(pick(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST))
+
+		sleep(1)
+
+	// Reset transformation
+	animate(M, transform = null, time = 5, loop = 0)
+	to_chat(M, span_notice("Reality stabilizes around you once more."), confidential = TRUE)

--- a/code/modules/admin/smites/repentance_banish.dm
+++ b/code/modules/admin/smites/repentance_banish.dm
@@ -1,0 +1,32 @@
+/// Violently spins the target and banishes them to the realm of sealed regrets
+/datum/smite/repentance_banish
+	name = "Banish to Repentance Dimension"
+
+/datum/smite/repentance_banish/effect(client/user, mob/living/target)
+	. = ..()
+
+	if(!isliving(target))
+		return
+
+	if(!ishuman(target))
+		to_chat(user, span_warning("Only humans can be banished to the realm of sealed regrets."), confidential = TRUE)
+		return
+
+	var/mob/living/carbon/human/H = target
+
+	// Check if already trapped
+	if(IsTrappedInRepentance(H))
+		to_chat(user, span_warning("[H] is already trapped in the realm of sealed regrets."), confidential = TRUE)
+		return
+
+	// Dramatic message
+	to_chat(H, span_userdanger("The fabric of reality tears open beneath you! You feel yourself being pulled into a dimension of eternal regret!"), confidential = TRUE)
+	H.visible_message(span_warning("[H] is violently twisted by unseen forces as reality tears around them!"))
+
+	// Send them to the dimension with spinning
+	var/message = "You have been banished to the realm of sealed regrets by divine judgment!"
+	SendToRepentanceDimension(H, message, TRUE)
+
+	// Admin log
+	log_admin("[key_name(user)] banished [key_name(H)] to the realm of sealed regrets.")
+	message_admins("[key_name_admin(user)] banished [key_name_admin(H)] to the realm of sealed regrets.")

--- a/code/modules/mob/living/simple_animal/abnormality/teth/door_to_nowhere.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/door_to_nowhere.dm
@@ -1,3 +1,192 @@
+
+// realm of sealed regrets SYSTEM
+// A standalone system for trapping players in an alternate dimension of regret and repentance
+// Can be used by any game mechanic without requiring specific abnormalities
+
+GLOBAL_LIST_EMPTY(repentance_trapped_players)         // List of all trapped players
+GLOBAL_LIST_EMPTY(repentance_return_locations)        // Original locations to return players to
+GLOBAL_LIST_EMPTY(repentance_status_effects)          // Status effects applied to trapped players
+GLOBAL_LIST_EMPTY(repentance_spawn_points)            // Valid spawn locations in the dimension
+
+/// Initializes repentance dimension spawn locations from landmarks
+/proc/InitializeRepentanceLocations()
+	GLOB.repentance_spawn_points = list()
+	for(var/obj/effect/landmark/repentance_spawn/L in GLOB.landmarks_list)
+		GLOB.repentance_spawn_points += get_turf(L)
+
+	// Fallback if no landmarks exist - use z-level 1,1,1
+	if(!LAZYLEN(GLOB.repentance_spawn_points))
+		var/turf/T = locate(1, 1, 1)
+		if(T)
+			GLOB.repentance_spawn_points += T
+
+/// Sends a player to the realm of sealed regrets
+/// H - The human to send
+/// send_message - Optional custom message to display (null = use default)
+/// spin_effect - Whether to apply violent spinning effect
+/// Returns TRUE if successful
+/proc/SendToRepentanceDimension(mob/living/carbon/human/H, send_message = null, spin_effect = TRUE)
+	if(!H || QDELETED(H))
+		return FALSE
+
+	// Already trapped check
+	if(H in GLOB.repentance_trapped_players)
+		return FALSE
+
+	// Initialize spawn points if needed
+	if(!LAZYLEN(GLOB.repentance_spawn_points))
+		InitializeRepentanceLocations()
+
+	// Add to global tracking
+	GLOB.repentance_trapped_players += H
+	GLOB.repentance_return_locations[H] = get_turf(H)
+
+	// Display message
+	if(send_message)
+		to_chat(H, span_userdanger(send_message))
+	else
+		to_chat(H, span_userdanger("You are pulled into a strange dimension!"))
+
+	// Apply spinning effect if requested
+	if(spin_effect)
+		playsound(get_turf(H), 'sound/abnormalities/dinner_chair/ragdoll_effect.ogg', 75, TRUE)
+		INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(RepentanceViolentSpin), H)
+		// Wait for spinning to finish before teleporting
+		addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(RepentanceFinishTeleport), H), 12 SECONDS)
+	else
+		RepentanceFinishTeleport(H)
+
+	return TRUE
+
+/// Violent spinning effect for dimension transport
+/proc/RepentanceViolentSpin(mob/living/M)
+	if(!M || QDELETED(M))
+		return
+
+	var/matrix/initial_matrix = matrix(M.transform)
+	for(var/i in 1 to 120) // 12 seconds at 0.1 second intervals
+		if(!M || QDELETED(M))
+			return
+
+		// Violent rotation
+		initial_matrix = matrix(M.transform)
+		initial_matrix.Turn(rand(45, 180))
+
+		// Extreme position changes
+		var/x_shift = rand(-10, 10)
+		var/y_shift = rand(-10, 10)
+		initial_matrix.Translate(x_shift, y_shift)
+
+		animate(M, transform = initial_matrix, time = 1, loop = 0, easing = pick(LINEAR_EASING, SINE_EASING, CIRCULAR_EASING))
+
+		// Rapid direction changes
+		M.setDir(pick(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST))
+
+		sleep(1)
+
+	// Reset transformation
+	animate(M, transform = null, time = 5, loop = 0)
+
+/// Completes the teleportation to realm of sealed regrets
+/proc/RepentanceFinishTeleport(mob/living/carbon/human/H)
+	if(!H || QDELETED(H) || !(H in GLOB.repentance_trapped_players))
+		return
+
+	to_chat(H, span_warning("You find yourself in the realm of sealed regrets."))
+	to_chat(H, span_warning("The air is heavy with regret and the weight of unspoken apologies."))
+
+	playsound(get_turf(H), 'sound/effects/podwoosh.ogg', 50, TRUE)
+
+	// Pick a random repentance dimension location
+	var/turf/destination
+	if(LAZYLEN(GLOB.repentance_spawn_points))
+		destination = pick(GLOB.repentance_spawn_points)
+	else
+		destination = locate(1, 1, 1) // Emergency fallback
+
+	if(destination)
+		H.forceMove(destination)
+
+	H.Stun(30)
+	H.adjustSanityLoss(20)
+
+	// Spawn an empty tape recorder for them to record their regrets
+	var/obj/item/taperecorder/empty/recorder = new /obj/item/taperecorder/empty(destination)
+	to_chat(H, span_notice("A tape recorder materializes before you, as if the dimension itself wants to hear your confession..."))
+
+	// Try to put it in their hand if possible
+	if(!H.put_in_hands(recorder))
+		// If hands are full, place it next to them
+		recorder.forceMove(get_step(destination, pick(NORTH, SOUTH, EAST, WEST)))
+
+	// Apply repentance dimension status effect
+	var/datum/status_effect/repentance_ambience/B = H.apply_status_effect(/datum/status_effect/repentance_ambience)
+	if(B)
+		GLOB.repentance_status_effects[H] = B
+
+/// Rescues a player from the realm of sealed regrets
+/// H - The human to rescue
+/// return_turf - Optional specific return location (null = use saved location)
+/// rescue_message - Optional custom message (null = use default)
+/// Returns TRUE if successful
+/proc/RescueFromRepentanceDimension(mob/living/carbon/human/H, turf/return_turf = null, rescue_message = null)
+	if(!H || QDELETED(H))
+		return FALSE
+
+	// Not trapped check
+	if(!(H in GLOB.repentance_trapped_players))
+		return FALSE
+
+	// Remove from global tracking
+	GLOB.repentance_trapped_players -= H
+
+	// Determine return location
+	if(!return_turf)
+		return_turf = GLOB.repentance_return_locations[H]
+	if(!return_turf)
+		// Find a safe station turf as fallback
+		for(var/turf/T in GLOB.station_turfs)
+			if(!T.density)
+				return_turf = T
+				break
+	if(!return_turf)
+		return_turf = locate(1, 1, 1) // Ultimate fallback
+
+	GLOB.repentance_return_locations -= H
+
+	// Remove status effect
+	if(GLOB.repentance_status_effects[H])
+		H.remove_status_effect(/datum/status_effect/repentance_ambience)
+		GLOB.repentance_status_effects -= H
+
+	// Display message
+	if(rescue_message)
+		to_chat(H, span_nicegreen(rescue_message))
+	else
+		to_chat(H, span_nicegreen("You feel a pull back to reality!"))
+
+	playsound(get_turf(H), 'sound/magic/teleport_app.ogg', 50, TRUE)
+
+	// Teleport back
+	H.forceMove(return_turf)
+
+	return TRUE
+
+/// Checks if a player is trapped in the realm of sealed regrets
+/proc/IsTrappedInRepentance(mob/living/carbon/human/H)
+	if(!H)
+		return FALSE
+	return (H in GLOB.repentance_trapped_players)
+
+/// Returns a list of all trapped players
+/proc/GetRepentanceTrappedList()
+	return GLOB.repentance_trapped_players.Copy()
+
+/// Rescues all trapped players (for emergency use)
+/proc/RescueAllFromRepentance(rescue_message = "The dimension collapses, ejecting everyone!")
+	for(var/mob/living/carbon/human/H in GLOB.repentance_trapped_players.Copy())
+		RescueFromRepentanceDimension(H, null, rescue_message)
+
 /mob/living/simple_animal/hostile/abnormality/door_to_nowhere
 	name = "Door to Nowhere"
 	desc = "A door wrapped in chains, floating ominously in the air. Behind it lies memories best left forgotten, regrets that should remain sealed."
@@ -48,13 +237,13 @@
 		"It's just a locked door" = list(FALSE, "You turn away from the door. Some things are meant to stay locked."),
 	)
 
-	var/list/trapped_employees = list()
-	var/list/original_locations = list()
-	var/list/backrooms_locations = list()
-	var/list/backrooms_effects = list() // Track status effects
+	// Use global repentance dimension system - no local tracking needed
 
 	// Spirit projection ability variable
 	var/projecting_spirit = FALSE
+
+	// Track who has received their first tape recorder
+	var/list/workers_with_recorders = list()
 
 /mob/living/simple_animal/hostile/abnormality/door_to_nowhere/Initialize()
 	. = ..()
@@ -65,17 +254,24 @@
 	var/datum/action/innate/door_possession/possess_ability = new
 	possess_ability.Grant(src)
 
-	// Find all backrooms landmarks
-	for(var/obj/effect/landmark/backrooms_spawn/L in GLOB.landmarks_list)
-		backrooms_locations += get_turf(L)
+	// Initialize global repentance dimension locations
+	InitializeRepentanceLocations()
 
-	// Fallback if no landmarks exist
-	if(!LAZYLEN(backrooms_locations))
-		var/turf/T = locate(1, 1, z)
-		if(T)
-			backrooms_locations += T
-		else
-			backrooms_locations += get_turf(src)
+	// Register for insanity events
+	RegisterSignal(SSdcs, COMSIG_GLOB_HUMAN_INSANE, PROC_REF(on_human_insane))
+
+// Handle human insanity - decrease Qliphoth counter
+/mob/living/simple_animal/hostile/abnormality/door_to_nowhere/proc/on_human_insane(datum/source, mob/living/carbon/human/H, turf/T)
+	SIGNAL_HANDLER
+
+	// Only react to insanity on our Z-level
+	if(!H || H.z != z)
+		return
+
+	// Decrease Qliphoth counter
+	if(datum_reference)
+		datum_reference.qliphoth_change(-1)
+		visible_message(span_warning("[src]'s chains rattle ominously as madness spreads..."))
 
 // Override say to use ethereal whispers instead
 /mob/living/simple_animal/hostile/abnormality/door_to_nowhere/say(message, bubble_type, list/spans, sanitize, datum/language/language, ignore_spam, forced)
@@ -100,14 +296,96 @@
 	// Don't call parent - we don't want normal speech
 	return
 
+// Allow willing entry into the dimension
+/mob/living/simple_animal/hostile/abnormality/door_to_nowhere/attack_hand(mob/living/carbon/human/M)
+	. = ..()
+	if(!ishuman(M))
+		return
+
+	// Only allow non-harmful intent
+	if(M.a_intent == INTENT_HARM)
+		to_chat(M, span_warning("You strike at the door, but the chains hold it firmly shut."))
+		return
+
+	// Check if already trapped
+	if(IsTrappedInRepentance(M))
+		to_chat(M, span_warning("You are already within the dimension..."))
+		return
+
+	// Confirm the action
+	if(alert(M, "Do you wish to step through the Door to Nowhere and enter the realm of sealed regrets?", "Enter the Door", "Yes", "No") != "Yes")
+		return
+
+	to_chat(M, span_notice("You place your hand on the door. The chains begin to loosen as it recognizes your willing surrender..."))
+
+	// Long channel time - 5 seconds
+	if(do_after(M, 50, target = src))
+		// Double-check they haven't been trapped in the meantime
+		if(IsTrappedInRepentance(M))
+			return
+
+		to_chat(M, span_userdanger("You step through the door willingly, accepting whatever fate awaits within..."))
+		visible_message(span_warning("[M] steps through [src], vanishing into the realm beyond!"))
+
+		// Send them to the dimension without spinning
+		var/message = "You willingly entered the realm of sealed regrets. The door closes gently behind you."
+		SendToRepentanceDimension(M, message, FALSE)
+
+		// Increase Qliphoth counter as reward for willing sacrifice
+		if(datum_reference)
+			datum_reference.qliphoth_change(1)
+			visible_message(span_notice("The door seems satisfied with the willing offering, its chains tightening."))
+	else
+		to_chat(M, span_notice("You pull your hand back from the door."))
+
 /mob/living/simple_animal/hostile/abnormality/door_to_nowhere/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	. = ..()
+
+	// 5% chance to drop a tape from the Mirror Worlds
+	if(prob(5))
+		var/turf/drop_location = get_turf(user)
+		var/obj/item/tape/mirror_tape = new /obj/item/tape(drop_location)
+
+		// Configure the tape
+		mirror_tape.name = "mirror shattered tape"
+		mirror_tape.desc = "A tape that seems to have fallen through the cracks of reality. It flickers with otherworldly static."
+		mirror_tape.filters += filter(type = "blur", size = 1.5)
+
+		// If available, copy content from persistence archive
+		if(LAZYLEN(SSpersistence.door_to_nowhere_tapes))
+			var/list/tape_data = pick(SSpersistence.door_to_nowhere_tapes)
+			var/list/stored_info = tape_data["storedinfo"]
+			var/list/stored_timestamp = tape_data["timestamp"]
+			if(stored_info)
+				mirror_tape.storedinfo = stored_info.Copy()
+			if(stored_timestamp)
+				mirror_tape.timestamp = stored_timestamp.Copy()
+				mirror_tape.used_capacity = stored_timestamp[stored_timestamp.len]
+
+		// Visual and audio feedback
+		visible_message(span_warning("A tape materializes from the door's chains and falls to the floor!"))
+		playsound(src, 'sound/effects/ghost2.ogg', 50, TRUE)
+
+		// Check if this worker needs a tape recorder
+		var/user_ckey = user.ckey
+		if(user_ckey && !(user_ckey in workers_with_recorders))
+			workers_with_recorders += user_ckey
+
+			var/obj/item/taperecorder/empty/recorder = new /obj/item/taperecorder/empty(drop_location)
+			to_chat(user, span_notice("A tape recorder materializes alongside the tape, as if the door wants you to listen..."))
+
+			// Try to put recorder in their hand
+			if(!user.put_in_hands(recorder))
+				// If hands full, drop it nearby
+				recorder.forceMove(get_step(drop_location, pick(NORTH, SOUTH, EAST, WEST)))
+
 	// Handle Repression work - rescue trapped employees
 	if(work_type == ABNORMALITY_WORK_REPRESSION)
-		if(LAZYLEN(trapped_employees))
-			var/mob/living/carbon/human/rescued = pick(trapped_employees)
-			RescueFromBackrooms(rescued)
-			to_chat(user, span_notice("You manage to pull [rescued] back from that strange place!"))
+		var/list/trapped = GetRepentanceTrappedList()
+		if(LAZYLEN(trapped))
+			var/mob/living/carbon/human/rescued = pick(trapped)
+			RescueFromRepentanceDimension(rescued, get_turf(src), "You manage to pull them back from that strange place!")
+			to_chat(user, span_notice("You successfully rescued [rescued]!"))
 		else
 			to_chat(user, span_notice("There's no one to rescue."))
 		return
@@ -123,105 +401,39 @@
 
 /mob/living/simple_animal/hostile/abnormality/door_to_nowhere/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	. = ..()
-	// 70% chance to send to backrooms on bad work (except Repression)
+	// 70% chance to send to repentance dimension on bad work (except Repression)
 	if(work_type != ABNORMALITY_WORK_REPRESSION && prob(70))
-		SendToBackrooms(user)
-
-/mob/living/simple_animal/hostile/abnormality/door_to_nowhere/proc/SendToBackrooms(mob/living/carbon/human/H)
-	if(!H || (H in trapped_employees))
-		return
-
-	trapped_employees += H
-	original_locations[H] = get_turf(H)
-
-	to_chat(H, span_userdanger("The door's chains rattle violently as it pulls you into a realm of sealed memories!"))
-	playsound(get_turf(H), 'sound/abnormalities/dinner_chair/ragdoll_effect.ogg', 75, TRUE)
-
-	// Apply violent spinning effect
-	INVOKE_ASYNC(src, PROC_REF(ViolentSpin), H)
-
-	// Wait for the spinning to finish before teleporting
-	addtimer(CALLBACK(src, PROC_REF(FinishTeleport), H), 12 SECONDS)
-
-/mob/living/simple_animal/hostile/abnormality/door_to_nowhere/proc/ViolentSpin(mob/living/M)
-	if(!M)
-		return
-
-	var/matrix/initial_matrix = matrix(M.transform)
-	// 10x more extreme than disco dance
-	for(var/i in 1 to 120) // 12 seconds worth at 0.1 second intervals
-		if(!M || QDELETED(M))
-			return
-
-		// Violent rotation
-		initial_matrix = matrix(M.transform)
-		initial_matrix.Turn(rand(45, 180)) // Random violent turns
-
-		// Extreme position changes
-		var/x_shift = rand(-10, 10)
-		var/y_shift = rand(-10, 10)
-		initial_matrix.Translate(x_shift, y_shift)
-
-		animate(M, transform = initial_matrix, time = 1, loop = 0, easing = pick(LINEAR_EASING, SINE_EASING, CIRCULAR_EASING))
-
-		// Rapid direction changes
-		M.setDir(pick(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST))
-
-		sleep(1)
-
-	// Reset transformation
-	animate(M, transform = null, time = 5, loop = 0)
-
-/mob/living/simple_animal/hostile/abnormality/door_to_nowhere/proc/FinishTeleport(mob/living/carbon/human/H)
-	if(!H || !(H in trapped_employees))
-		return
-
-	to_chat(H, span_warning("You find yourself in a liminal space of forgotten memories. The walls echo with regrets that were never voiced, sealed away behind countless doors."))
-	to_chat(H, span_warning("Each door you see is chained shut, hiding moments that someone desperately wanted to forget."))
-
-	playsound(get_turf(H), 'sound/effects/podwoosh.ogg', 50, TRUE)
-
-	// Pick a random backrooms location
-	var/turf/destination = pick(backrooms_locations)
-	H.forceMove(destination)
-
-	H.Stun(30)
-	H.adjustSanityLoss(20)
-
-	// Apply backrooms status effect
-	var/datum/status_effect/backrooms_ambience/B = H.apply_status_effect(/datum/status_effect/backrooms_ambience)
-	if(B)
-		backrooms_effects[H] = B
-
-/mob/living/simple_animal/hostile/abnormality/door_to_nowhere/proc/RescueFromBackrooms(mob/living/carbon/human/H)
-	if(!H || !(H in trapped_employees))
-		return
-
-	trapped_employees -= H
-	var/turf/return_turf = original_locations[H]
-	if(!return_turf)
-		return_turf = get_turf(src)
-
-	original_locations -= H
-
-	// Remove status effect
-	if(backrooms_effects[H])
-		H.remove_status_effect(/datum/status_effect/backrooms_ambience)
-		backrooms_effects -= H
-
-	to_chat(H, span_nicegreen("You feel a pull back to reality!"))
-	playsound(get_turf(H), 'sound/magic/teleport_app.ogg', 50, TRUE)
-
-	H.forceMove(return_turf)
+		var/message = "The door's chains rattle violently as it pulls you into the realm of sealed regrets!"
+		SendToRepentanceDimension(user, message, TRUE)
 
 /mob/living/simple_animal/hostile/abnormality/door_to_nowhere/ZeroQliphoth(mob/living/carbon/human/user)
+	// Count active agents to determine victim count
+	var/agent_count = 0
+	var/list/agent_roles = list(
+		"Agent Captain",
+		"Agent",
+		"Agent Intern"
+	)
+
+	for(var/mob/player in GLOB.player_list)
+		if(!player.mind || !player.mind.assigned_role)
+			continue
+		if(player.stat == DEAD)
+			continue
+		if(player.mind.assigned_role in agent_roles)
+			agent_count++
+
+	// Calculate victims: 1 per 4 agents, minimum 1
+	var/victims_to_send = max(1, round(agent_count / 4))
+
+	// Build list of potential victims
 	var/list/potential_victims = list()
 	for(var/mob/living/carbon/human/H in GLOB.player_list)
 		if(H.z != z)
 			continue
 		if(H.stat == DEAD)
 			continue
-		if(H in trapped_employees)
+		if(IsTrappedInRepentance(H))
 			continue
 		if(!H.mind)
 			continue
@@ -230,57 +442,70 @@
 	if(!LAZYLEN(potential_victims))
 		return
 
-	var/victims_count = min(rand(1, 3), LAZYLEN(potential_victims))
+	// Send victims up to calculated amount or available victims
+	var/victims_count = min(victims_to_send, LAZYLEN(potential_victims))
 
 	for(var/i in 1 to victims_count)
 		if(!LAZYLEN(potential_victims))
 			break
 		var/mob/living/carbon/human/victim = pick_n_take(potential_victims)
-		SendToBackrooms(victim)
-		to_chat(victim, span_userdanger("The door has dragged you behind its threshold, into the realm of sealed regrets!"))
+		var/message = "The door has dragged you into the realm of sealed regrets!"
+		SendToRepentanceDimension(victim, message, TRUE)
+		to_chat(victim, span_userdanger("The door has dragged you into the realm of sealed regrets!"))
 
 	visible_message(span_danger("[src]'s chains burst open momentarily, releasing waves of forgotten regrets before sealing shut once more."))
+
+	// Announce the breach scale
+	if(victims_count == 1)
+		visible_message(span_warning("The door claims a single soul..."))
+	else
+		visible_message(span_warning("The door claims [victims_count] souls in its hunger for repentance!"))
+
 	datum_reference.qliphoth_change(3)
 
 /mob/living/simple_animal/hostile/abnormality/door_to_nowhere/Destroy()
-	for(var/mob/living/carbon/human/H in trapped_employees)
-		RescueFromBackrooms(H)
+	// Unregister signal
+	UnregisterSignal(SSdcs, COMSIG_GLOB_HUMAN_INSANE)
+	// Rescue all trapped players when destroyed
+	for(var/mob/living/carbon/human/H in GetRepentanceTrappedList())
+		RescueFromRepentanceDimension(H, get_turf(src))
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/door_to_nowhere/death(gibbed)
-	for(var/mob/living/carbon/human/H in trapped_employees)
-		RescueFromBackrooms(H)
-		to_chat(H, span_notice("With the door shattered, the sealed memories dissipate and you are freed from that forsaken realm."))
+	// Rescue all trapped players when killed
+	for(var/mob/living/carbon/human/H in GetRepentanceTrappedList())
+		var/message = "With the door shattered, the sealed memories dissipate and you are freed from that forsaken realm."
+		RescueFromRepentanceDimension(H, get_turf(src), message)
 	density = FALSE
 	animate(src, alpha = 0, time = 5 SECONDS)
 	QDEL_IN(src, 5 SECONDS)
 	..()
 
-// Backrooms landmark for mapping
-/obj/effect/landmark/backrooms_spawn
-	name = "backrooms spawn"
+// Repentance dimension landmark for mapping
+/obj/effect/landmark/repentance_spawn
+	name = "repentance dimension spawn"
 	icon_state = "x2"
 
-/area/fishboat/backrooms
-	name = "???"
+/area/fishboat/repentance
+	name = "realm of sealed regrets"
 
-// Status effect for ambient backrooms audio
-/datum/status_effect/backrooms_ambience
-	id = "backrooms_ambience"
+// Status effect for ambient repentance dimension audio
+/datum/status_effect/repentance_ambience
+	id = "repentance_ambience"
 	duration = -1 // Permanent until removed
 	alert_type = null
 	var/next_sound_time = 0
 
-/datum/status_effect/backrooms_ambience/tick()
+/datum/status_effect/repentance_ambience/tick()
 	if(world.time >= next_sound_time)
 		if(ishuman(owner))
 			var/mob/living/carbon/human/H = owner
 			H.playsound_local(get_turf(H), 'sound/ambience/VoidsEmbrace.ogg', 50, FALSE, pressure_affected = FALSE)
-			to_chat(H, span_warning("You hear whispers of regrets... memories trying to claw their way back into existence."))
+			to_chat(H, span_warning("You hear whispers of repentance... souls seeking forgiveness for their regrets."))
 		// Next sound in 5-10 minutes (converted to deciseconds)
 		next_sound_time = world.time + rand(3000, 6000) // 300-600 seconds = 5-10 minutes
 
-/datum/status_effect/backrooms_ambience/on_apply()
+/datum/status_effect/repentance_ambience/on_apply()
 	. = ..()
 	// Play the sound immediately when first applied
 	if(ishuman(owner))
@@ -298,6 +523,7 @@
 	opacity = FALSE
 	resistance_flags = INDESTRUCTIBLE
 	density = FALSE
+	var/custom_name = FALSE
 	var/door_name = ""
 	var/door_desc = ""
 	var/spirit_name = ""
@@ -306,8 +532,9 @@
 
 /obj/structure/regret_door/Initialize()
 	. = ..()
-	generate_regret_identity()
-	spawn_associated_spirit()
+	if(!custom_name)
+		generate_regret_identity()
+		spawn_associated_spirit()
 
 /obj/structure/regret_door/proc/generate_regret_identity()
 	// Lists of regret themes
@@ -402,10 +629,10 @@
 	desc = door_desc
 
 /obj/structure/regret_door/proc/spawn_associated_spirit()
-	// Find all valid turfs in the backrooms area
+	// Find all valid turfs in the repentance dimension area
 	var/list/valid_turfs = list()
 	for(var/turf/T in range(10, src))
-		if(istype(T.loc, /area/fishboat/backrooms) && !T.density)
+		if(istype(T.loc, /area/fishboat/repentance) && !T.density)
 			var/blocked = FALSE
 			for(var/atom/A in T)
 				if(A.density)
@@ -433,10 +660,57 @@
 			var/mob/living/carbon/human/H = user
 			H.adjustSanityLoss(5)
 
+// Allow entering the door from outside the dimension
+/obj/structure/regret_door/attack_hand(mob/living/carbon/human/M)
+	. = ..()
+	if(!ishuman(M))
+		return
+
+	// Check if already in the repentance dimension
+	if(istype(M.loc.loc, /area/fishboat/repentance))
+		to_chat(M, span_warning("You are already within the realm of sealed regrets. This door leads nowhere from here."))
+		return
+
+	// Check if already trapped (shouldn't happen but safety check)
+	if(IsTrappedInRepentance(M))
+		to_chat(M, span_warning("You are already bound to this dimension..."))
+		return
+
+	// Confirm the action
+	if(alert(M, "Do you wish to open this door and step into the realm it guards? The name reads: '[name]'", "Open Regret Door", "Yes", "No") != "Yes")
+		return
+
+	to_chat(M, span_notice("You grasp the handle of [name]. The chains rattle as they slowly unwrap..."))
+	to_chat(M, span_warning("You feel the weight of [pick("regret", "sorrow", "loss", "remorse")] pulling you forward..."))
+
+	// Long channel time - 5 seconds
+	if(do_after(M, 50, target = src))
+		// Double-check they haven't been trapped in the meantime
+		if(IsTrappedInRepentance(M))
+			return
+
+		to_chat(M, span_userdanger("You push open [name] and step through into the realm of repentance!"))
+		visible_message(span_warning("[M] opens [name] and steps through, disappearing into the darkness beyond!"))
+
+		// Custom message based on the door type
+		var/entry_message = "You stepped through [name]. [door_desc]"
+		SendToRepentanceDimension(M, entry_message, FALSE)
+
+		// Visual effect
+		playsound(src, 'sound/effects/ghost2.ogg', 50, TRUE)
+
+		// The door closes behind them
+		visible_message(span_notice("[name] swings shut with a heavy thud, the chains wrapping back around it."))
+	else
+		to_chat(M, span_notice("You release the handle, deciding against entering."))
+
 /obj/structure/regret_door/Destroy()
 	if(associated_spirit)
 		qdel(associated_spirit)
 	return ..()
+
+/obj/structure/regret_door/custom
+	custom_name = TRUE
 
 // Regret Spirit Mob
 /mob/living/simple_animal/hostile/regret_spirit
@@ -454,8 +728,8 @@
 	friendly_verb_continuous = "mourns at"
 	friendly_verb_simple = "mourn at"
 	speed = 2
-	maxHealth = 100
-	health = 100
+	maxHealth = 200
+	health = 200
 	faction = list("neutral")
 	harm_intent_damage = 0
 	melee_damage_lower = 0
@@ -599,9 +873,6 @@
 	P.source_door = src
 	P.faction = faction.Copy()
 
-	// Store original body reference
-	var/mob/living/original_body = src
-
 	// Transfer mind
 	var/datum/mind/door_mind = mind
 	if(door_mind)
@@ -620,8 +891,8 @@
 	visible_message(span_warning("[src] shudders as a ghostly form emerges from within! The door becomes completely still..."))
 	playsound(src, 'sound/effects/ghost2.ogg', 50, TRUE)
 
-	// Set timer to return
-	addtimer(CALLBACK(src, PROC_REF(recall_spirit), P, original_body), 30 SECONDS)
+	// Set timer to return (using src as the original body)
+	addtimer(CALLBACK(src, PROC_REF(recall_spirit), P, src), 30 SECONDS)
 
 	return TRUE
 
@@ -828,7 +1099,8 @@
 
 	// Check for teleportation
 	if(stacks >= 5 && source_door && !QDELETED(source_door))
-		source_door.SendToBackrooms(owner)
+		var/message = "The weight of accumulated regret pulls you into the realm of sealed regrets!"
+		SendToRepentanceDimension(owner, message, TRUE)
 		qdel(src)
 		return
 
@@ -864,8 +1136,8 @@
 /mob/living/simple_animal/hostile/regret_spirit/projection
 	name = "projected spirit"
 	desc = "A temporary manifestation of regret and sorrow."
-	health = 50  // Fragile
-	maxHealth = 50
+	health = 250  // Fragile
+	maxHealth = 250
 	var/mob/living/simple_animal/hostile/abnormality/door_to_nowhere/source_door
 	del_on_death = TRUE
 
@@ -1025,7 +1297,13 @@
 		world.log << "Tape spawner: Found [LAZYLEN(SSpersistence.door_to_nowhere_tapes)] tapes in archive"
 		var/list/tape_data = pick(SSpersistence.door_to_nowhere_tapes)
 		new_tape = new /obj/item/tape(T)
-		new_tape.name = tape_data["name"]
+
+		// Check if the name is just "tape" and rename it
+		if(tape_data["name"] == "tape")
+			new_tape.name = "mirror shattered tape"
+		else
+			new_tape.name = tape_data["name"]
+
 		new_tape.desc = tape_data["desc"]
 		new_tape.icon_state = tape_data["icon_state"]
 		var/list/stored_info = tape_data["storedinfo"]
@@ -1043,6 +1321,9 @@
 			new_tape.timestamp = list()
 			new_tape.used_capacity = 0
 			world.log << "Tape spawner: Warning - stored_timestamp was null!"
+
+		// Add blur effect to the tape
+		new_tape.filters += filter(type = "blur", size = 1.5)
 
 	qdel(src)
 
@@ -1333,9 +1614,9 @@ GLOBAL_LIST_EMPTY(regret_shrines)
 			INVOKE_ASYNC(src, PROC_REF(drop), thing)
 
 /datum/component/door_dimension_void/proc/droppable(atom/movable/AM)
-	// Prevent infinite loops
-	if(falling_atoms[AM] && falling_atoms[AM] > 30)
-		return FALSE
+	// Prevent infinite loops and re-triggering
+	if(falling_atoms[AM])
+		return FALSE // Already falling, don't process again
 	if(!isliving(AM) && !isobj(AM))
 		return FALSE
 	if(is_type_in_typecache(AM, forbidden_types) || AM.throwing || (AM.movement_type & (FLOATING|FLYING)))
@@ -1363,23 +1644,31 @@ GLOBAL_LIST_EMPTY(regret_shrines)
 	if(!AM || QDELETED(AM))
 		return
 
-	falling_atoms[AM] = (falling_atoms[AM] || 0) + 1
+	// Mark as falling
+	falling_atoms[AM] = TRUE
 
-	// Visual feedback
-	AM.visible_message(span_boldwarning("[AM] falls into the reality void!"), span_userdanger("You feel yourself being pulled back to your own dimension!"))
+	// Visual feedback - only show generic message if not trapped in repentance
+	var/is_trapped = FALSE
+	if(ishuman(AM))
+		var/mob/living/carbon/human/H = AM
+		is_trapped = IsTrappedInRepentance(H)
+
+	if(!is_trapped)
+		AM.visible_message(span_boldwarning("[AM] falls into the reality void!"), span_userdanger("You feel yourself being pulled back to your own dimension!"))
+	else
+		AM.visible_message(span_boldwarning("[AM] falls into the reality void!"))
 
 	// Animate the fall
 	if(isliving(AM))
 		var/mob/living/L = AM
 		L.notransform = TRUE
-		L.Paralyze(40) // 4 seconds
+		L.Stun(20) // 2 seconds - match the animation duration
 
-	// Falling animation
-	var/oldtransform = AM.transform
+	// Falling animation - removed transform manipulation to fix reset bug
 	var/oldcolor = AM.color
 	var/oldalpha = AM.alpha
 	var/oldpixel_y = AM.pixel_y
-	animate(AM, transform = matrix() - matrix(), alpha = 0, color = rgb(85, 26, 139), time = 10) // Purple fade
+	animate(AM, alpha = 0, color = rgb(85, 26, 139), pixel_y = AM.pixel_y - 10, time = 10) // Purple fade with downward movement
 
 	for(var/i in 1 to 5)
 		if(!AM || QDELETED(AM))
@@ -1387,20 +1676,22 @@ GLOBAL_LIST_EMPTY(regret_shrines)
 			if(AM)
 				AM.alpha = oldalpha
 				AM.color = oldcolor
-				AM.transform = oldtransform
 				AM.pixel_y = oldpixel_y
+				if(isliving(AM))
+					var/mob/living/L = AM
+					L.notransform = FALSE
+			falling_atoms -= AM
 			return
-		AM.pixel_y--
 		sleep(2)
 
 	// Make sure still exists
 	if(!AM || QDELETED(AM))
+		falling_atoms -= AM
 		return
 
 	// Always reset appearance before processing
 	AM.alpha = oldalpha
 	AM.color = oldcolor
-	AM.transform = oldtransform
 	AM.pixel_y = oldpixel_y
 
 	// Teleport out instead of killing
@@ -1408,58 +1699,30 @@ GLOBAL_LIST_EMPTY(regret_shrines)
 		var/mob/living/L = AM
 		L.notransform = FALSE
 
-		// Find ANY Door to Nowhere abnormality (even without datum_reference)
-		var/mob/living/simple_animal/hostile/abnormality/door_to_nowhere/door = null
-		for(var/mob/living/simple_animal/hostile/abnormality/door_to_nowhere/D in GLOB.abnormality_mob_list)
-			door = D
-			if(D.datum_reference) // Prefer one with datum
-				break
+		// Use global repentance dimension rescue system
+		if(ishuman(L))
+			var/mob/living/carbon/human/H = L
+			if(IsTrappedInRepentance(H))
+				RescueFromRepentanceDimension(H, null, "The void expels you back to reality!")
+				// Return early - rescue is complete
+				falling_atoms -= AM
+				return
 
-		// If they're trapped and there's a door, use the rescue proc
-		if(door && ishuman(L) && (L in door.trapped_employees))
-			door.RescueFromBackrooms(L)
-			to_chat(L, span_warning("The void expels you back to reality!"))
-			// RescueFromBackrooms handles the teleport and effects
+		// Not trapped or not human - just teleport them somewhere safe
+		var/turf/destination
+		var/list/possible_turfs = list()
+		for(var/turf/T in GLOB.station_turfs)
+			if(T.density)
+				continue
+			possible_turfs += T
+		if(length(possible_turfs))
+			destination = pick(possible_turfs)
 		else
-			// Not trapped - need to manually clean up and teleport
-			var/turf/destination
+			destination = get_turf(parent)
 
-			// Check if they have backrooms status effect and remove it
-			if(ishuman(L))
-				var/mob/living/carbon/human/H = L
-				if(H.has_status_effect(/datum/status_effect/backrooms_ambience))
-					H.remove_status_effect(/datum/status_effect/backrooms_ambience)
-
-				// Clean up from any door's tracking lists
-				if(door)
-					if(H in door.trapped_employees)
-						door.trapped_employees -= H
-					if(H in door.original_locations)
-						door.original_locations -= H
-					if(H in door.backrooms_effects)
-						door.backrooms_effects -= H
-
-			// Find destination
-			if(door && door.datum_reference && door.datum_reference.landmark)
-				destination = get_turf(door.datum_reference.landmark)
-			else
-				// Fallback to random teleport
-				var/list/possible_turfs = list()
-				for(var/turf/T in GLOB.station_turfs)
-					if(T.density)
-						continue
-					possible_turfs += T
-				if(length(possible_turfs))
-					destination = pick(possible_turfs)
-
-			if(destination)
-				to_chat(L, span_warning("You are expelled from the door's dimension!"))
-				L.forceMove(destination)
-				playsound(destination, 'sound/effects/phasein.ogg', 50, TRUE)
-			else
-				// Emergency fallback - just move them up if we can't find anywhere
-				L.forceMove(get_turf(parent))
-				to_chat(L, span_warning("The void rejects you, spitting you back out!"))
+		to_chat(L, span_warning("The void rejects you, spitting you back out!"))
+		L.forceMove(destination)
+		playsound(destination, 'sound/effects/phasein.ogg', 50, TRUE)
 	else if(isobj(AM))
 		// Objects just get destroyed
 		qdel(AM)

--- a/code/modules/paperwork/records/info/teth.dm
+++ b/code/modules/paperwork/records/info/teth.dm
@@ -243,6 +243,7 @@
 		"When Insight work was performed, the Qliphoth Counter increased by 2. The chains seemed to tighten, keeping the memories locked away.",
 		"When any work other than Insight or Repression was performed, the Qliphoth Counter decreased by 1.",
 		"When the work result was Bad on any work except Repression, there was a 70% chance the employee would be pulled through the door into a realm of sealed regrets.",
+		"Each time a human panicked within the facility, Qliphoth Counter decreased by 1. It appeared to be trying to reach out to those humans...",
 		"Employees who passed through the door reported being trapped in a liminal space filled with forgotten memories and unspoken regrets, each one sealed behind its own chained door.",
 		"When Repression work was performed, any employees lost in the realm of regrets were pulled back through the door to reality.",
 		"When the Qliphoth Counter reached 0, the chains burst open momentarily and 1-3 random facility personnel were dragged through the door into that forsaken realm."

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -1633,6 +1633,8 @@
 #include "code\modules\admin\smites\lightning.dm"
 #include "code\modules\admin\smites\nugget.dm"
 #include "code\modules\admin\smites\puzzle.dm"
+#include "code\modules\admin\smites\ragdoll_spin.dm"
+#include "code\modules\admin\smites\repentance_banish.dm"
 #include "code\modules\admin\smites\rod.dm"
 #include "code\modules\admin\smites\scarify.dm"
 #include "code\modules\admin\smites\smite.dm"


### PR DESCRIPTION
## About The Pull Request

### Summary
This commit implements a complete overhaul of the Door to Nowhere abnormality, transforming it into a global dimension system called the "Dimension of Repentance". The system is now modular and can be used by other game mechanics beyond just the abnormality.

### Major Changes

### 1. Dynamic Breach Scaling
- Breach now scales with active agent count (not counting clerks, managers, reps, ect... anyone who can't work.)
- Sends 1 victim per 4 agents (minimum 1 victim)
- Better balances difficulty for different crew sizes

### 2. Voluntary Entry System
- Players can willingly enter the dimension via touching the Door to Nowhere with 5-second channel
- Non-harm intent required
- Rewards abnormality with +1 Qliphoth counter for willing sacrifice
- Also, the regret doors can be used to enter the dimension willingly, if they are not already inside the dimension.

### 3. Tape Recorder Integration
- Empty tape recorder spawns when entering dimension
- 5% chance to drop mirror world tapes during work
- First-time tape drops include a free tape recorder
- Tapes have blur effect and special "mirror shattered" naming

### 4. Insanity Response
- Door responds to global human insanity events (`COMSIG_GLOB_HUMAN_INSANE`)
- Decreases Qliphoth counter by 1 when humans go insane on same Z-level

### 5. Admin Tools
Two new admin smites added:
- **Ragdoll Spin**: Violently spins target with ragdoll animation for 12 seconds
- **Repentance Banish**: Spins target and banishes them to the Door's Dimension

### 6. Bug Fixes
- Fixed double teleport bug causing invisibility
- Removed transform manipulation that caused unfixable player transforms
- Synchronized stun duration with animation (2 seconds)
- Added proper cleanup in all exit paths
- Prevented re-triggering while already falling

## Why It's Good For The Game

Mostly, this PR cleans up the code of the Door to Nowhere, making it more universally usable, along with making the abno require a bit more attention from the players, rather than just being an abno you can forget about after reaching the HE phase.

Additionally, this resolves several issues with the door's dimensions, making it more widely usable in admin events or potentially serving as an easter egg in other maps.

### Put your cool images here

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Changelog
:cl:
code: making the code cleaner
add: Added new admin smites/functions the door
fix: fixed the hole to escape the dimension
balance: added scaling to the door
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
