### PR TITLE
Fixes whitescreen on Buildmode Proccall

### DIFF
--- a/code/modules/buildmode/submodes/proccall.dm
+++ b/code/modules/buildmode/submodes/proccall.dm
@@ -25,7 +25,7 @@
 
 /datum/buildmode_mode/proccall/handle_click(client/user, params, datum/object)
 	if(!proc_name || !proc_args)
-		tgui_alert(user, "Undefined ProcCall or arguments.")
+		alert(user, "Undefined ProcCall or arguments. Right click the ProcCall mode button to set a proc to call.")
 		return
 
 	if(!hascall(object, proc_name))


### PR DESCRIPTION
## About The Pull Request
There's an admin tool called buildmode, which has a mode called proccall, and if you click on something without first defining a proc, you will get a white window on your client until you close it. You cannot close the white window. You just have to exit Dream Seeker.

This PR fixes that.

The root cause was that someone was calling tgui_alert without enough arguments. I just made it a regular alert.
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
If admins don't have to deal with jank like this then maybe they might be more merciful on the playerbase since they'll be less frustrated
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [x] This PR compiles
* [x] This PR runs fine in a local test
* [x] This PR does not produce runtimes
* [x] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
fix: Buildmode Proc-call no longer whitescreens when clicking without a set proc
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
