### PR TITLE
Make DeferProjectile Abnormality Helper

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/abnormality_helpers.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/abnormality_helpers.dm
@@ -1,4 +1,21 @@
 /*
+* For projectiles that dont originate from
+* a creatures position
+*/
+/mob/living/simple_animal/hostile/proc/DeferProjectile(projectile_type, mob/living/target_shoot, turf/T, projectile_telegraph_delay = 3)
+	if(!target_shoot || !T)
+		return
+	var/obj/projectile/P = new projectile_type(T)
+	P.starting = T
+	P.firer = src
+	P.fired_from = T
+	P.yo = target_shoot.y - T.y
+	P.xo = target_shoot.x - T.x
+	P.original = target_shoot
+	P.preparePixelProjectile(target_shoot, T)
+	addtimer(CALLBACK (P, TYPE_PROC_REF(/obj/projectile, fire)), projectile_telegraph_delay)
+
+/*
 * This Proc converts armor values into
 * mob defense values
 */

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nihil.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nihil.dm
@@ -294,16 +294,7 @@
 				if(T.density)
 					i -= 1
 					continue
-				var/obj/projectile/despair_rapier/P
-				P = new(T)
-				P.starting = T
-				P.firer = src
-				P.fired_from = T
-				P.yo = target.y - T.y
-				P.xo = target.x - T.x
-				P.original = target
-				P.preparePixelProjectile(target, T)
-				addtimer(CALLBACK (P, TYPE_PROC_REF(/obj/projectile, fire)), 30)
+				DeferProjectile(/obj/projectile/despair_rapier, target, T, 30)
 				var/list/hit_line = getline(T, get_turf(target)) //targetting line
 				for(var/turf/TF in hit_line)
 					if(TF.density)

--- a/code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm
@@ -195,7 +195,7 @@
 	ranged_cooldown = world.time + ranged_cooldown_time
 	var/turf/T = get_step(get_turf(src), pick(1,2,4,5,6,8,9,10))
 	if(T.density == FALSE)
-		ProjectSplinter(target, T, 8)
+		DeferProjectile(/obj/projectile/frost_splinter, target, T, 8)
 		SLEEP_CHECK_DEATH(3)
 		playsound(get_turf(src), 'sound/abnormalities/despairknight/attack.ogg', 50, 0, 4)
 		return
@@ -256,6 +256,10 @@
 		ReleasePrisoners()
 	ClearEffects()
 	QDEL_NULL(RVP)
+	kissed = null
+	snow_prison = null
+	storybook_hero = null
+	frozen_employee = null
 	return ..()
 
 		/*---------------------\
@@ -329,21 +333,6 @@
 
 	SLEEP_CHECK_DEATH(0.5 SECONDS)
 	can_act = TRUE
-
-//Quick proc for spawning and launching a frost splinter projectile.
-/mob/living/simple_animal/hostile/abnormality/snow_queen/proc/ProjectSplinter(mob/living/L, turf/T, projectile_telegraph_delay = 3)
-	if(!L || !T)
-		return
-	var/obj/projectile/frost_splinter/P
-	P = new(T)
-	P.starting = T
-	P.firer = src
-	P.fired_from = T
-	P.yo = L.y - T.y
-	P.xo = L.x - T.x
-	P.original = L
-	P.preparePixelProjectile(L, T)
-	addtimer(CALLBACK (P, TYPE_PROC_REF(/obj/projectile, fire)), projectile_telegraph_delay)
 
 		/*--------\
 		|WORK KISS|
@@ -585,7 +574,7 @@
 			break
 		if(!do_after(src, 2, target = src) && get_health > health)
 			break
-		ProjectSplinter(L, get_turf(src), 3)
+		DeferProjectile(/obj/projectile/frost_splinter, L, get_turf(src), 3)
 		playsound(get_turf(src), 'sound/abnormalities/despairknight/attack.ogg', 50, 0, 4)
 
 //At half health a healing patch of roses spawn to assist the player.
@@ -662,7 +651,7 @@
 			break
 		if(shootems == get_turf(src))
 			continue
-		ProjectSplinter(L, shootems, 3)
+		DeferProjectile(/obj/projectile/frost_splinter, L, shootems, 3)
 		playsound(shootems, 'sound/abnormalities/despairknight/attack.ogg', 50, 0, 4)
 
 //Determines if the effect on a AOE area is telegraphed or actually harmful.

--- a/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
@@ -157,24 +157,16 @@
 	if(ranged_cooldown > world.time)
 		return FALSE
 	ranged_cooldown = world.time + ranged_cooldown_time
+	var/tries = 8
 	for(var/i = 1 to 4)
+		if(tries < 1)
+			break
 		var/turf/T = get_step(get_turf(src), pick(1,2,4,5,6,8,9,10))
 		if(T.density)
 			i -= 1
+			tries--
 			continue
-		var/obj/projectile/despair_rapier/P
-		if(nihil_present)
-			P = new /obj/projectile/despair_rapier/justice(T)
-		else
-			P = new(T)
-		P.starting = T
-		P.firer = src
-		P.fired_from = T
-		P.yo = target.y - T.y
-		P.xo = target.x - T.x
-		P.original = target
-		P.preparePixelProjectile(target, T)
-		addtimer(CALLBACK (P, TYPE_PROC_REF(/obj/projectile, fire)), 3)
+		DeferProjectile(nihil_present ? /obj/projectile/despair_rapier/justice : /obj/projectile/despair_rapier, target, T, 3)
 	SLEEP_CHECK_DEATH(3)
 	playsound(get_turf(src), 'sound/abnormalities/despairknight/attack.ogg', 50, 0, 4)
 	return

--- a/code/modules/mob/living/simple_animal/abnormality/waw/pygmalion.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/pygmalion.dm
@@ -81,20 +81,16 @@
 	if(ranged_cooldown > world.time)
 		return FALSE
 	ranged_cooldown = world.time + ranged_cooldown_time
+	var/tries = 8
 	for(var/i = 1 to 4)
+		if(tries < 1)
+			break
 		var/turf/T = get_step(get_turf(src), pick(1,2,4,5,6,8,9,10))
 		if(T.density)
 			i -= 1
+			tries--
 			continue
-		var/obj/projectile/P = sculptor ?  new /obj/projectile/bride_bolts/(T) : new /obj/projectile/bride_bolts_enraged/(T)
-		P.starting = T
-		P.firer = src
-		P.fired_from = T
-		P.yo = target.y - T.y
-		P.xo = target.x - T.x
-		P.original = target
-		P.preparePixelProjectile(target, T)
-		addtimer(CALLBACK (P, TYPE_PROC_REF(/obj/projectile, fire)), 3)
+		DeferProjectile(sculptor ? /obj/projectile/bride_bolts : /obj/projectile/bride_bolts_enraged, target, T, 3)
 	return
 
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -575,7 +575,9 @@
  * Used to not even attempt to Bump() or fail to Cross() anything we already hit.
  */
 /obj/projectile/CanPassThrough(atom/blocker, turf/target, blocker_opinion)
-	return impacted[blocker]? TRUE : ..()
+	if(!(blocker in impacted))
+		return ..()
+	return impacted[blocker] ? TRUE : ..()
 
 /**
  * Projectile moved:


### PR DESCRIPTION
## About The Pull Request
Nihil, Despair Knight, Pygmalion,  and Snow Queen all use similar code to  shoot  projectiles that are a tile away from  their  bodies. This compacts all  that  code into a abnormality helper proc.
Also fixed a projectile  runtime i noticed  during testing.

## Why It's Good For The Game
Makes the code  more readable

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [x] This PR compiles
* [x] This PR runs fine in a local test
* [x] This PR does not produce runtimes
* [x] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
refactor:  Projectile shooting in Snow Queen, Nihil, Pygmalion, and  Despair Knight.
fix: Bad Index runtime that occurred when despair knight  shot projectiles.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
