### PR TITLE
Fixing up Gib Sounds [DONE]

### DIFF
--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -73,18 +73,18 @@
 	if(reagents)
 		for(var/datum/reagent/R in reagents.reagent_list)
 			R.on_ex_act()
-	..()
+	return ..()
 
 /obj/effect/decal/cleanable/fire_act(exposed_temperature, exposed_volume)
 	if(reagents)
 		reagents.expose_temperature(exposed_temperature)
-	..()
+	return ..()
 
 
 //Add "bloodiness" of this blood's type, to the human's shoes
 //This is on /cleanable because fuck this ancient mess
 /obj/effect/decal/cleanable/Crossed(atom/movable/AM)
-	..()
+	. = ..()
 	if(iscarbon(AM) && blood_state && bloodiness >= 40)
 		SEND_SIGNAL(AM, COMSIG_STEP_ON_BLOOD, src)
 		update_icon()

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -113,9 +113,11 @@
 	. = ..()
 	reagents.add_reagent(/datum/reagent/liquidgibs, 5)
 	RegisterSignal(src, COMSIG_MOVABLE_PIPE_EJECTING, PROC_REF(on_pipe_eject))
+	pixel_x = rand(-5,5)
+	pixel_y = rand(-5,5)
 
 /obj/effect/decal/cleanable/blood/gibs/replace_decal(obj/effect/decal/cleanable/C)
-	return FALSE //Never fail to place us
+	return FALSE
 
 /obj/effect/decal/cleanable/blood/gibs/dry()
 	. = ..()
@@ -124,11 +126,6 @@
 
 /obj/effect/decal/cleanable/blood/gibs/ex_act(severity, target)
 	return FALSE
-
-/obj/effect/decal/cleanable/blood/gibs/Crossed(atom/movable/L)
-	if(isliving(L) && has_gravity(loc))
-		playsound(loc, 'sound/effects/gib_step.ogg', HAS_TRAIT(L, TRAIT_LIGHT_STEP) ? 20 : 50, TRUE)
-	return ..()
 
 /obj/effect/decal/cleanable/blood/gibs/proc/on_pipe_eject(atom/source, direction)
 	SIGNAL_HANDLER

--- a/code/game/objects/effects/spawners/gibspawner.dm
+++ b/code/game/objects/effects/spawners/gibspawner.dm
@@ -5,14 +5,13 @@
 	var/virusProb = 20 //the chance for viruses to spread on the gibs
 	var/gib_mob_type  //generate a fake mob to transfer DNA from if we weren't passed a mob.
 	var/sound_to_play = 'sound/effects/blobattack.ogg'
-	var/sound_vol = 60
+	var/sound_vol = 10
 	var/list/gibtypes = list() //typepaths of the gib decals to spawn
 	var/list/gibamounts = list() //amount to spawn for each gib decal type we'll spawn.
 	var/list/gibdirections = list() //of lists of possible directions to spread each gib decal type towards.
 
 /obj/effect/gibspawner/Initialize(mapload, mob/living/source_mob, list/datum/disease/diseases)
 	. = ..()
-
 	if(gibtypes.len != gibamounts.len)
 		stack_trace("Gib list amount length mismatch!")
 		return

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -49,6 +49,12 @@
 	if(is_station_level(z))
 		GLOB.station_turfs += src
 
+/turf/open/floor/Entered(atom/movable/AM)
+	. = ..()
+	if(isliving(AM) && locate(/obj/effect/decal/cleanable/blood/gibs) in src)
+		var/mob/living/L = AM
+		playsound(src, 'sound/effects/gib_step.ogg', HAS_TRAIT(L, TRAIT_LIGHT_STEP) ? 20 : 50, TRUE)
+
 /turf/open/floor/proc/setup_broken_states()
 	return list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
 


### PR DESCRIPTION
## About The Pull Request
Gibs are a very loud and numerous source of sound. In this i hope to quell some of that sound and make the squishie gore caked floors of the facility sound more realistic.

So far ive removed the squish sound from gibs and moved it to floor turf. Floor turf will now check if it has a gib on it, do let me know if this is processor intensive to check if there is a gib on the tile every time a person walks on it, and then play a squish sound instead of 10 gibs playing a sound all at once.

Currently i cant find a solution to the deafening shriek of several creatures gibbing at once other than reducing the sound from 60 to 10.

I also added a pixel x and pixel y variance to gibs so that they spread over a tile more smoothly.

My alternate solutions to this was to make gibs overlay onto eachother but that would nerf some creatures that rely on gibs.

## Why It's Good For The Game
Ive been asked to fix the sound because of the above descriptions of it being a horrid shriek.

### Put your cool images here
Gibtesting

https://github.com/user-attachments/assets/83268541-2021-4eef-8406-567cd1c99c12



<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [x] This PR compiles
* [x] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
fix: Several gibs making squish sounds when a person walks onto them.
fix: Gibspawners being very loud.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
