### PR TITLE
Pink no longer breaches Highway Devotee

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/misc.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/misc.dm
@@ -24,7 +24,9 @@
 				/mob/living/simple_animal/hostile/abnormality/white_night,
 				/mob/living/simple_animal/hostile/abnormality/nihil,
 				/mob/living/simple_animal/hostile/abnormality/hatred_queen,
-				/mob/living/simple_animal/hostile/abnormality/wrath_servant)
+				/mob/living/simple_animal/hostile/abnormality/wrath_servant,
+				/mob/living/simple_animal/hostile/abnormality/highway_devotee,
+				)
 
 
 /mob/living/simple_animal/hostile/ordeal/pink_midnight/Initialize()


### PR DESCRIPTION
## Why It's Good For The Game
Highway devotee is not meant for this sort of breach; and as such it has been removed from being breached by pink midnight.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [ ] This PR compiles
* [ ] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
balance: Pink no longer breaches Highway Devotee
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
