### PR TITLE
KoD new Attacks [DONE]

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
@@ -60,6 +60,7 @@
 	var/mob/living/carbon/human/blessed_human = null
 	var/teleport_cooldown
 	var/teleport_cooldown_time = 20 SECONDS
+	var/special_atk_combo = 0
 	var/swords = 0
 	var/nihil_present = FALSE
 	var/can_act = TRUE
@@ -68,7 +69,6 @@
 		/datum/action/innate/change_icon_kod,
 		/datum/action/cooldown/knightblessing,
 	)
-
 
 /datum/action/innate/change_icon_kod
 	name = "Toggle Icon"
@@ -147,16 +147,26 @@
 	swords += 1
 
 /mob/living/simple_animal/hostile/abnormality/despair_knight/AttackingTarget(atom/attacked_target)
+	if(!can_act && !client)
+		return
 	if(!target)
 		GiveTarget(attacked_target)
+	if(!client && get_dist(get_turf(src), get_turf(attacked_target)) == 1 && attack_cooldown <= world.time && target)
+		attack_cooldown = attack_cooldown + 5
+		return prob(50) ?  Slash() : HopelessRetort()
 	return OpenFire()
 
 /mob/living/simple_animal/hostile/abnormality/despair_knight/OpenFire()
 	if(!can_act)
 		return FALSE
-	if(ranged_cooldown > world.time)
-		return FALSE
+	if(!client && get_dist(get_turf(src), get_turf(target)) == 1 && attack_cooldown <= world.time && target)
+		attack_cooldown = attack_cooldown + 5
+		return prob(50) ?  Slash() : HopelessRetort()
+	special_atk_combo += 1
 	ranged_cooldown = world.time + ranged_cooldown_time
+	//Sorry player no funny attacks for you.
+	if(special_atk_combo >= 7 && !client)
+		return RapidFire()
 	var/tries = 8
 	for(var/i = 1 to 4)
 		if(tries < 1)
@@ -329,6 +339,7 @@
 	new /obj/effect/temp_visual/guardian/phase/out(teleport_target)
 	forceMove(teleport_target)
 
+
 /mob/living/simple_animal/hostile/abnormality/despair_knight/death(gibbed)
 	if(!nihil_present)
 		return ..()
@@ -342,4 +353,135 @@
 		death()
 		return FALSE
 	return ..()
+
+/*--------------\
+|Special Attacks|
+\--------------*/
+/mob/living/simple_animal/hostile/abnormality/despair_knight/proc/RapidFire()
+	if(!can_act)
+		return FALSE
+	can_act = FALSE
+	var/tries = 10
+	for(var/round = 1 to 12)
+		if(!target)
+			break
+		if(tries < 1)
+			break
+		var/turf/T = get_step(get_turf(src), pick(1,4,5,6,8,9,10))
+		if(T.density)
+			round -= 1
+			tries--
+			continue
+		if(!do_after(src, 2, target = src))
+			break
+		DeferProjectile(nihil_present ? /obj/projectile/despair_rapier/justice : /obj/projectile/despair_rapier, target, T, 3)
+		playsound(get_turf(src), 'sound/abnormalities/despairknight/attack.ogg', 25, 0, 4)
+	SLEEP_CHECK_DEATH(2)
+	can_act = TRUE
+	special_atk_combo = 0
+
+//This proc should make a wall of swords that shoot towards who KoD is facing.
+/*
+* Originally this was going to use locate to find the cordnates of
+* diagonal turfs and then cycle downwards or across with get_step
+* but that seemed too convoluted in comparison to range(). -IP
+*/
+/mob/living/simple_animal/hostile/abnormality/despair_knight/proc/HopelessRetort()
+	can_act = FALSE
+	var/our_projectile_path = nihil_present ? /obj/projectile/despair_rapier/justice : /obj/projectile/despair_rapier
+	var/dir_to_target = get_cardinal_dir(get_turf(src), get_turf(target))
+
+	var/list/origin_turfs = list()
+	//Give me all the  turfs that are 2 tiles away
+	//Default is EAST
+	var/invert = -1
+	//Ill figure out a way to write this shorter someday
+	if(dir_to_target == WEST || dir_to_target == SOUTH)
+		invert = 1
+	var/positionx = x+(2*invert)
+	var/positiony = 0
+	if(dir_to_target == NORTH || dir_to_target == SOUTH)
+		positionx = 0
+		positiony = y+(2*invert)
+
+	for(var/turf/T in orange(get_turf(src),2))
+		if(!isopenturf(T))
+			continue
+		if(positionx && positionx != T.x)
+			continue
+		if(positiony && positiony != T.y)
+			continue
+		if(z != T.z)
+			//Just in case
+			continue
+		origin_turfs += T
+
+	if(!length(origin_turfs))
+		can_act = TRUE
+		return
+
+	var/turf_dir
+	var/delay = 3
+	for(var/turf/bullet_turfs in origin_turfs)
+		if(!turf_dir)
+			turf_dir = dir_to_target
+		DeferProjectile(our_projectile_path, get_step(bullet_turfs, turf_dir), bullet_turfs, delay)
+		delay++
+	SLEEP_CHECK_DEATH(5)
+	can_act = TRUE
+
+/mob/living/simple_animal/hostile/abnormality/despair_knight/proc/Slash()
+	if(!target)
+		stack_trace("KoD Slash called without target.")
+		return
+	can_act = FALSE
+	var/dir_to_target = get_cardinal_dir(get_turf(src), get_turf(target))
+	var/turf/source_turf = get_step(get_turf(src), dir_to_target)
+	var/turf/area_of_effect = list()
+	var/turf/middle_line = list()
+	var/upline = NORTH
+	var/downline = SOUTH
+	var/smash_length = 2
+	var/smash_width = 1
+	playsound(get_turf(src), 'sound/weapons/bladeslice.ogg', 50, 0, 5)
+	middle_line = getline(source_turf, get_ranged_target_turf(source_turf, dir_to_target, smash_length))
+	if(dir_to_target == NORTH || dir_to_target == SOUTH)
+		upline = EAST
+		downline = WEST
+	for(var/turf/T in middle_line)
+		if(T.density)
+			break
+		for(var/turf/Y in getline(T, get_ranged_target_turf(T, upline, smash_width)))
+			if (Y.density)
+				break
+			if (Y in area_of_effect)
+				continue
+			area_of_effect += Y
+		for(var/turf/U in getline(T, get_ranged_target_turf(T, downline, smash_width)))
+			if (U.density)
+				break
+			if (U in area_of_effect)
+				continue
+			area_of_effect += U
+	if(!dir_to_target)
+		for(var/turf/TT in view(1, src))
+			if (TT.density)
+				break
+			if (TT in area_of_effect)
+				continue
+			area_of_effect |= TT
+	if (!LAZYLEN(area_of_effect))
+		return
+	can_act = FALSE
+	dir = dir_to_target
+	for(var/turf/T in area_of_effect)
+		new /obj/effect/temp_visual/revenant(T)
+	SLEEP_CHECK_DEATH(1 SECONDS)
+	for(var/turf/T in area_of_effect)
+		new /obj/effect/temp_visual/smash_effect(T)
+		for(var/mob/living/L in HurtInTurf(T, list(), 20, work_damage_type, check_faction = TRUE, hurt_mechs = TRUE, attack_type = (ATTACK_TYPE_MELEE | ATTACK_TYPE_SPECIAL)))
+			playsound(get_turf(src), 'sound/magic/teleport_app.ogg', 30, 1)
+
+	SLEEP_CHECK_DEATH(0.5 SECONDS)
+	can_act = TRUE
 


### PR DESCRIPTION
## About The Pull Request
Gives KoD a rapid fire attack for every seventh attack and a melee cleave attack.
Due to the RapidFire causing the player to go stationary it may be a significant debuff for RCA KoD.
Also gives HopelessRetort, a line attack that has 5 rapiers appear behind KoD and fire in the general direction she is facing.

Currently all special attacks are locked to AI control to avoid problems with RCA players.

## Why It's Good For The Game
Was requested to add more to KoD's combat prowess

### Put your cool images here
4/5/26 local test of new attacks.

https://github.com/user-attachments/assets/39e413b4-dec2-4b2e-8e92-dc0b8da273fe

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [x] This PR compiles
* [x] This PR runs fine in a local test
* [x] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
add: New KoD Attacks
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
