### PR TITLE
Component Hard Delete Fixing [DONE]

### DIFF
--- a/code/datums/components/ai_leadership.dm
+++ b/code/datums/components/ai_leadership.dm
@@ -37,6 +37,10 @@
 	ScanLocation()
 	START_PROCESSING(SSdcs, src)
 
+/datum/component/ai_leadership/Destroy()
+	followers = null
+	return ..()
+
 /datum/component/ai_leadership/RegisterWithParent()
 	if(isliving(parent))
 		RegisterSignal(parent, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING), PROC_REF(RemoveLeader))
@@ -174,12 +178,14 @@
 //Register recruit with the system
 /datum/component/ai_leadership/proc/Recruit(mob/living/L)
 	followers += L
+	RegisterSignal(L, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING), PROC_REF(Disband))
 	SSmobcommander.RecruitFollower(L)
 	FollowLeader(L)
 
 //Releases the recruit from our command
 /datum/component/ai_leadership/proc/Disband(mob/living/L)
 	followers -= L
+	UnregisterSignal(L, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING))
 	SSmobcommander.DismissFollower(L)
 
 //Is the recruit already recruited in the system?

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -26,6 +26,10 @@
 		/obj/effect/wisp,
 	))
 
+/datum/component/chasm/Destroy()
+	target_turf = null
+	return ..()
+
 /datum/component/chasm/Initialize(turf/target)
 	RegisterSignal(parent, list(COMSIG_MOVABLE_CROSSED, COMSIG_ATOM_ENTERED), PROC_REF(Entered))
 	target_turf = target

--- a/code/datums/components/cognitohazard_visual.dm
+++ b/code/datums/components/cognitohazard_visual.dm
@@ -17,6 +17,9 @@
 /datum/component/cognitohazard_visual/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(Examine))
 
+/datum/component/cognitohazard_visual/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_PARENT_EXAMINE)
+
 /**
 	This proc will trigger when someone examines the parent.
 	It will attach the text found in the body of the proc to the `examine_list` and display it to the player examining the parent.

--- a/code/datums/components/monwave_spawners.dm
+++ b/code/datums/components/monwave_spawners.dm
@@ -64,6 +64,15 @@
 
 	addtimer(CALLBACK(src, PROC_REF(LateInitialize)))
 
+/datum/component/monwave_spawner/Destroy()
+	assult_path = null
+	current_wave = null
+	existing_mobs = null
+	last_wave = null
+	wave_leader = null
+	assault_target = null
+	return ..()
+
 /datum/component/monwave_spawner/proc/LateInitialize()
 	GeneratePath()
 	BeginProcessing()
@@ -106,7 +115,7 @@
 	var/mob/living/simple_animal/hostile/spawned_mob = new mobtype(pick(get_adjacent_open_turfs(parent)))
 	if(!wave_leader && LeaderQualifications(spawned_mob))
 		wave_leader = spawned_mob
-	current_wave += spawned_mob
+	LAZYADD(current_wave, spawned_mob)
 	current_existing_mobs += 1
 	spawned_mob.faction = faction.Copy()
 	RegisterSignal(spawned_mob, COMSIG_LIVING_DEATH, PROC_REF(MinionSlain))
@@ -179,6 +188,10 @@
 	. = ..()
 	AddElement(/datum/element/point_of_interest)
 
+/obj/effect/wave_commander/Destroy()
+	our_path = null
+	return ..()
+
 /obj/effect/wave_commander/proc/DoPath(list/assault_path)
 	our_path = assault_path.Copy()
 	if(length(our_path) <= 0)
@@ -227,4 +240,3 @@
 	if(patrol_move_timer)
 		deltimer(patrol_move_timer)
 	QDEL_IN(src, 5)
-


### PR DESCRIPTION
## About The Pull Request
Atomizing this because the original fixing PR was a bit much https://github.com/Lobotomy-Corporation-13/lc13/pull/368

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [x] This PR compiles
* [x] This PR runs fine in a local test
* [x] This PR does not produce runtimes
* [x] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
fix: some components causing hard deletes.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
