### PR TITLE
Adds 2 Roaming Associate Fixer slots to CoL on Roundstart

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -368,10 +368,17 @@ SUBSYSTEM_DEF(ticker)
 			iter_human.hardcore_survival_score *= 2 //Double for antags
 		to_chat(iter_human, "<span class='notice'>You will gain [round(iter_human.hardcore_survival_score)] hardcore random points if you survive this round!</span>")
 
+	// Roundstart changes for certain map types.
+
 	// Gamespeed vote and no-Manager Core Suppression selection override for LobCorp gamemodes.
 	if((SSmaptype.maptype in SSmaptype.lc_maps) || SSmaptype.maptype == "mini")
 		addtimer(CALLBACK(src, PROC_REF(DoGamespeedVote)), 10 SECONDS)
 		addtimer(CALLBACK(SSlobotomy_corp, TYPE_PROC_REF(/datum/controller/subsystem/lobotomy_corp, LiftCoreSelectionRestriction)), SSlobotomy_corp.core_selection_restriction_lift_timer)
+	else if((SSmaptype.maptype == "city")) // On City of Light specifically (not City Fixers or etc), add 2 Roamer slots at roundstart
+		for(var/datum/job/processing in SSjob.occupations)
+			if((istype(processing, /datum/job/associateroaming)))
+				processing.total_positions += 2
+				break
 
 //These callbacks will fire after roundstart key transfer
 /datum/controller/subsystem/ticker/proc/OnRoundstart(datum/callback/cb)


### PR DESCRIPTION
## About The Pull Request
When the round starts, if the gamemode is SPECIFICALLY City of Light (not City FIxers or any other), 2 Roaming Associate slots will open. For those who are unfamiliar, Roaming Associate Fixer is a Trusted-only role that randomly makes you part of an Association that isn't necessarily the "official" Association for the round.

<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A lot of players are quite fond of the role, so this will help move some pop from ghosts to active players, and make the round livelier.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [x] This PR compiles
* [x] This PR runs fine in a local test
* [x] This PR does not produce runtimes
* [x] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
tweak: Opens 2 Roaming Associate Fixer slots on City of Light at roundstart
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
