### PR TITLE
Add: Expansion to the HighPopQueue, now accepts Discord queuers

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -529,12 +529,18 @@
 	min_val = 0.0
 	max_val = 1.0
 
+/datum/config_entry/flag/high_pop_ping_enabled
+	config_entry_value = FALSE
+
+/datum/config_entry/string/high_pop_ping_roleid
+	config_entry_value = null
+
 /datum/config_entry/number/high_pop_ping_threshold
 	config_entry_value = 7
 	integer = TRUE
 
-/datum/config_entry/string/high_pop_ping_roleid
-	config_entry_value = null
+/datum/config_entry/number/high_pop_queue_weight
+	config_entry_value = 1
 
 // If midnight has started by this time - upon finishing it, the core suppression will be available
 // In 1/10 of a second

--- a/code/modules/discord/tgs_commands.dm
+++ b/code/modules/discord/tgs_commands.dm
@@ -15,3 +15,23 @@
 	// If we got here, they arent in the list. Chuck 'em in!
 	SSdiscord.notify_members += sender.mention
 	return "You will now be notified when the server restarts"
+
+/datum/tgs_chat_command/highpopqueue
+	name = "highpopqueue"
+	help_text = "Pings the invoker when the highpop threshhold is reached"
+
+/datum/tgs_chat_command/highpopqueue/Run(datum/tgs_chat_user/sender, params)
+	if(!CONFIG_GET(flag/high_pop_ping_enabled))
+		return "High pop queue pings are currently disabled"
+
+	if(SSdiscord.high_pop_pinged)
+		return "There was already a high pop ping this round"
+
+	// See above, remove if invoked again aka person doesn't want ping anymore
+	for(var/member in SSdiscord.highpopqueue_members)
+		if(member == sender.mention)
+			SSdiscord.highpopqueue_members -= sender.mention
+			return "You will no longer be notified when the server passes the high pop threshold"
+
+	SSdiscord.highpopqueue_members += sender.mention
+	return "You will now be notified when the server passes the high pop threshold"

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -547,11 +547,19 @@ DEFAULT_VIEW_SQUARE 15x15
 
 #### OTHER DISCORD STUFF ####
 
+## Uncomment to enable high pop pings
+#HIGH_POP_PING_ENABLED
+
 ## Add the role ID of the role you wish to ping for high pop, leave commented out to disable high pop role pings
 #HIGH_POP_PING_ROLEID 000000000000000000
 
 ## Uncomment to change the number of active players needed for a Discord ping to be sent
 #HIGH_POP_PING_THRESHOLD 7
+
+## Uncomment & change this number to modify the weight Discord queued people have
+## This is what the queue count gets multiplied with and added to the in-game count
+## 2 = double weight, 1 = full weight, 0 = no weight
+#HIGH_POP_QUEUE_WEIGHT 1
 
 ##Amount of time required for senior job titles in minutes
 SENIOR_TIMELOCK 600


### PR DESCRIPTION
## About The Pull Request
Expands the high pop queue thingy with the ability to sign up to be pinged on Discord as well pinging the role configured.
The weight of the individuals queued on Discord can be adjusted via a config entry.
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More pop more good~!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here
N/A
<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?
* [X] This PR compiles
* [ ] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution
N/A
<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
add: You can now use !tgs highpopqueue on Discord to queue for a ping and count toward the high pop threshold!
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
