### PR TITLE
Fixing Some Runtimes [DONE]

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1525,7 +1525,8 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 /proc/fade_blurb(client/C, obj/T, fade_time = 5)
 	animate(T, alpha = 0, time = fade_time)
 	sleep(fade_time)
-	C.screen -= T
+	if(C)
+		C.screen -= T
 	qdel(T)
 
 /proc/show_letterbox(client/C, duration)

--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -240,7 +240,7 @@
 	var/attribute_type = "N/A"
 	var/attribute_given = 0
 	if(pe > 0) // Work did not fail
-		if(!stupid)
+		if(!stupid && !QDELETED(current))
 			attribute_type = current.work_attribute_types[work_type]
 		else
 			attribute_type = WORK_TO_ATTRIBUTE[work_type]

--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -95,7 +95,8 @@
 				if (3 to INFINITY)
 					if (i == ingredients.len - 1)
 						ending = ", and "
-			ingredients_listed += "\a [ingredient.name][ending]"
+			if(ingredient)
+				ingredients_listed += "\a [ingredient.name][ending]"
 	examine_list += "It contains [LAZYLEN(ingredients) ? "[ingredients_listed]" : " no ingredients, "]making a [custom_adjective()]-sized [initial(atom_parent.name)]."
 
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/dealerdamned.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/dealerdamned.dm
@@ -17,7 +17,6 @@
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gluttony
 	speak_emote = list("states")
-	pet_bonus = "waves"
 
 	ego_list = list(
 		/datum/ego_datum/weapon/luckdraw,
@@ -38,18 +37,23 @@
 		"Fold" = list(FALSE, "You fold, wishing to cling to what little remains of your wealth. Despite lacking any facial features, you can feel the Dealer's disappointment..."),
 	)
 
-//Coinflip V1; Expect Jank
-/mob/living/simple_animal/hostile/abnormality/dealerdamned/funpet(mob/petter)
-	..()
-	if(!isliving(petter))
+//Coinflip V2; Expect Jank
+/mob/living/simple_animal/hostile/abnormality/dealerdamned/attack_hand(mob/user)
+	. = ..()
+	if(.)
 		return
+	if(!isliving(user))
+		return
+	if(user.a_intent != INTENT_HELP)
+		return
+	user.changeNext_move(CLICK_CD_MELEE)
 	if(has_flipped)
 		say("Woah there, hotshot. We've already had a game recently!")
 		return
 	var/flip_modifier = 0
 	has_flipped = TRUE
-	var/mob/living/user = petter
-	user.deal_damage(user.maxHealth*0.2, RED_DAMAGE, flags = (DAMAGE_FORCED))
+	var/mob/living/gambler = user
+	gambler.deal_damage(gambler.maxHealth*0.2, RED_DAMAGE, flags = (DAMAGE_FORCED))
 	icon_state = "dealerflip"
 	manual_emote("flips a gold coin.")
 	SLEEP_CHECK_DEATH(10)
@@ -60,7 +64,7 @@
 	if(prob(35)+flip_modifier)
 		say("Heads, huh? Looks like you win this one.")
 		coin_status = TRUE
-		user.adjustBruteLoss(-user.maxHealth*0.2)
+		gambler.adjustBruteLoss(-gambler.maxHealth*0.2)
 	else
 		say("Tails. Sorry, high roller, but a deal's a deal.")
 	return
@@ -103,7 +107,7 @@
 				playsound(user, 'sound/weapons/gun/revolver/shot_alt.ogg', 100, FALSE)
 				russian_roulette = FALSE
 				if(player_shot)
-					user.gib()
+					user.gib(FALSE,FALSE,TRUE)
 					say("Shame. Was quite fun havin' ya here, but you know how it is.")
 				else
 					new /obj/item/ego_weapon/ranged/pistol/deathdealer(get_turf(user))

--- a/code/modules/mob/living/simple_animal/abnormality/teth/lunar_rabbit.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/lunar_rabbit.dm
@@ -63,7 +63,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/lunar_rabbit/Initialize(atom/attacked_target)
 	.=..()
-	var/breachtime = 5 MINUTES + rand(1, 10 MINUTES) + datum_reference.transferable_simple * 3 MINUTES
+	var/breachtime = 5 MINUTES + rand(1, 10 MINUTES) + (datum_reference ? datum_reference.transferable_simple : 1) * 3 MINUTES
 	addtimer(CALLBACK(src, PROC_REF(BreachMe)), breachtime)
 
 /mob/living/simple_animal/hostile/abnormality/lunar_rabbit/proc/BreachMe(atom/attacked_target)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/screenwriter.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/screenwriter.dm
@@ -1,9 +1,9 @@
 #define STATUS_EFFECT_ACTOR /datum/status_effect/actor
 //Coded by Coxswain, Sprited by Quack
 /*
-Bit of a complicated abnormality, but to put to sum it up,
-it debuffs random players and then summons a murderer to kill them one at a time.
-Defeating the murderer also surpresses the abnormality.
+* Bit of a complicated abnormality, but to put to sum it up,
+* it debuffs random players and then summons a murderer to kill them one at a time.
+* Defeating the murderer also surpresses the abnormality.
 */
 /mob/living/simple_animal/hostile/abnormality/screenwriter
 	name = "Poor Screenwriter's Note"
@@ -52,7 +52,7 @@ Defeating the murderer also surpresses the abnormality.
 	)
 
 	pet_bonus = "shuffles" //saves a few lines of code by allowing funpet() to be called by attack_hand()
-	var/mob/living/simple_animal/hostile/actor/A
+	var/mob/living/simple_animal/hostile/actor/our_actor
 	var/happy = FALSE
 	var/melting
 	var/preferred_work_type
@@ -70,14 +70,14 @@ Defeating the murderer also surpresses the abnormality.
 	return FALSE
 
 /mob/living/simple_animal/hostile/abnormality/screenwriter/Destroy()
-	if(A)
-		A.death()
+	if(our_actor)
+		our_actor.death()
 	EndScenario()
 	return ..()
 
 //Work stuff
 /mob/living/simple_animal/hostile/abnormality/screenwriter/AttemptWork(mob/living/carbon/human/user, work_type)
-	if(A)
+	if(our_actor)
 		to_chat(user, span_warning("The abnormality ignores you!"))
 		return FALSE
 	if(work_type == preferred_work_type || !preferred_work_type)
@@ -122,9 +122,9 @@ Defeating the murderer also surpresses the abnormality.
 
 //Breach
 /mob/living/simple_animal/hostile/abnormality/screenwriter/ZeroQliphoth(mob/living/carbon/human/user)
-	if(QDELETED(A))
-		A = null
-	if(A)
+	if(QDELETED(our_actor))
+		our_actor = null
+	if(our_actor)
 		return
 	MeltdownEffect()
 	return
@@ -135,8 +135,8 @@ Defeating the murderer also surpresses the abnormality.
 
 /mob/living/simple_animal/hostile/abnormality/screenwriter/proc/MeltdownEffect()
 	var/turf/actor_location = pick(GLOB.department_centers) //Spawn the murderer
-	A = new (actor_location)
-	RegisterSignal(A, COMSIG_LIVING_DEATH, PROC_REF(EndScenario))
+	our_actor = new (actor_location)
+	RegisterSignal(our_actor, COMSIG_LIVING_DEATH, PROC_REF(EndScenario))
 	var/list/potentialmarked = list()
 	var/list/marked = list()
 	var/mob/living/carbon/human/Y
@@ -182,7 +182,8 @@ Defeating the murderer also surpresses the abnormality.
 		var/datum/status_effect/actor/S = L.has_status_effect(/datum/status_effect/actor)
 		if(S)
 			qdel(S)
-	UnregisterSignal(A, COMSIG_LIVING_DEATH)
+	if(our_actor)
+		UnregisterSignal(our_actor, COMSIG_LIVING_DEATH)
 
 //Overlays
 /mob/living/simple_animal/hostile/abnormality/screenwriter/proc/SpawnIcon()

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -97,8 +97,9 @@
 	log_message("Client [key_name(src)] has taken ownership of mob [src]([src.type])", LOG_OWNERSHIP)
 	SEND_SIGNAL(src, COMSIG_MOB_CLIENT_LOGIN, client)
 	client.init_verbs()
-
-	client.patreon = new(client)
+	//Gibbed brains were having runtimes with this line.
+	if(client)
+		client.patreon = new(client)
 
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request
Fixed a few runtimes that occured with Dealer of the Damned and Lunar Rabbit.
Dealer of the Damned was having issues because its datum reference attempted to check it after it had gibbed.
Another runtime occured when someones brain was being checked for a client after they had been gibbed.
### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [x] This PR compiles
* [x] This PR runs fine in a local test
* [x] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
fix: Runtimes with Lunar Rabbit and Dealer of the Damned
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
