### PR TITLE
Hard Deletion Prevention for Abnormalities Part 1 [DONE]

### DIFF
--- a/code/datums/weakrefs.dm
+++ b/code/datums/weakrefs.dm
@@ -10,6 +10,46 @@
 /datum/proc/create_weakref()		//Forced creation for admin proccalls
 	return WEAKREF(src)
 
+/** Exerpt from TGstation
+ * A weakref holds a non-owning reference to a datum.
+ * The datum can be referenced again using `resolve()`.
+ *
+ * To figure out why this is important, you must understand how deletion in
+ * BYOND works.
+ *
+ * Imagine a datum as a TV in a living room. When one person enters to watch
+ * TV, they turn it on. Others can come into the room and watch the TV.
+ * When the last person leaves the room, they turn off the TV because it's
+ * no longer being used.
+ *
+ * A datum being deleted tells everyone who's watching the TV to stop.
+ * If everyone leaves properly (AKA cleaning up their references), then the
+ * last person will turn off the TV, and everything is well.
+ * However, if someone is resistant (holds a hard reference after deletion),
+ * then someone has to walk in, drag them away, and turn off the TV forecefully.
+ * This process is very slow, and it's known as hard deletion.
+ *
+ * This is where weak references come in. Weak references don't count as someone
+ * watching the TV. Thus, when what it's referencing is destroyed, it will
+ * hopefully clean up properly, and limit hard deletions.
+ *
+ * A common use case for weak references is holding onto what created itself.
+ * For example, if a machine wanted to know what its last user was, it might
+ * create a `var/mob/living/last_user`. However, this is a strong reference to
+ * the mob, and thus will force a hard deletion when that mob is deleted.
+ * It is often better in this case to instead create a weakref to the user,
+ * meaning this type definition becomes `var/datum/weakref/last_user`.
+ *
+ * A good rule of thumb is that you should hold strong references to things
+ * that you *own*. For example, a dog holding a chew toy would be the owner
+ * of that chew toy, and thus a `var/obj/item/chew_toy` reference is fine
+ * (as long as it is cleaned up properly).
+ * However, a chew toy does not own its dog, so a `var/mob/living/dog/owner`
+ * might be inferior to a weakref.
+ * This is also a good rule of thumb to avoid circular references, such as the
+ * chew toy example. A circular reference that doesn't clean itself up properly
+ * will always hard delete.
+ */
 /datum/weakref
 	var/reference
 

--- a/code/modules/mob/living/carbon/human/ego_gifts.dm
+++ b/code/modules/mob/living/carbon/human/ego_gifts.dm
@@ -66,6 +66,11 @@
 	user.physiology.repression_success_mod -= src.repression_mod
 	QDEL_NULL(src)
 
+/datum/ego_gifts/Destroy()
+	owner = null
+	datum_reference = null
+	return ..()
+
 /datum/ego_gifts/Topic(href, list/href_list)
 	switch(href_list["choice"])
 		if("lock")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -200,6 +200,13 @@
 /mob/living/carbon/human/Destroy()
 	QDEL_NULL(physiology)
 	GLOB.human_list -= src
+	wear_suit = null
+	w_uniform = null
+	belt = null
+	wear_id = null
+	r_store = null
+	l_store = null
+	s_store = null
 	return ..()
 
 /mob/living/carbon/human/ZImpactDamage(turf/T, levels)

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -35,7 +35,7 @@
 	var/good_droprate = 0
 	var/neutral_droprate = 0
 	var/bad_droprate = 0
-	/// List of humans that witnessed the abnormality breaching
+	/// List of humans that witnessed the abnormality breaching, uses tags
 	var/list/breach_affected = list()
 	/// Copy-pasted from megafauna.dm: This allows player controlled mobs to use abilities
 	var/chosen_attack = 1
@@ -231,6 +231,8 @@
 
 /mob/living/simple_animal/hostile/abnormality/Destroy()
 	SHOULD_CALL_PARENT(TRUE)
+	breach_affected = null
+	attack_action_types = null
 	if(istype(datum_reference)) // Respawn the mob on death
 		datum_reference.current = null
 		addtimer(CALLBACK (datum_reference, TYPE_PROC_REF(/datum/abnormality, RespawnAbno)), 30 SECONDS)
@@ -316,11 +318,11 @@
 	if(fear_level <= 0)
 		return
 	for(var/mob/living/carbon/human/H in ohearers(7, src))
-		if(H in breach_affected)
+		if(H.tag in breach_affected)
 			continue
 		if(H.stat == DEAD)
 			continue
-		breach_affected += H
+		breach_affected += H.tag
 		if(HAS_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE))
 			to_chat(H, span_notice("This again...?"))
 			H.apply_status_effect(/datum/status_effect/panicked_lvl_0)

--- a/code/modules/mob/living/simple_animal/abnormality/abno_cores.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/abno_cores.dm
@@ -13,6 +13,11 @@
 	var/threat_level
 	var/ego_list = list()
 
+/obj/structure/abno_core/Destroy()
+	contained_abno = null
+	ego_list = null
+	return ..()
+
 /obj/structure/abno_core/proc/Release()
 	if(!contained_abno)//Is this core properly generated?
 		return

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/army_in_black.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/army_in_black.dm
@@ -65,11 +65,11 @@ GLOBAL_LIST_EMPTY(army)
 	//Unique variables
 	var/death_counter = 0
 	var/protection_duration = 120 SECONDS
-	var/protected_targets = list()
-	var/summoned_army = list()//hostile unit list
 	var/boom_radius = 20
 	var/boom_damage = 70
 	var/adds_max = 1
+	var/list/protected_targets = list()
+	var/list/summoned_army = list()//hostile unit list
 
 /***Simple mob procs***/
 //checks for deaths
@@ -81,15 +81,8 @@ GLOBAL_LIST_EMPTY(army)
 //stops the previous snippet from destroying the server
 /mob/living/simple_animal/hostile/abnormality/army/Destroy()
 	UnregisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH)
+	MassUnregisterMob()
 	return ..()
-
-/mob/living/simple_animal/hostile/abnormality/army/Life()
-	..()
-	if(LAZYLEN(protected_targets))
-		for(var/mob/living/carbon/human/H in protected_targets)
-			if(!H.has_status_effect(STATUS_EFFECT_PROTECTION))
-				protected_targets -= H
-	return
 
 //no more nuzzling
 /mob/living/simple_animal/hostile/abnormality/army/AttackingTarget()
@@ -110,7 +103,7 @@ GLOBAL_LIST_EMPTY(army)
 			if((get_user_level(user)) < 4)
 				user.SanityLossEffect(TEMPERANCE_ATTRIBUTE)
 				return FALSE
-			protected_targets += user
+			RegisterMob(user,protected_targets)
 			user.apply_status_effect(STATUS_EFFECT_PROTECTION)
 			to_chat(user, span_nicegreen("You feel like you're in good company."))
 			playsound(get_turf(user), 'sound/abnormalities/armyinblack/pink_heal.ogg', 50, 0, 2)
@@ -154,7 +147,7 @@ GLOBAL_LIST_EMPTY(army)
 	if(breach_type == BREACH_MINING)
 		for(var/i in 1 to 3)
 			var/mob/living/simple_animal/hostile/army_enemy/E = new(get_turf(src))
-			RegisterSignal(E, COMSIG_PARENT_QDELETING, PROC_REF(ArmyDeath))
+			RegisterMob(E,summoned_army)
 	else
 		FearEffect()
 		Blackify()
@@ -171,17 +164,9 @@ GLOBAL_LIST_EMPTY(army)
 	for(var/i = 1 to adds_max)//# of iterations is equal to adds_max
 		for(var/turf/T in spawns)//this picks the first few shuffled xeno spawns. Maybe change it to a different type of loop
 			var/mob/living/simple_animal/hostile/army_enemy/E = new(get_turf(T))
-			summoned_army += E//the actual army list
-			RegisterSignal(E, COMSIG_PARENT_QDELETING, PROC_REF(ArmyDeath))
+			RegisterMob(E,summoned_army)
 			spawns -= T
 			break
-
-/mob/living/simple_animal/hostile/abnormality/army/proc/ArmyDeath(mob/E)//return to containment when all armies are dead
-	UnregisterSignal(E, COMSIG_PARENT_QDELETING)
-	summoned_army -= E
-	if(LAZYLEN(summoned_army) <=1)
-		qdel(src)//suppress the abnormality
-		return
 
 //convert all protection buffs into hostile units
 /mob/living/simple_animal/hostile/abnormality/army/proc/Blackify()
@@ -190,10 +175,32 @@ GLOBAL_LIST_EMPTY(army)
 		P.boom = FALSE
 		A.remove_status_effect(STATUS_EFFECT_PROTECTION)
 		var/mob/living/simple_animal/hostile/army_enemy/B = new(get_turf(A))
-		protected_targets -= A
-		summoned_army += B
+		UnregisterMob(A)
+		RegisterMob(B, summoned_army)
+
+/mob/living/simple_animal/hostile/abnormality/army/proc/RegisterMob(mob/living/signalee, list/add_list)
+	RegisterSignal(signalee, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMob))
+	add_list += signalee
+
+/mob/living/simple_animal/hostile/abnormality/army/proc/UnregisterMob(mob/living/designal)
+	UnregisterSignal(designal, list(COMSIG_PARENT_QDELETING))
+	if(designal in protected_targets)
+		protected_targets -= designal
+	if(designal in summoned_army)
+		summoned_army -= designal
+		if(LAZYLEN(summoned_army) <=1)
+			qdel(src)//suppress the abnormality
+
+/mob/living/simple_animal/hostile/abnormality/army/proc/MassUnregisterMob()
+	var/unit_track_lists = protected_targets + summoned_army
+	LAZYCLEARLIST(protected_targets)
+	LAZYCLEARLIST(summoned_army)
+	for(var/mob/living/targets in unit_track_lists)
+		UnregisterMob(targets)
+
 
 //hostile breach mob
+//Theres a rutime of this having a timer conected to a qdeleted object. Im not sure how to fix it -IP
 /mob/living/simple_animal/hostile/army_enemy
 	name = "Army In Black"
 	desc = "Yes.. we, the Army in Black.. blend into the human heart.. and drive away good thoughts.."
@@ -226,6 +233,12 @@ GLOBAL_LIST_EMPTY(army)
 	var/boom_damage = 70
 	var/targetted_beacon
 	var/list/moving_path
+
+
+/mob/living/simple_animal/hostile/army_enemy/Destroy()
+	moving_path = null
+	targetted_beacon = null
+	return ..()
 
 //movement and AI
 /mob/living/simple_animal/hostile/army_enemy/AttackingTarget()
@@ -289,12 +302,12 @@ GLOBAL_LIST_EMPTY(army)
 
 /mob/living/simple_animal/hostile/army_enemy/proc/FearEffect()
 	for(var/mob/living/carbon/human/H in view(7, src))
-		if(H in fear_affected)
+		if(H.tag in fear_affected)
 			continue
 		if(HAS_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE))
 			continue
 		H.adjustSanityLoss(H.maxSanity*0.3)
-		fear_affected += H
+		fear_affected += H.tag
 		if(H.sanity_lost)
 			continue
 		to_chat(H, span_warning("Oh dear."))

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/black_sun.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/black_sun.dm
@@ -37,6 +37,12 @@
 	RegisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH, PROC_REF(on_mob_death))
 	nextstage = world.time + 1 MINUTES
 
+/mob/living/simple_animal/hostile/abnormality/black_sun/Destroy()
+	Refreshment(-1 * (stage*10))
+	pillars = null
+	UnregisterAll()
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/black_sun/Life()
 	. = ..()
 	if(nextstage < world.time && !LAZYLEN(pillars))
@@ -46,14 +52,11 @@
 	stage++
 	//Add 10 stats to everyone.
 	if(stage == 1)
-		affected_players = list()	//Clear the list, then fill it up
+		UnregisterAll()
 		for(var/mob/living/carbon/human/L in GLOB.player_list)
-			affected_players += L
+			RegisterMob(L)
 
-	for(var/mob/living/carbon/human/L in affected_players)
-		L.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, 10)
-		L.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, 10)
-		L.adjust_attribute_buff(JUSTICE_ATTRIBUTE, 10)
+	Refreshment(10)
 
 	switch(stage)
 		if(1)
@@ -79,11 +82,7 @@
 
 	to_chat(GLOB.clients,"<span class='colossus'>THE BLACK SUN HAS RISEN.</span>")
 	//Also remove your stats
-	var/removestats = stage*10
-	for(var/mob/living/carbon/human/L in affected_players)
-		L.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, -removestats)
-		L.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, -removestats)
-		L.adjust_attribute_buff(JUSTICE_ATTRIBUTE, -removestats)
+	Refreshment(-1 * (stage*10))
 	stage = 0
 	for(var/i = 0 to 2)
 		var/X = pick(GLOB.department_centers)
@@ -110,12 +109,30 @@
 
 /mob/living/simple_animal/hostile/abnormality/black_sun/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	to_chat(GLOB.clients, span_warning("The Black Sun fades from the sky. You are safe for now."))
-	var/removestats = stage*10
-	for(var/mob/living/carbon/human/L in affected_players)
-		L.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, -removestats)
-		L.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, -removestats)
-		L.adjust_attribute_buff(JUSTICE_ATTRIBUTE, -removestats)
+	Refreshment(-1 * (stage*10))
 	stage = 0
+
+/mob/living/simple_animal/hostile/abnormality/black_sun/proc/Refreshment(stat_change = 0)
+	for(var/mob/living/carbon/human/L in affected_players)
+		if(QDELETED(L))
+			UnregisterMob(affected_players)
+			continue
+		L.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, stat_change)
+		L.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, stat_change)
+		L.adjust_attribute_buff(JUSTICE_ATTRIBUTE, stat_change)
+
+/mob/living/simple_animal/hostile/abnormality/black_sun/proc/RegisterMob(mob/living/L)
+	RegisterSignal(L, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMob))
+	affected_players += L
+
+/mob/living/simple_animal/hostile/abnormality/black_sun/proc/UnregisterMob(mob/living/L)
+	UnregisterSignal(L, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING))
+	affected_players -= L
+
+/mob/living/simple_animal/hostile/abnormality/black_sun/proc/UnregisterAll()
+	for(var/mob/living/L in affected_players)
+		UnregisterMob(L)
+	affected_players.Cut()
 
 //Weather effect
 /datum/weather/bloody_water

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
@@ -309,11 +309,11 @@
 // Applies fear damage to everyone in range, copied from abnormalities
 /mob/living/simple_animal/hostile/mini_censored/proc/FearEffect()
 	for(var/mob/living/carbon/human/H in view(7, src))
-		if(H in breach_affected)
+		if(H.tag in breach_affected)
 			continue
 		if(HAS_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE))
 			continue
-		breach_affected += H
+		breach_affected += H.tag
 		H.adjustSanityLoss(20)
 		if(H.sanity_lost)
 			continue

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
@@ -125,7 +125,6 @@
 	var/jump_ready = FALSE
 	var/special_attack = null
 	var/special_attack_cooldown
-	var/list/been_hit = list()
 	var/list/time_stopped = list()
 
 /mob/living/simple_animal/hostile/abnormality/distortedform/Initialize()
@@ -323,7 +322,7 @@
 			to_chat(M, span_userdanger("Horrifying screams come from out of the darkness!"))
 			flash_color(M, flash_color = COLOR_ALMOST_BLACK, flash_time = 80)
 		if(M.stat != DEAD && ishuman(M) && M.ckey)
-			survivors += M
+			RegisterMob(M,survivors)
 	can_act = FALSE
 	addtimer(CALLBACK(src, PROC_REF(GoActive)), 50)
 	addtimer(CALLBACK(src, PROC_REF(BreachAudioFX)), 45)
@@ -369,6 +368,15 @@
 /mob/living/simple_animal/hostile/abnormality/distortedform/Destroy()
 	for(var/mob/living/L in time_stopped)
 		UnFreezeMob(L)
+	if(soundloop)
+		QDEL_NULL(soundloop)
+	if(current_effect)
+		QDEL_NULL(current_effect)
+	UnregisterAll(survivors)
+	meltdowns = null
+	connected_door = null
+	connected_panel = null
+	time_stopped = null
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/distortedform/Move()
@@ -834,8 +842,8 @@
 	// Close range gives you more time to dodge
 	var/hello_delay = (get_dist(src, target) <= 2) ? (1 SECONDS) : (0.5 SECONDS)
 	SLEEP_CHECK_DEATH(hello_delay)
-	var/list/been_hit = list()
 	var/broken = FALSE
+	var/list/hit_guys = list()
 	for(var/turf/T in getline(get_turf(src), target_turf))
 		if(T.density)
 			if(broken)
@@ -845,8 +853,8 @@
 			if(TF.density)
 				continue
 			new /obj/effect/temp_visual/smash_effect(TF)
-			been_hit = HurtInTurf(TF, been_hit, 120, RED_DAMAGE, null, null, TRUE, FALSE, TRUE, TRUE, attack_type = (ATTACK_TYPE_RANGED | ATTACK_TYPE_SPECIAL))
-	for(var/mob/living/L in been_hit)
+			hit_guys = HurtInTurf(TF, list(), 120, RED_DAMAGE, null, null, TRUE, FALSE, TRUE, TRUE, attack_type = (ATTACK_TYPE_RANGED | ATTACK_TYPE_SPECIAL))
+	for(var/mob/living/L in hit_guys)
 		if(L.health < 0)
 			L.gib()
 	playsound(get_turf(src), 'sound/abnormalities/nothingthere/hello_bam.ogg', 100, 0, 7)
@@ -1100,41 +1108,10 @@
 	SLEEP_CHECK_DEATH(5)
 	can_act = TRUE
 
+//I hate this abno since its just entirely copied unoptimized code.
 /mob/living/simple_animal/hostile/abnormality/distortedform/proc/SpearAttack(target)
 	special_attack_cooldown = world.time + 10 SECONDS
 	ourdash.Perform(target, src)
-
-/mob/living/simple_animal/hostile/abnormality/distortedform/proc/do_dash(move_dir, times_ran)
-	var/stop_charge = FALSE
-	if(times_ran >= 50)
-		stop_charge = TRUE
-	var/turf/T = get_step(get_turf(src), move_dir)
-	if(!T)
-		transform_cooldown += 1 SECONDS
-		can_act = TRUE
-		addtimer(CALLBACK(src, PROC_REF(ScytheAttack)), 5)
-		return
-	if(T.density)
-		stop_charge = TRUE
-	for(var/obj/structure/window/W in T.contents)
-		W.obj_destruction("holy spear")
-	for(var/obj/machinery/door/D in T.contents)
-		if(D.density)
-			addtimer(CALLBACK (D, TYPE_PROC_REF(/obj/machinery/door, open)))
-	if(stop_charge)
-		transform_cooldown += 1 SECONDS
-		can_act = TRUE
-		addtimer(CALLBACK(src, PROC_REF(ScytheAttack)), 5)
-		return
-	forceMove(T)
-	for(var/turf/TF in view(1, T))
-		new /obj/effect/temp_visual/small_smoke/halfsecond(TF)
-		var/list/new_hits = HurtInTurf(T, been_hit, 250, BLACK_DAMAGE, check_faction = TRUE, hurt_mechs = TRUE, hurt_structure = TRUE, attack_type = (ATTACK_TYPE_MELEE | ATTACK_TYPE_SPECIAL)) - been_hit
-		been_hit += new_hits
-		for(var/mob/living/L in new_hits)
-			visible_message(span_boldwarning("[src] runs through [L]!"), span_nicegreen("You impaled heretic [L]!"))
-			new /obj/effect/temp_visual/cleave(get_turf(L))
-	addtimer(CALLBACK(src, PROC_REF(do_dash), move_dir, (times_ran + 1)), 0.5) // SPEED
 
 //Red Queen
 /mob/living/simple_animal/hostile/abnormality/distortedform/proc/ChangeQueen()
@@ -1168,7 +1145,7 @@
 	// Close range gives you more time to dodge
 	var/slash_delay = (get_dist(src, target) <= 2) ? (1.5 SECONDS) : (1 SECONDS)
 	SLEEP_CHECK_DEATH(slash_delay)
-	var/list/been_hit = list()
+	var/list/hittins = list()
 	var/broken = FALSE
 	for(var/turf/T in getline(get_turf(src), target_turf))
 		if(T.density)
@@ -1179,8 +1156,8 @@
 			if(TF.density)
 				continue
 			new /obj/effect/temp_visual/smash_effect(TF)
-			been_hit = HurtInTurf(TF, been_hit, 80, RED_DAMAGE, null, null, TRUE, FALSE, TRUE, TRUE, attack_type = (ATTACK_TYPE_MELEE | ATTACK_TYPE_SPECIAL))
-	for(var/mob/living/L in been_hit)
+			hittins = HurtInTurf(TF, hittins, 80, RED_DAMAGE, null, null, TRUE, FALSE, TRUE, TRUE, attack_type = (ATTACK_TYPE_MELEE | ATTACK_TYPE_SPECIAL))
+	for(var/mob/living/L in hittins)
 		if(L.health < 0)
 			if(!ishuman(L))
 				L.gib()
@@ -1423,7 +1400,7 @@
 	target.add_overlay(icon('icons/effects/effects.dmi', "chronofield"))
 	addtimer(CALLBACK(target, TYPE_PROC_REF(/atom, cut_overlay), \
 							icon('icons/effects/effects.dmi', "chronofield")), 40)
-	time_stopped += target
+	RegisterMob(target,time_stopped)
 	addtimer(CALLBACK(src, PROC_REF(FreezeMob), target), 40)
 
 /mob/living/simple_animal/hostile/abnormality/distortedform/proc/FreezeMob(mob/living/H)
@@ -1447,7 +1424,7 @@
 	H.AdjustStun(-20, ignore_canstun = TRUE)
 	REMOVE_TRAIT(H, TRAIT_MUTE, TIMESTOP_TRAIT)
 	H.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY)
-	time_stopped -= H
+	UnregisterMob(H,time_stopped)
 
 
 //You're Bald...
@@ -1525,10 +1502,10 @@
 
 /mob/living/simple_animal/hostile/abnormality/distortedform/proc/CalanderAttack(faction_check = "hostile")
 	icon_state = "doomsday_universe"
-	been_hit = list()
 	playsound(src, 'sound/abnormalities/doomsdaycalendar/Doomsday_Universe.ogg', 50, FALSE, 50)
 	var/turf/target_c = get_turf(src)
 	var/list/turf_list = list()
+	var/got_hit = list()
 	for(var/i = 1 to 48)
 		turf_list = spiral_range_turfs(i, target_c) - spiral_range_turfs(i-1, target_c)
 		for(var/turf/open/T in turf_list)
@@ -1536,13 +1513,14 @@
 			S.color = "#003FFF"
 			for(var/mob/living/L in T)
 				new /obj/effect/temp_visual/dir_setting/cult/phase(T, L.dir)
-				addtimer(CALLBACK(src, PROC_REF(CalanderAttackHit), L, i, faction_check))
+				if(L in got_hit)
+					continue
+				got_hit += L
+				//Why is it a callback, why is it a callback? -IP
+				addtimer(CALLBACK(src, PROC_REF(CalanderAttackHit), L, i, faction_check, got_hit))
 		SLEEP_CHECK_DEATH(1.5)
 
 /mob/living/simple_animal/hostile/abnormality/distortedform/proc/CalanderAttackHit(mob/living/L, attack_range = 1, faction_check = "hostile")
-	if(L in been_hit)
-		return
-	been_hit += L
 	if(!(faction_check in L.faction))
 		playsound(L.loc, 'sound/effects/burn.ogg', 50 - attack_range, TRUE, -1)
 		var/dealt_damage = max(5, 75 - (attack_range))
@@ -1815,7 +1793,7 @@
 		new /obj/effect/temp_visual/small_smoke/halfsecond(T)
 		for(var/mob/living/carbon/human/H in HurtInTurf(T, list(), 100, RED_DAMAGE, null, null, TRUE, FALSE, TRUE, FALSE, TRUE, TRUE, attack_type = (ATTACK_TYPE_MELEE | ATTACK_TYPE_SPECIAL)))
 			if(H.health <= 0)
-				H.gib()
+				H.gib(TRUE,TRUE,TRUE)
 
 /mob/living/simple_animal/hostile/abnormality/distortedform/proc/MediumJump(turf/target_turf)
 	name = "grant us love"
@@ -1835,7 +1813,7 @@
 		new /obj/effect/temp_visual/small_smoke/halfsecond(T)
 		for(var/mob/living/carbon/human/H in HurtInTurf(T, list(), 150, BLACK_DAMAGE, null, null, TRUE, FALSE, TRUE, FALSE, TRUE, TRUE, attack_type = (ATTACK_TYPE_MELEE | ATTACK_TYPE_SPECIAL)))
 			if(H.health <= 0)
-				H.gib()
+				H.gib(TRUE,TRUE,TRUE)
 
 /mob/living/simple_animal/hostile/abnormality/distortedform/proc/HeavyJump(turf/target_turf)
 	name = "Baba Yaga"
@@ -1867,8 +1845,7 @@
 		else
 			L.deal_damage(600 - ((dist > 2 ? dist : 0 )* 75), RED_DAMAGE, src, attack_type = (ATTACK_TYPE_MELEE | ATTACK_TYPE_SPECIAL)) //0-600 damage scaling on distance, we don't want it oneshotting mobs
 		if(L.health < 0)
-			L.gib()
-
+			L.gib(TRUE, TRUE, TRUE)
 
 //Miscellaneous random sprites - does nothing. Very low chance. This where you put the silly meme stuff.
 /mob/living/simple_animal/hostile/abnormality/distortedform/proc/Pause()
@@ -1885,6 +1862,23 @@
 /mob/living/simple_animal/hostile/abnormality/distortedform/proc/PickForm()
 	name = pick("bill", "cube", "fairies", "shadow")
 	icon_state = name
+
+/mob/living/simple_animal/hostile/abnormality/distortedform/proc/RegisterMob(mob/living/L, list/record)
+	RegisterSignal(L, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING), PROC_REF(ForceUnregisterMob))
+	record += L
+
+/mob/living/simple_animal/hostile/abnormality/distortedform/proc/UnregisterMob(mob/living/L, list/record)
+	record -= L
+	UnregisterSignal(L, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING))
+
+/mob/living/simple_animal/hostile/abnormality/distortedform/proc/ForceUnregisterMob(mob/living/L)
+	UnregisterSignal(L, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING))
+	time_stopped -= L
+
+/mob/living/simple_animal/hostile/abnormality/distortedform/proc/UnregisterAll(list/emptying)
+	for(var/mob/living/L in emptying)
+		UnregisterMob(L, emptying)
+	emptying.Cut()
 
 //Misc Objects
 /obj/effect/temp_visual/jumpwarning
@@ -1960,96 +1954,19 @@
 	duration = 40
 	layer = RIPPLE_LAYER	//We want this HIGH. SUPER HIGH. We want it so that you can absolutely, guaranteed, see exactly what is about to hit you.
 	var/damage = 45 //Pale Damage
-	var/mob/living/caster
+	var/datum/weakref/castor_memory
 	var/slash_width = 2
 	var/slash_length = 5
 
 /obj/effect/temp_visual/remnant_of_time/Initialize(mapload, new_caster)
 	. = ..()
 	if(new_caster)
-		caster = new_caster
+		castor_memory = WEAKREF(new_caster)
 	addtimer(CALLBACK(src, PROC_REF(explode)), 2 SECONDS)
 
 /obj/effect/temp_visual/remnant_of_time/proc/explode()
-	var/turf/source_turf = get_turf(src)
-	var/turf/area_of_effect = list()
-	var/turf/middle_line = list()
-	switch(dir)
-		if(EAST)
-			middle_line = getline(source_turf, get_ranged_target_turf(source_turf, EAST, slash_length))
-			for(var/turf/T in middle_line)
-				if(T.density)
-					break
-				for(var/turf/Y in getline(T, get_ranged_target_turf(T, NORTH, slash_width)))
-					if (Y.density)
-						break
-					if (Y in area_of_effect)
-						continue
-					area_of_effect += Y
-				for(var/turf/U in getline(T, get_ranged_target_turf(T, SOUTH, slash_width)))
-					if (U.density)
-						break
-					if (U in area_of_effect)
-						continue
-					area_of_effect += U
-		if(WEST)
-			middle_line = getline(source_turf, get_ranged_target_turf(source_turf, WEST, slash_length))
-			for(var/turf/T in middle_line)
-				if(T.density)
-					break
-				for(var/turf/Y in getline(T, get_ranged_target_turf(T, NORTH, slash_width)))
-					if (Y.density)
-						break
-					if (Y in area_of_effect)
-						continue
-					area_of_effect += Y
-				for(var/turf/U in getline(T, get_ranged_target_turf(T, SOUTH, slash_width)))
-					if (U.density)
-						break
-					if (U in area_of_effect)
-						continue
-					area_of_effect += U
-		if(SOUTH)
-			middle_line = getline(source_turf, get_ranged_target_turf(source_turf, SOUTH, slash_length))
-			for(var/turf/T in middle_line)
-				if(T.density)
-					break
-				for(var/turf/Y in getline(T, get_ranged_target_turf(T, EAST, slash_width)))
-					if (Y.density)
-						break
-					if (Y in area_of_effect)
-						continue
-					area_of_effect += Y
-				for(var/turf/U in getline(T, get_ranged_target_turf(T, WEST, slash_width)))
-					if (U.density)
-						break
-					if (U in area_of_effect)
-						continue
-					area_of_effect += U
-		if(NORTH)
-			middle_line = getline(source_turf, get_ranged_target_turf(source_turf, NORTH, slash_length))
-			for(var/turf/T in middle_line)
-				if(T.density)
-					break
-				for(var/turf/Y in getline(T, get_ranged_target_turf(T, EAST, slash_width)))
-					if (Y.density)
-						break
-					if (Y in area_of_effect)
-						continue
-					area_of_effect += Y
-				for(var/turf/U in getline(T, get_ranged_target_turf(T, WEST, slash_width)))
-					if (U.density)
-						break
-					if (U in area_of_effect)
-						continue
-					area_of_effect += U
-		else
-			for(var/turf/T in view(1, src))
-				if (T.density)
-					break
-				if (T in area_of_effect)
-					continue
-				area_of_effect |= T
+	var/turf/area_of_effect = FormulateExplode(dir)
+	var/mob/living/caster = castor_memory?.resolve()
 	if (!LAZYLEN(area_of_effect))
 		return
 	playsound(get_turf(src), 'sound/weapons/fixer/generic/sheath2.ogg', 75, 0, 5)
@@ -2063,3 +1980,40 @@
 			if(L == caster)
 				continue
 			caster.HurtInTurf(T, list(), damage, PALE_DAMAGE, check_faction = TRUE, hurt_mechs = TRUE, attack_type = (ATTACK_TYPE_MELEE | ATTACK_TYPE_SPECIAL))
+
+/obj/effect/temp_visual/remnant_of_time/proc/FormulateExplode(dir_to_target)
+	. = list()
+	var/turf/source_turf = get_turf(src)
+	var/list/middle_line = list()
+	var/list/directional_list  = list(NORTH,SOUTH,EAST,WEST)
+	//Default is North/South
+	var/right_dir = EAST
+	var/left_dir = WEST
+	if(dir_to_target ==  EAST || dir_to_target == WEST)
+		right_dir =  NORTH
+		left_dir = SOUTH
+
+	if(dir_to_target in directional_list)
+		middle_line = getline(source_turf, get_ranged_target_turf(source_turf, NORTH, slash_length))
+		for(var/turf/T in middle_line)
+			if(T.density)
+				break
+			for(var/turf/Y in getline(T, get_ranged_target_turf(T, right_dir, slash_width)))
+				if (Y.density)
+					break
+				if (Y in .)
+					continue
+				. += Y
+			for(var/turf/U in getline(T, get_ranged_target_turf(T, left_dir, slash_width)))
+				if (U.density)
+					break
+				if (U in .)
+					continue
+				. += U
+	else
+		for(var/turf/T in view(1, src))
+			if (T.density)
+				break
+			if (T in .)
+				continue
+			. |= T

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/last_shot.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/last_shot.dm
@@ -64,6 +64,11 @@ GLOBAL_LIST_EMPTY(meat_list)
 /mob/living/simple_animal/hostile/abnormality/last_shot/Move()
 	return FALSE
 
+/mob/living/simple_animal/hostile/abnormality/last_shot/Destroy()
+	UnregisterAll()
+	meat = null
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/last_shot/BreachEffect(mob/living/carbon/human/user, breach_type)
 	if(breach_type == BREACH_MINING)
 		return ..()
@@ -103,7 +108,6 @@ GLOBAL_LIST_EMPTY(meat_list)
 	datum_reference.qliphoth_change(-1)
 	return
 
-
 /mob/living/simple_animal/hostile/abnormality/last_shot/Life()
 	. = ..()
 	if(!.)
@@ -118,19 +122,19 @@ GLOBAL_LIST_EMPTY(meat_list)
 	for(var/i=spawn_number, i>=1, i--)	//This counts down. - Spawn meat guards
 		if(prob(gunnerchance))
 			var/mob/living/simple_animal/hostile/meatblob/gunner/G = new(get_turf(src))
-			gremlins+=G
+			RegisterMob(G)
 			continue
 		if(prob(gunnerchance))
 			var/mob/living/simple_animal/hostile/meatblob/gunner/sniper/S = new(get_turf(src))
-			gremlins+=S
+			RegisterMob(S)
 			continue
 		if(prob(gunnerchance))
 			var/mob/living/simple_animal/hostile/meatblob/gunner/shotgun/SG = new(get_turf(src))
-			gremlins+=SG
+			RegisterMob(SG)
 			continue
 		else
 			var/mob/living/simple_animal/hostile/meatblob/V = new(get_turf(src))
-			gremlins+=V
+			RegisterMob(V)
 
 	for(var/turf/open/L in view(7, src)) //Spawn barricades on meat
 		if((get_dist(src, L) % 2 != 1))
@@ -165,14 +169,24 @@ GLOBAL_LIST_EMPTY(meat_list)
 	meat_reach = clamp(meat_reach + 1, 0, 10) //MEAT!!!!!
 
 /mob/living/simple_animal/hostile/abnormality/last_shot/death()
-	for(var/V in gremlins)
-		QDEL_NULL(V)
-		gremlins-=V
-
 	for(var/Y in GLOB.meat_list)
 		QDEL_NULL(Y)
 		GLOB.meat_list-=Y
-	..()
+	return ..()
+
+/mob/living/simple_animal/hostile/abnormality/last_shot/proc/RegisterMob(mob/living/L)
+	RegisterSignal(L, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMob))
+	gremlins += L
+
+/mob/living/simple_animal/hostile/abnormality/last_shot/proc/UnregisterMob(mob/living/L)
+	UnregisterSignal(L, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING))
+	gremlins -= L
+
+/mob/living/simple_animal/hostile/abnormality/last_shot/proc/UnregisterAll()
+	for(var/mob/living/L in gremlins)
+		UnregisterMob(L)
+		qdel(L)
+	gremlins.Cut()
 
 //////////////
 //STRUCTURES//
@@ -317,7 +331,7 @@ GLOBAL_LIST_EMPTY(meat_list)
 	var/reload_sound = 'sound/weapons/gun/general/bolt_rack.ogg'
 
 /mob/living/simple_animal/hostile/meatblob/gunner/Initialize(mapload)
-	..()
+	. = ..()
 	var/units_to_add = list(
 		/mob/living/simple_animal/hostile/meatblob = 1,
 		)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
@@ -80,6 +80,10 @@
 		|Stay Together...|: When you click on a tile outside your melee range, You will fire a slime projectile towards that tile. The projectile will inflict the target with 'SLIMED' and deal BLACK damage.\
 		If the projectile hits a dead body, it will convert it into a slime pawn.</b>")
 
+/mob/living/simple_animal/hostile/abnormality/melting_love/Destroy()
+	UnregisterMob()
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/melting_love/death(gibbed)
 	density = FALSE
 	animate(src, alpha = 0, time = (5 SECONDS))
@@ -196,7 +200,7 @@
 	if(GODMODE in user.status_flags)
 		return
 	if(!gifted_human && istype(user) && work_type != ABNORMALITY_WORK_REPRESSION && user.stat != DEAD && (status_flags & GODMODE))
-		gifted_human = user
+		RegisterMob(user)
 		RegisterSignal(gifted_human, COMSIG_WORK_COMPLETED, PROC_REF(GiftedAnger))
 		user.apply_status_effect(STATUS_EFFECT_MELTYLOVE)
 		to_chat(user, span_nicegreen("You feel like you received a gift..."))
@@ -218,6 +222,7 @@
 	C.emote("scream")
 	C.deal_damage(800, BLACK_DAMAGE, src, flags = (DAMAGE_FORCED), attack_type = (ATTACK_TYPE_STATUS))
 	C.remove_status_effect(STATUS_EFFECT_MELTYLOVE)
+
 
 /mob/living/simple_animal/hostile/abnormality/melting_love/proc/UnregisterGiftedSignals(mob/living/carbon/human/user)
 	if(user)
@@ -256,10 +261,18 @@
 	desc += " It looks angry."
 
 /mob/living/simple_animal/hostile/abnormality/melting_love/proc/SpawnBigSlime(mob/living/simple_animal/hostile/slime/big/S)
-	gifted_human = null
+	UnregisterMob()
 	datum_reference.qliphoth_change(-9)
 	if(S)
 		RegisterSignal(S, COMSIG_LIVING_DEATH, PROC_REF(SlimeDeath))
+
+/mob/living/simple_animal/hostile/abnormality/melting_love/proc/RegisterMob(mob/living/L)
+	RegisterSignal(L, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMob))
+	gifted_human = L
+
+/mob/living/simple_animal/hostile/abnormality/melting_love/proc/UnregisterMob()
+	UnregisterSignal(gifted_human, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING))
+	gifted_human = null
 
 /* Slimes (HE) */
 /mob/living/simple_animal/hostile/slime
@@ -355,11 +368,6 @@
 	new /mob/living/simple_animal/hostile/slime(get_turf(H))
 	H.gib(FALSE, TRUE, TRUE)
 	return TRUE
-
-//3 monsters including parasite tree sapling and naked nest use this proc i might make it part of the root in the future -IP
-/mob/living/simple_animal/hostile/slime/proc/NestedItems(mob/living/simple_animal/hostile/nest, obj/item/nested_item)
-	if(nested_item)
-		nested_item.forceMove(nest)
 
 /* Big Slimes (WAW) */
 /mob/living/simple_animal/hostile/slime/big

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm
@@ -57,7 +57,8 @@
 	//Contained Variables
 	var/reflect_timer
 	var/shelled = FALSE
-	var/mob/living/carbon/human/chosen = null
+	var/datum/weakref/chosen_memory
+	can_act = TRUE
 	var/current_stage = 1
 	var/next_transform = null
 	var/list/longhair = list( // EXTREMELY TEMPORARY but easier to do than figuring out complex image manipulation
@@ -81,7 +82,7 @@
 	var/grab_windup_time = 16
 	var/grab_damage = 200 //The amount dealt when grabbing someone, twice if they aren't grabbed for whatever reason
 	var/strangle_damage = 50 //dealt over time to whoever is grabbed
-	var/mob/living/carbon/human/grab_victim = null
+	var/datum/weakref/grab_memory
 	var/release_threshold = 500 //Total raw damage needed to break a player out of a grab (from any source)
 	var/release_damage = 0
 	var/last_heal_time = 0
@@ -95,7 +96,7 @@
 	var/grab_damage_oberon = 140
 	var/strangle_damage_oberon = 35
 	var/melee_damage_oberon = 15
-	var/mob/living/simple_animal/hostile/abnormality/titania/abno_host
+	var/datum/weakref/host_memory
 	var/obj/effect/titania_aura/fairy_aura
 
 	//PLAYABLES ATTACKS
@@ -134,6 +135,11 @@
 	toggle_message = span_colossus("You will now shoot out tendrils.")
 	button_icon_toggle_deactivated = "nt_toggle0"
 
+/mob/living/simple_animal/hostile/abnormality/nobody_is/Destroy()
+	QDEL_NULL(fairy_aura)
+	QDEL_NULL(headicon)
+	return ..()
+
 //Spawning
 /mob/living/simple_animal/hostile/abnormality/nobody_is/PostSpawn()
 	. = ..()
@@ -154,6 +160,7 @@
 	reflect_timer = addtimer(CALLBACK(src, PROC_REF(ReflectionCheck)), 3 MINUTES, TIMER_STOPPABLE)
 
 /mob/living/simple_animal/hostile/abnormality/nobody_is/proc/ChangeReflection()
+	var/mob/living/carbon/chosen = chosen_memory ? chosen_memory.resolve() : null
 	var/list/potentialmarked = list()
 	for(var/mob/living/carbon/human/L in GLOB.player_list)
 		if(L.stat >= HARD_CRIT || L.sanity_lost || z != L.z) // Dead or in hard crit, insane, or on a different Z level.
@@ -173,7 +180,8 @@
 
 /mob/living/simple_animal/hostile/abnormality/nobody_is/proc/ReflectChosen(mob/living/carbon/human/reflect_target)
 	CheckMirrorIcon()
-	chosen = reflect_target
+	chosen_memory = WEAKREF(reflect_target)
+	var/mob/living/carbon/human/chosen = chosen_memory ? chosen_memory.resolve() : null
 	if(!chosen || !IsContained())
 		return
 	var/obj/item/bodypart/HD = chosen.get_bodypart("head")
@@ -225,7 +233,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/nobody_is/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	. = ..()
-	if(user == chosen) //It makes more sense to just check for a disguise, but this is called before PostWorkEffect()
+	if(user == chosen_memory ? chosen_memory.resolve() : null) //It makes more sense to just check for a disguise, but this is called before PostWorkEffect()
 		return
 	datum_reference.qliphoth_change(-1)
 
@@ -290,6 +298,7 @@
 	. = ..()
 	if(. < 10)
 		return
+	var/mob/living/carbon/human/grab_victim = grab_memory ? grab_memory.resolve() : null
 	if(grab_victim)
 		release_damage = clamp(release_damage + ., 0, release_threshold)
 		if(release_damage >= release_threshold)
@@ -307,6 +316,7 @@
 	. = ..()
 	if(!.)
 		return
+	var/mob/living/simple_animal/hostile/abnormality/titania/abno_host = host_memory ? host_memory.resolve() : null
 	if(!oberon_mode)
 		if((last_heal_time + 1 SECONDS) < world.time) // One Second between heals guaranteed
 			var/heal_amount = ((world.time - last_heal_time)/10)*heal_percent_per_second*maxHealth
@@ -375,7 +385,7 @@
 		Oberon_Fusion(T)
 
 /mob/living/simple_animal/hostile/abnormality/nobody_is/proc/Oberon_Fusion(mob/living/simple_animal/hostile/abnormality/titania/T)
-	abno_host = T
+	host_memory = WEAKREF(T)
 	T.pass_flags = PASSTABLE | PASSMOB
 	T.is_flying_animal = FALSE
 	T.density = FALSE
@@ -422,6 +432,8 @@
 		fairy_aura.dir = dir
 
 /mob/living/simple_animal/hostile/abnormality/nobody_is/death(gibbed)
+	var/mob/living/carbon/human/grab_victim = grab_memory ? grab_memory.resolve() : null
+	var/mob/living/simple_animal/hostile/abnormality/titania/abno_host = host_memory ? host_memory.resolve() : null
 	if(headicon) //Gets rid of the reflection if they died in containtment for any reason
 		qdel(headicon)
 		headicon = null
@@ -497,6 +509,7 @@
 	grab_cooldown = world.time + grab_cooldown_time
 	can_act = FALSE
 	playsound(get_turf(src), 'sound/abnormalities/woodsman/woodsman_prepare.ogg', 75, 0, 5)
+	var/mob/living/carbon/human/grab_victim = grab_memory ? grab_memory.resolve() : null
 	if(shelled)
 		add_overlay(icon('icons/effects/effects.dmi', "lovetown_shapes"))
 	else
@@ -519,9 +532,9 @@
 					if(faction_check_mob(H, FALSE) || H.z != z)
 						continue
 					if(!shelled) //If we don't have a shell, we can't grab just anyone. Only the chosen one.
-						if(H != chosen)
+						if(H != chosen_memory ? chosen_memory.resolve() : null)
 							continue
-					grab_victim = H
+					grab_memory = WEAKREF(H)
 					Strangle()
 			else //deal the damage twice if we already have someone grabbed
 				L.deal_damage(grab_damage, BLACK_DAMAGE, src, attack_type = (ATTACK_TYPE_MELEE | ATTACK_TYPE_SPECIAL))
@@ -538,6 +551,7 @@
 /mob/living/simple_animal/hostile/abnormality/nobody_is/proc/Strangle()
 	set waitfor = FALSE
 	release_damage = 0
+	var/mob/living/carbon/human/grab_victim = grab_memory ? grab_memory.resolve() : null
 	grab_victim.Immobilize(10)
 	if(grab_victim.sanity_lost)
 		grab_victim.Stun(10) //Immobilize does not stop AI controllers from moving, for some reason.
@@ -553,6 +567,7 @@
 	StrangleHit(1)
 
 /mob/living/simple_animal/hostile/abnormality/nobody_is/proc/StrangleHit(count)
+	var/mob/living/carbon/human/grab_victim = grab_memory ? grab_memory.resolve() : null
 	if(!grab_victim)
 		ReleaseGrab()
 		return
@@ -588,10 +603,11 @@
 	StrangleHit(count)
 
 /mob/living/simple_animal/hostile/abnormality/nobody_is/proc/ReleaseGrab()
+	var/mob/living/carbon/human/grab_victim = grab_memory ? grab_memory.resolve() : null
 	if(grab_victim)
 		animate(grab_victim, pixel_y = 0, time = 5)
 		grab_victim.pixel_y = 0
-	grab_victim = null
+	grab_memory = null
 	can_act = TRUE
 
 /mob/living/simple_animal/hostile/abnormality/nobody_is/OpenFire()
@@ -611,7 +627,7 @@
 /mob/living/simple_animal/hostile/abnormality/nobody_is/proc/Finisher(mob/living/carbon/human/H) //return TRUE to prevent attacking, as attacking causes runtimes if the target is gibbed.
 	if(shelled)
 		return FALSE //We don't want it repeatedly turning into different people
-	else if(H == chosen) // Uh oh
+	else if(H == chosen_memory ? chosen_memory.resolve() : null) // Uh oh
 		disguise_as(H)
 		return TRUE
 	return FALSE
@@ -649,6 +665,7 @@
 /mob/living/simple_animal/hostile/abnormality/nobody_is/patrol_select() //Hunt down the chosen one
 	if(shelled) // We don't need a chosen anymore, or any special pathfinding behavior
 		return ..()
+	var/mob/living/carbon/chosen = chosen_memory ? chosen_memory.resolve() : null
 	if(chosen) //YOU'RE MINE
 		SEND_SIGNAL(src, COMSIG_PATROL_START, src, get_turf(chosen)) //Overrides the usual proc to target a specific tile
 		SEND_GLOBAL_SIGNAL(src, COMSIG_GLOB_PATROL_START, src, get_turf(chosen))
@@ -665,7 +682,7 @@
 			continue
 		if(ishuman(L))
 			var/mob/living/carbon/human/H = L
-			if(H == chosen)
+			if(H == chosen_memory ? chosen_memory.resolve() : null)
 				return H //YOU'RE MINE
 		if(L.health <= 0) //ignore the dead
 			continue
@@ -751,7 +768,7 @@
 	if(!ishuman(speaker))
 		return
 	var/mob/living/carbon/human/talker = speaker
-	if(talker != chosen) // Only copies the person it has chosen
+	if(talker != chosen_memory ? chosen_memory.resolve() : null) // Only copies the person it has chosen
 		return
 	if((findtext(message, "uwu") || findtext(message, "owo") || findtext(message, "daddy") || findtext(message, "what the dog doin")) && !isnull(talker) && talker.stat != DEAD)
 		if(status_flags & GODMODE) //if contained
@@ -770,11 +787,13 @@
 //Allow for titana's laws to exist for nobody is I think
 /mob/living/simple_animal/hostile/abnormality/nobody_is/bullet_act(obj/projectile/Proj)
 	if(oberon_mode)
+		var/mob/living/simple_animal/hostile/abnormality/titania/abno_host = host_memory ? host_memory.resolve() : null
 		abno_host.bullet_act(Proj)
 	..()
 
 /mob/living/simple_animal/hostile/abnormality/nobody_is/attacked_by(obj/item/I, mob/living/user)
 	if(oberon_mode)
+		var/mob/living/simple_animal/hostile/abnormality/titania/abno_host = host_memory ? host_memory.resolve() : null
 		abno_host.attacked_by(I, user)
 	..()
 
@@ -812,6 +831,7 @@
 		ZeroQliphoth()
 
 /mob/living/simple_animal/hostile/abnormality/nobody_is/proc/QuickOberonSpawn()
+	var/mob/living/carbon/chosen = chosen_memory ? chosen_memory.resolve() : null
 	if(!chosen || oberon_mode)//makes sure it doesn't continue if its already oberon or if there's no chosen.)
 		return
 	TransformNoKill(chosen)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
@@ -63,7 +63,7 @@
 	)
 
 	var/shelled
-	var/mob/living/disguise_ref
+	var/datum/weakref/disguise_weak
 	var/saved_appearance
 	var/current_stage = 1
 	var/next_transform = null
@@ -89,7 +89,7 @@
 	var/heard_words = list()
 	var/listen_chance = 10 // 20 for testing, 10 for base
 	var/utterance = 5 // 10 for testing, 5 for base
-	var/worker = null
+	var/datum/weakref/worker_memory
 
 	//PLAYABLES ATTACKS
 	attack_action_types = list(
@@ -212,6 +212,7 @@
 			speak_list = heard_words[speak_list]
 			say(pick(speak_list))
 		return
+	var/mob/living/disguise_ref = disguise_weak ? disguise_weak.resolve() : null
 	if(.)
 		if((shelled) && LAZYLEN(heard_words[disguise_ref]) && prob(utterance*2))
 			speak_list = heard_words[disguise_ref]
@@ -249,6 +250,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/nothing_there/Hear(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods)
 	. = ..()
+	var/mob/living/worker = worker_memory ? worker_memory.resolve() : null
 	if(speaker == worker) // More likely to pick things up from those working on it
 		listen_chance *= 2
 	if(prob(listen_chance) && istype(speaker, /mob/living/carbon/human))
@@ -277,7 +279,7 @@
 	to_chat(M, span_userdanger("Oh no..."))
 	shelled = TRUE
 	CopyHumanAppearance(M) // This is the same proc used by Nobody Is for stealing skin. Should be less buggy than copying appearance var.
-	disguise_ref = M // We keep a reference to the "shell" for utterances and the like, but it's not absolutely necessary in case they gib somehow
+	disguise_weak = WEAKREF(M) // We keep a reference to the "shell" for utterances and the like, but it's not absolutely necessary in case they gib somehow
 	M.death()
 	M.forceMove(src) // Hide them
 	disguiseloop.start()
@@ -286,6 +288,7 @@
 /mob/living/simple_animal/hostile/abnormality/nothing_there/proc/drop_disguise()
 	if(!shelled)
 		return
+	var/mob/living/disguise_ref = disguise_weak ? disguise_weak.resolve() : null
 	next_transform = world.time + rand(30 SECONDS, 40 SECONDS)
 	ChangeMoveToDelayBy(1.5)
 	appearance = saved_appearance
@@ -383,7 +386,7 @@
 /mob/living/simple_animal/hostile/abnormality/nothing_there/AttemptWork(mob/living/carbon/human/user, work_type)
 	if(shelled)
 		return FALSE
-	worker = user
+	worker_memory = WEAKREF(user)
 	var/growl_prob = (work_type in list(ABNORMALITY_WORK_REPRESSION, ABNORMALITY_WORK_INSIGHT)) ? 100 : 25
 	if(prob(growl_prob)) // Spooky
 		playsound(get_turf(src), 'sound/abnormalities/nothingthere/growl.ogg', 25, 0)
@@ -397,7 +400,7 @@
 	return adjusted_chance
 
 /mob/living/simple_animal/hostile/abnormality/nothing_there/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
-	worker = null
+	worker_memory = null
 	// Award achievement for surviving non-instinct/attachment work
 	if(work_type != ABNORMALITY_WORK_INSTINCT && work_type != ABNORMALITY_WORK_ATTACHMENT && user.stat != DEAD)
 		user.client?.give_award(/datum/award/achievement/abno/nothing_survivor, user)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/seasons.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/seasons.dm
@@ -326,6 +326,7 @@
 	EndWeather()
 	for(var/obj/effect/season_turf/newturf in spawned_turfs)
 		newturf.DoDelete()
+	spawned_turfs = null
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/seasons/BreachEffect(mob/living/carbon/human/user, breach_type)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
@@ -41,7 +41,7 @@
 			... <br>that's all."),
 	)
 
-	var/chosen
+	var/datum/weakref/chosen_memory
 	var/list/sacrificed = list()
 	var/list/heretics = list()
 	var/meltdown_cooldown_time = 15 MINUTES
@@ -54,8 +54,17 @@
 	. = ..()
 	meltdown_cooldown = world.time + meltdown_cooldown_time
 
+/mob/living/simple_animal/hostile/abnormality/staining_rose/Destroy()
+	var/list/signal_list = sacrificed + heretics
+	for(var/mob/living/L in signal_list)
+		ForceUnregisterMob(L)
+	sacrificed = null
+	heretics = null
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/staining_rose/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
 	safe = TRUE
+	var/mob/living/chosen = chosen_memory ? chosen_memory.resolve() : null
 	if (chosen == null)
 		chosen = user
 		user.visible_message(span_warning("You are now Staining Rose's Chosen."))
@@ -66,7 +75,7 @@
 		user.apply_status_effect(STATUS_EFFECT_SCHISMATIC)
 		user.client?.give_award(/datum/award/achievement/abno/schismatic, user)
 		if(!(user in heretics))
-			heretics += user
+			RegisterMob(user, heretics)
 		pissed()
 	else
 		user.visible_message(span_warning("Staining Rose is content."))
@@ -74,7 +83,7 @@
 	if(get_attribute_level(user, JUSTICE_ATTRIBUTE) < 100)
 		user.apply_status_effect(STATUS_EFFECT_SACRIFICE)
 		if(!(user in sacrificed))
-			sacrificed += user
+			RegisterMob(user, sacrificed)
 			user.visible_message(span_warning("Staining Rose drains your strength, and it is born anew."))
 			meltdown_cooldown = world.time + meltdown_cooldown_time	//There we go!
 		pissed()
@@ -84,6 +93,7 @@
 	if(meltdown_cooldown < world.time && !datum_reference.working)
 		meltdown_cooldown = world.time + meltdown_cooldown_time
 		sound_to_playing_players('sound/abnormalities/rose/meltdown.ogg')	//Church bells ringing, whether it happens or not.
+		var/mob/living/chosen = chosen_memory ? chosen_memory.resolve() : null
 		if(chosen)
 			to_chat(chosen, span_boldwarning("Staining Rose requires you to resonate with it again!"))
 		if(!safe)
@@ -102,13 +112,15 @@
 //Death and Meltdown
 /mob/living/simple_animal/hostile/abnormality/staining_rose/ZeroQliphoth(mob/living/carbon/human/user)
 	SSweather.run_weather(/datum/weather/petals)
-	chosen = null 	//You breached, now pick a new person to work on you
+	chosen_memory = null 	//You breached, now pick a new person to work on you
 	icon_state = "rose"
 	//Clean up the sacrificed and schismatic
 	for(var/mob/living/carbon/human/G in sacrificed)
+		ForceUnregisterMob(G)
 		G.remove_status_effect(STATUS_EFFECT_SACRIFICE)
-	for(var/mob/living/carbon/human/G in heretics)
-		G.remove_status_effect(STATUS_EFFECT_SCHISMATIC)
+	for(var/mob/living/carbon/human/H in heretics)
+		ForceUnregisterMob(H)
+		H.remove_status_effect(STATUS_EFFECT_SCHISMATIC)
 	death()	//It wilts away.
 
 /mob/living/simple_animal/hostile/abnormality/staining_rose/death(gibbed)
@@ -116,6 +128,20 @@
 	animate(src, alpha = 0, time = 10 SECONDS)
 	QDEL_IN(src, 10 SECONDS)
 	..()
+
+/mob/living/simple_animal/hostile/abnormality/staining_rose/proc/RegisterMob(mob/living/L, list/record)
+	RegisterSignal(L, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING), PROC_REF(ForceUnregisterMob))
+	record += L
+
+/mob/living/simple_animal/hostile/abnormality/staining_rose/proc/UnregisterMob(mob/living/L, list/record)
+	record -= L
+	if(!(L in sacrificed) && !(L in heretics))
+		UnregisterSignal(L, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING))
+
+/mob/living/simple_animal/hostile/abnormality/staining_rose/proc/ForceUnregisterMob(mob/living/L)
+	UnregisterSignal(L, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING))
+	sacrificed -= L
+	heretics -= L
 
 //Weather and such
 /datum/weather/petals

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
@@ -63,8 +63,9 @@
 	var/fairy_spawn_limit = 30 // Oh boy, what can go wrong?
 	//Fairy spawn limit only matters for the spawn loop, players she kills and spawned via the law don't count
 	var/list/spawned_mobs = list()
+	//Tags of agents who worked on titania
 	var/list/worked = list()
-	var/mob/living/carbon/human/nemesis			//Who is her nemesis?
+	var/datum/weakref/nemesis_memory //Who is her nemesis?
 	//The nemesis is referred to as Oberon in the rest of the comments.
 
 	//Laws
@@ -81,6 +82,10 @@
 	. = ..()
 	if(fused) // So you can't just spoon her to death while in nobody is.
 		adjustBruteLoss(-(maxHealth))
+
+/mob/living/simple_animal/hostile/abnormality/titania/Destroy()
+	UnregisterAll()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/titania/Move()
 	if(fused)
@@ -104,7 +109,7 @@
 		SpawnFairies(fairy_spawn_number * 2, H, ignore_cap = TRUE)
 		H.gib()
 		return
-
+	var/mob/living/carbon/human/nemesis = nemesis_memory ? nemesis_memory.resolve() : null
 	if(attacked_target == nemesis)	//Deals pale damage to Oberon, fuck you.
 		melee_damage_type = PALE_DAMAGE
 		melee_damage_lower = 61
@@ -122,7 +127,7 @@
 		adjustBruteLoss(-maxHealth, forced = TRUE) // Round 2, baby
 
 		to_chat(src, span_userdanger("[nemesis], my beloved devil, I finally get my revenge."))
-		nemesis = null
+		nemesis_memory = null
 		if(!client)
 			say("Oberon. The abhorrent taker of my child. You are slain.")
 
@@ -147,8 +152,7 @@
 	for(var/i in 1 to amount)
 		var/mob/living/simple_animal/hostile/fairyswarm/fairy = new(spawn_turf)
 		fairy.faction = faction
-		fairy.mommy = src
-		spawned_mobs += fairy
+		RegisterMob(fairy)
 
 //Setting the nemesis
 /mob/living/simple_animal/hostile/abnormality/titania/proc/ChooseNemesis()
@@ -163,7 +167,7 @@
 			continue
 		potentialmarked += L
 	if(LAZYLEN(potentialmarked))
-		nemesis = pick(potentialmarked)
+		nemesis_memory = WEAKREF(pick(potentialmarked))
 
 //Cleaning fairies
 /mob/living/simple_animal/hostile/abnormality/titania/death(gibbed)
@@ -180,6 +184,7 @@
 	if(IsCombatMap())
 		return
 
+	var/mob/living/carbon/human/nemesis = nemesis_memory ? nemesis_memory.resolve() : null
 
 	var/lawmessage
 
@@ -240,6 +245,8 @@
 	if(currentlaw == "armor" && Proj.damage_type == RED_DAMAGE)
 		Punishment(Proj.firer)
 
+	var/mob/living/carbon/human/nemesis = nemesis_memory ? nemesis_memory.resolve() : null
+
 	if(currentlaw == "nemesis" && H != nemesis)
 		Punishment(Proj.firer)
 		H.apply_lc_fragile(5)
@@ -262,6 +269,7 @@
 	if(currentlaw == "armor" && I.damtype == RED_DAMAGE && I.force >= 10)
 		Punishment(user)
 
+	var/mob/living/carbon/human/nemesis = nemesis_memory ? nemesis_memory.resolve() : null
 	if(currentlaw == "nemesis" && user != nemesis)
 		Punishment(user)
 		user.apply_lc_fragile(5)
@@ -275,20 +283,37 @@
 	ChooseNemesis()
 	addtimer(CALLBACK(src, PROC_REF(FairyLoop)), 10 SECONDS)	//10 seconds from now you start spawning fairies
 	addtimer(CALLBACK(src, PROC_REF(SetLaw)), law_timer)	//Set Laws in 30 Seconds
+
+	var/mob/living/carbon/human/nemesis = nemesis_memory ? nemesis_memory.resolve() : null
 	if(nemesis)
 		to_chat(src, span_userdanger("[nemesis], you are to die!"))
 	if(!client && nemesis)
 		say("[nemesis], you are a monster and I will slay you.")
 
 /mob/living/simple_animal/hostile/abnormality/titania/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
-	if(!(user in worked))
+	if(!(user.tag in worked))
 		datum_reference.qliphoth_change(-1)
-		worked+=user
+		worked+=user.tag
 	return
 
 /mob/living/simple_animal/hostile/abnormality/titania/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	. = ..()
 	datum_reference.qliphoth_change(-1)
+
+
+/mob/living/simple_animal/hostile/abnormality/titania/proc/RegisterMob(mob/living/L)
+	RegisterSignal(L, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMob))
+	spawned_mobs += L
+
+/mob/living/simple_animal/hostile/abnormality/titania/proc/UnregisterMob(mob/living/L)
+	UnregisterSignal(L, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING))
+	spawned_mobs -= L
+
+/mob/living/simple_animal/hostile/abnormality/titania/proc/UnregisterAll()
+	for(var/mob/living/L in spawned_mobs)
+		UnregisterMob(L)
+		qdel(L)
+	spawned_mobs.Cut()
 
 
 //The Mini fairies
@@ -314,18 +339,11 @@
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	mob_size = MOB_SIZE_TINY
 	del_on_death = TRUE
-	var/mob/living/simple_animal/hostile/abnormality/titania/mommy
 
 /mob/living/simple_animal/hostile/fairyswarm/Initialize()
 	. = ..()
 	pixel_x = rand(-16, 16)
 	pixel_y = rand(-16, 16)
-
-/mob/living/simple_animal/hostile/fairyswarm/Destroy()
-	if(mommy)
-		mommy.spawned_mobs -= src
-		mommy = null
-	return ..()
 
 /mob/living/simple_animal/hostile/fairyswarm/AttackingTarget(atom/attacked_target)
 	..()

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
@@ -66,10 +66,12 @@ GLOBAL_LIST_EMPTY(apostles)
 	var/holy_revival_damage = 80 // Pale damage, scales with distance
 	var/holy_revival_range = 80
 	/// List of mobs that have been hit by the revival field to avoid double effect
+	//Uses Tags
 	var/list/been_hit = list()
 	/// Currently spawned apostles by this mob
 	var/list/apostles = list()
 	/// List of Living People on Breach
+	// Uses tags
 	var/list/heretics = list()
 
 	var/datum/reusable_visual_pool/RVP = new(500)
@@ -119,8 +121,8 @@ GLOBAL_LIST_EMPTY(apostles)
 			for(var/mob/living/carbon/human/H in GLOB.player_list)
 				if(H.stat != DEAD && H.client && H.z == z)
 					H.client.give_award(/datum/award/achievement/abno/kill_wn_pink_midnight, H)
-	for(var/mob/living/carbon/human/heretic in heretics)
-		if(heretic.stat == DEAD || !heretic.ckey)
+	for(var/mob/living/carbon/human/heretic in GLOB.player_list)
+		if(heretic.stat == DEAD || !heretic.ckey || !(heretic.tag in heretics))
 			continue
 		heretic.Apply_Gift(new /datum/ego_gifts/blessing)
 		heretic.playsound_local(get_turf(heretic), 'sound/abnormalities/whitenight/apostle_bell.ogg', 50)
@@ -129,11 +131,10 @@ GLOBAL_LIST_EMPTY(apostles)
 
 /mob/living/simple_animal/hostile/abnormality/white_night/Destroy()
 	for(var/mob/living/simple_animal/hostile/apostle/A in apostles)
+		UnregisterMob(A)
 		A.death()
 		QDEL_IN(A, 1.5 SECONDS)
-	apostles = null
 	QDEL_NULL(particles)
-	particles = null
 	QDEL_NULL(RVP)
 	return ..()
 
@@ -164,9 +165,9 @@ GLOBAL_LIST_EMPTY(apostles)
 		SLEEP_CHECK_DEATH(1.5)
 
 /mob/living/simple_animal/hostile/abnormality/white_night/proc/revive_target(mob/living/L, attack_range = 1, faction_check = "apostle")
-	if(L in been_hit)
+	if(L.tag in been_hit)
 		return
-	been_hit += L
+	been_hit += L.tag
 	if(!(faction_check in L.faction))
 		playsound(L.loc, 'sound/machines/clockcult/ark_damage.ogg', 50 - attack_range, TRUE, -1)
 		// The farther you are from white night - the less damage it deals
@@ -198,7 +199,8 @@ GLOBAL_LIST_EMPTY(apostles)
 			apostle_type = /mob/living/simple_animal/hostile/apostle/staff
 		if(i in list(7,8,9,10))
 			apostle_type = /mob/living/simple_animal/hostile/apostle/spear
-		apostles += new apostle_type(get_turf(src))
+		var/new_apostle = new apostle_type(get_turf(src))
+		RegisterMob(new_apostle)
 		var/list/possible_locs = GLOB.xeno_spawn.Copy()
 		for(var/mob/living/simple_animal/hostile/apostle/A in apostles)
 			if(istype(A, /mob/living/simple_animal/hostile/apostle/scythe/guardian))
@@ -243,7 +245,7 @@ GLOBAL_LIST_EMPTY(apostles)
 	. = ..()
 	for(var/mob/M in GLOB.player_list)
 		if(M.stat != DEAD && ishuman(M) && M.ckey)
-			heretics += M
+			heretics += M.tag
 		flash_color(M, flash_color = COLOR_RED, flash_time = 100)
 	sound_to_playing_players('sound/abnormalities/whitenight/apostle_bell.ogg')
 	add_filter("apostle", 1, rays_filter(size = 64, color = "#FFFF00", offset = 6, density = 16, threshold = 0.05))
@@ -263,6 +265,19 @@ GLOBAL_LIST_EMPTY(apostles)
 			if(L.stat || !L.client)
 				continue
 			L.client.give_award(/datum/award/achievement/abno/white_night, L)
+
+/mob/living/simple_animal/hostile/abnormality/white_night/proc/RegisterMob(mob/living/L)
+	RegisterSignal(L, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMob))
+	apostles += L
+
+/mob/living/simple_animal/hostile/abnormality/white_night/proc/UnregisterMob(mob/living/L)
+	UnregisterSignal(L, list(COMSIG_PARENT_QDELETING))
+	apostles -= L
+
+/mob/living/simple_animal/hostile/abnormality/white_night/proc/UnregisterAll()
+	for(var/mob/living/L in apostles)
+		UnregisterMob(L)
+	apostles.Cut()
 
 /* Apostles */
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/KHz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/KHz.dm
@@ -100,8 +100,8 @@
 	bitcalculator = 0
 
 	//If you're new, grab a callsign paper. Also set new input
-	if(!(user in worked))
-		worked+=user
+	if(!(user.tag in worked))
+		worked+=user.tag
 		new /obj/item/paper/fluff/radio_call(get_turf(user))
 	SetInput()
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/better_memories.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/better_memories.dm
@@ -45,7 +45,14 @@
 			The memory becomes more and more vivid as if its happening now... <br>when you finally break free you cannot recall what you fought so hard for."),
 	)
 
-	var/minions = 0
+	//A list for tracking the enemies
+	var/list/signal_tracker = list()
+
+/mob/living/simple_animal/hostile/abnormality/better_memories/Destroy()
+	for(var/mob/living/memory in signal_tracker)
+		UnregisterSignal(memory,COMSIG_PARENT_QDELETING)
+	signal_tracker.Cut()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/better_memories/Login()
 	. = ..()
@@ -66,7 +73,7 @@
 
 // Better memories can have 3 seperate minions who will terroize the facility. Code modified from luna.dm
 /mob/living/simple_animal/hostile/abnormality/better_memories/ZeroQliphoth(mob/living/carbon/human/user)
-	if(minions >= 3)
+	if(length(signal_tracker) >= 3)
 		return FALSE
 	var/mob/living/breaching_minion
 	//Normal breach
@@ -96,12 +103,13 @@
 /mob/living/simple_animal/hostile/abnormality/better_memories/proc/SpawnMinion(turf/spawn_turf)
 	var/mob/living/simple_animal/hostile/better_memories_minion/spawningmonster = new(spawn_turf)
 	RegisterSignal(spawningmonster, COMSIG_PARENT_QDELETING, PROC_REF(MinionSlain))
-	minions++
+	signal_tracker += spawningmonster
 	return spawningmonster
 
-/mob/living/simple_animal/hostile/abnormality/better_memories/proc/MinionSlain()
+/mob/living/simple_animal/hostile/abnormality/better_memories/proc/MinionSlain(mob/living/L)
 	SIGNAL_HANDLER
-	minions--
+	signal_tracker -= L
+	UnregisterSignal(L,COMSIG_PARENT_QDELETING)
 
 
 //Minion Spawn
@@ -135,7 +143,11 @@
 	var/current_target
 	var/list/static/hunt_targets = list()
 
-/mob/living/simple_animal/hostile/abnormality/better_memories/Login()
+/mob/living/simple_animal/hostile/better_memories_minion/Destroy()
+	current_target = null
+	return ..()
+
+/mob/living/simple_animal/hostile/better_memories_minion/Login()
 	. = ..()
 	if(!. || !client)
 		return FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/he/siren.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/siren.dm
@@ -57,6 +57,12 @@
 	var/playstatus = FALSE
 	var/playrange = 40
 
+
+/mob/living/simple_animal/hostile/abnormality/siren/Destroy()
+	if(musictime)
+		QDEL_NULL(musictime)
+	return ..()
+
 //Spawn/music stuff
 /mob/living/simple_animal/hostile/abnormality/siren/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/he/you_strong.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/you_strong.dm
@@ -69,6 +69,11 @@
 	var/summon_cooldown_time = 120 SECONDS
 	var/summon_count = 0
 
+/mob/living/simple_animal/hostile/abnormality/you_strong/Destroy()
+	if(soundloop)
+		QDEL_NULL(soundloop)
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/you_strong/Initialize(mapload)
 	. = ..()
 	soundloop = new(list(src), FALSE)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/fragment.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/fragment.dm
@@ -87,7 +87,8 @@
 	return TRUE
 
 /mob/living/simple_animal/hostile/abnormality/fragment/Destroy()
-	QDEL_NULL(legs)
+	if(legs)
+		QDEL_NULL(legs)
 	if(!particle_note)
 		return ..()
 	particle_note.fadeout()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
@@ -186,6 +186,18 @@
 	chosen_message = span_colossus("You will now use normal attacks.")
 	chosen_attack_num = 5
 
+/mob/living/simple_animal/hostile/abnormality/hatred_queen/Destroy()
+	spawned_effects.Cut()
+	beats_hit = null
+	if(current_beam)
+		QDEL_NULL(current_beam)
+	if(beamloop)
+		QDEL_NULL(beamloop)
+	if(wand)
+		QDEL_NULL(wand)
+	UnregisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH)
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/hatred_queen/Initialize()
 	. = ..()
 	beamloop = new(list(src), FALSE)
@@ -217,11 +229,8 @@
 	var/obj/effect/qoh_sygil/S = new(get_turf(src))
 	S.icon_state = "qoh2"
 	addtimer(CALLBACK(S, TYPE_PROC_REF(/obj/effect/qoh_sygil, fade_out)), 5 SECONDS)
-	UnregisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH)
 	if(friendly)
 		src.say("I swore I would protect everyone to the end…")
-	if(wand)
-		qdel(wand)
 	..()
 	animate(src, alpha = 0, time = 10 SECONDS)
 	QDEL_IN(src, 10 SECONDS)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/little_prince.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/little_prince.dm
@@ -46,13 +46,18 @@
 	base_pixel_x = -16
 	pixel_x = -16
 
+/mob/living/simple_animal/hostile/abnormality/little_prince/Destroy()
+	UnregisterAll()
+	QDEL_NULL(spore_icon)
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/little_prince/Life()
 	..()
 	for(var/mob/living/carbon/human/user in hypnotized)
 		if ((user.stat == DEAD) || !(user.sanity_lost))
 			QDEL_NULL(user.ai_controller)
 			user.cut_overlay(mutable_appearance('ModularLobotomy/_Lobotomyicons/tegu_effects32x48.dmi', "spore_hypno", -HALO_LAYER))
-			hypnotized -= user
+			UnregisterMob(user)
 	if(LAZYLEN(hypnotized))
 		icon_state = "little_princea"
 	else
@@ -65,7 +70,7 @@
 		user.deal_damage(user.maxSanity, WHITE_DAMAGE, flags = (DAMAGE_FORCED), attack_type = (ATTACK_TYPE_SPECIAL))
 		if (!(user.sanity_lost))
 			//Check Sanity twice to make sure you're actually insane
-			twice -= user
+			twice -= user.tag
 			to_chat(user, span_userdanger("You see mushrooms growing all over your body, and you tear them off!"))
 			return
 	to_chat(user, span_userdanger("You see mushrooms growing all over your body!"))
@@ -73,7 +78,7 @@
 	QDEL_NULL(user.ai_controller)
 	user.ai_controller = /datum/ai_controller/insane/hypno
 	user.InitializeAIController()
-	hypnotized += user
+	RegisterMob(user)
 	return
 
 /mob/living/simple_animal/hostile/abnormality/little_prince/proc/Infect(mob/living/carbon/human/user)
@@ -96,9 +101,9 @@
 	return TRUE
 
 /mob/living/simple_animal/hostile/abnormality/little_prince/proc/Fungify(mob/living/carbon/human/user)
-	once -= user
-	twice -= user
-	hypnotized -= user
+	once -= user.tag
+	twice -= user.tag
+	UnregisterMob(user)
 	user.cut_overlay(mutable_appearance('ModularLobotomy/_Lobotomyicons/tegu_effects32x48.dmi', "spore_hypno", -HALO_LAYER))
 	var/turf/T = get_turf(user)
 	user.visible_message(span_danger("Mushrooms rapidly grow all over [user]'s body, forming a giant mass!"))
@@ -112,12 +117,12 @@
 	SIGNAL_HANDLER
 	if (abno_datum == datum_reference) // They worked on us!
 		return FALSE
-	if (user in twice)
-		once += user
-		twice -= user
+	if (user.tag in twice)
+		once += user.tag
+		twice -= user.tag
 		return TRUE
-	if (user in once)
-		once -= user
+	if (user.tag in once)
+		once -= user.tag
 		UnregisterSignal(user, COMSIG_WORK_STARTED)
 		return FALSE
 	return TRUE
@@ -128,11 +133,11 @@
 	user_check = FALSE
 
 	//checks how many times they worked on prince
-	if (user in once)
-		once -= user
-		twice += user
-	if (!(user in once) && !(user in twice))
-		once += user
+	if (user.tag in once)
+		once -= user.tag
+		twice += user.tag
+	if (!(user.tag in once) && !(user.tag in twice))
+		once += user.tag
 		RegisterSignal(user, COMSIG_WORK_STARTED, PROC_REF(OnAbnoWork))
 
 	//insight work checks
@@ -158,7 +163,7 @@
 	return
 
 /mob/living/simple_animal/hostile/abnormality/little_prince/AttemptWork(mob/living/carbon/human/user, work_type)
-	if ((user in twice) || (user in hypnotized))
+	if ((user.tag in twice) || (user in hypnotized))
 		datum_reference.qliphoth_change(2)
 		UnregisterSignal(user, COMSIG_WORK_STARTED)
 		Fungify(user)
@@ -182,6 +187,19 @@
 			potential_hypno += H
 		Hypno(pick(potential_hypno))
 	return
+
+/mob/living/simple_animal/hostile/abnormality/little_prince/proc/RegisterMob(mob/living/L)
+	RegisterSignal(L, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMob))
+	hypnotized += L
+
+/mob/living/simple_animal/hostile/abnormality/little_prince/proc/UnregisterMob(mob/living/L)
+	UnregisterSignal(L, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING))
+	hypnotized -= L
+
+/mob/living/simple_animal/hostile/abnormality/little_prince/proc/UnregisterAll()
+	for(var/mob/living/L in hypnotized)
+		UnregisterMob(L)
+	hypnotized.Cut()
 
 /* Prince-01 */
 /mob/living/simple_animal/hostile/little_prince_1

--- a/code/modules/mob/living/simple_animal/abnormality/waw/luna.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/luna.dm
@@ -57,10 +57,10 @@
 /mob/living/simple_animal/hostile/abnormality/luna/CanAttack(atom/the_target)
 	return FALSE
 
-/mob/living/simple_animal/hostile/abnormality/luna/death(gibbed)
+/mob/living/simple_animal/hostile/abnormality/luna/Destroy()
 	if(breached_monster)
 		qdel(breached_monster)
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/luna/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
@@ -180,13 +180,13 @@
 	del_on_death = 1
 	vision_range = 18 //two screens away
 	var/panic_timer = 0
-	var/mob/living/simple_animal/hostile/abnormality/naked_nest/origin_nest
+	var/origin_nest
 
 /mob/living/simple_animal/hostile/naked_nest_serpent/Initialize()
 	. = ..()
-	var/home_naked_nest = locate(/mob/living/simple_animal/hostile/abnormality/naked_nest) in loc
+	var/mob/living/home_naked_nest = locate(/mob/living/simple_animal/hostile/abnormality/naked_nest) in loc
 	if(home_naked_nest)
-		origin_nest = home_naked_nest
+		origin_nest = home_naked_nest.tag
 	AddComponent(/datum/component/swarming)
 
 /mob/living/simple_animal/hostile/naked_nest_serpent/AttackingTarget(atom/attacked_target)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/orange_tree.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/orange_tree.dm
@@ -52,7 +52,8 @@
 	soundloop = new(list(src), TRUE)
 
 /mob/living/simple_animal/hostile/abnormality/orange_tree/Destroy()
-	QDEL_NULL(soundloop)
+	if(soundloop)
+		QDEL_NULL(soundloop)
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/orange_tree/PostSpawn()
@@ -222,6 +223,11 @@
 	resistance_flags = INDESTRUCTIBLE
 	var/open = FALSE
 	var/obj/item/ego_weapon/ranged/flammenwerfer/flamethrower
+
+/obj/structure/flamethrowercabinet/Destroy()
+	if(flamethrower)
+		QDEL_NULL(flamethrower)
+	return ..()
 
 /obj/structure/flamethrowercabinet/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/pile_of_mail.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/pile_of_mail.dm
@@ -50,7 +50,7 @@
 
 	var/cooldown
 	var/cooldown_time = 10 SECONDS
-	var/spawned_effects = list()
+	var/list/spawned_effects = list()
 	var/list/bad_mail_types = list(
 		/obj/item/mailpaper/junk,
 		/obj/item/mailpaper/pipebomb,
@@ -65,8 +65,7 @@
 	return FALSE
 
 /mob/living/simple_animal/hostile/abnormality/mailpile/Destroy()
-	for(var/obj/effect/VFX in spawned_effects)
-		qdel(VFX)
+	QDEL_LIST(spawned_effects)
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/mailpile/Initialize(mapload)

--- a/code/modules/mob/living/simple_animal/distortion/_distortion.dm
+++ b/code/modules/mob/living/simple_animal/distortion/_distortion.dm
@@ -80,11 +80,11 @@
 	if(fear_level <= 0)
 		return
 	for(var/mob/living/carbon/human/H in view(7, src))
-		if(H in breach_affected)
+		if(H.tag in breach_affected)
 			continue
 		if(H.stat == DEAD)
 			continue
-		breach_affected += H
+		breach_affected += H.tag
 		if(HAS_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE))
 			to_chat(H, "<span class='notice'>This again...?")
 			H.apply_status_effect(/datum/status_effect/panicked_lvl_0)

--- a/code/modules/mob/living/simple_animal/distortion/star/pianist.dm
+++ b/code/modules/mob/living/simple_animal/distortion/star/pianist.dm
@@ -600,11 +600,11 @@ Core mechanics:
 	if(fear_level <= 0)
 		return
 	for(var/mob/living/carbon/human/H in view(7, src))
-		if(H in breach_affected)
+		if(H.tag in breach_affected)
 			continue
 		if(H.stat == DEAD)
 			continue
-		breach_affected += H
+		breach_affected += H.tag
 		if(HAS_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE))
 			to_chat(H, span_notice("The music is haunting, but you resist its call."))
 			H.apply_status_effect(/datum/status_effect/panicked_lvl_0)

--- a/code/modules/mob/living/simple_animal/hostile/rce/xcorp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/rce/xcorp.dm
@@ -86,7 +86,7 @@
 	dash_cooldown = world.time + dash_cooldown_time
 	charging = TRUE
 	var/dir_to_target = get_dir(get_turf(src), get_turf(target))
-	been_hit = list()
+	been_hit.Cut()
 	SpinAnimation(3, 20)
 	dash_num = (get_dist(src, target) + extra_dash_distance)
 	addtimer(CALLBACK(src, PROC_REF(Charge), dir_to_target, 0), 2 SECONDS)
@@ -122,7 +122,7 @@
 	for(var/mob/living/L in range(dash_range, T))//damage applied to targets in range
 		if(faction_check_mob(L))
 			continue
-		if(L in been_hit)
+		if(L.tag in been_hit)
 			continue
 		if(L.z != z)
 			continue
@@ -130,7 +130,7 @@
 		var/turf/LT = get_turf(L)
 		new /obj/effect/temp_visual/kinetic_blast(LT)
 		L.deal_damage(dash_damage, BLACK_DAMAGE, source = src, attack_type = (ATTACK_TYPE_MELEE | ATTACK_TYPE_SPECIAL))
-		been_hit += L
+		been_hit += L.tag
 		playsound(L, 'sound/weapons/fixer/generic/sword4.ogg', 75, 1)
 		if(!ishuman(L))
 			continue


### PR DESCRIPTION
## About The Pull Request
I was told that it would help performance if we deleted reference to list variables when a abnormality is deleted. Very grunt work. 

Made the  "user" list in some tool abnormalities into a root  variable called "operators"

This PR being open now is so people can monitor my progress on it.

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [x] This PR compiles
* [x] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [x] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
fix: Some abnormalities hard deleting  due to list vars.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
