### PR TITLE
Fixes Hookah Caterpillar's Faction issue.

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/caterpillar.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/caterpillar.dm
@@ -44,6 +44,15 @@
 	var/darts_smoked	//how many times you didnt' work repression
 	var/can_counter = TRUE
 
+
+
+//These two overrides prevent it from attacking anyone.
+/mob/living/simple_animal/hostile/abnormality/caterpillar/FindTarget(list/possible_targets, HasTargetsList = 0)
+    return FALSE
+
+/mob/living/simple_animal/hostile/abnormality/caterpillar/AttackingTarget()
+  return FALSE
+
 //Set a smoker timer for 15 seconds
 /mob/living/simple_animal/hostile/abnormality/caterpillar/BreachEffect()
 	icon = 'ModularLobotomy/_Lobotomyicons/64x96.dmi'

--- a/code/modules/mob/living/simple_animal/abnormality/waw/caterpillar.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/caterpillar.dm
@@ -48,10 +48,10 @@
 
 //These two overrides prevent it from attacking anyone.
 /mob/living/simple_animal/hostile/abnormality/caterpillar/FindTarget(list/possible_targets, HasTargetsList = 0)
-    return FALSE
+	return FALSE
 
 /mob/living/simple_animal/hostile/abnormality/caterpillar/AttackingTarget()
-  return FALSE
+	return FALSE
 
 //Set a smoker timer for 15 seconds
 /mob/living/simple_animal/hostile/abnormality/caterpillar/BreachEffect()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/caterpillar.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/caterpillar.dm
@@ -20,7 +20,7 @@
 
 	can_breach = TRUE
 	threat_level = WAW_LEVEL
-	faction = list("neutral", "hostile")
+	faction = list("hostile")
 	start_qliphoth = 1
 	work_chances = list(
 		ABNORMALITY_WORK_INSTINCT = 75,


### PR DESCRIPTION
## About The Pull Request
Hookah has an issue, where, due to its faction being neutral, weapon faction checks do not allow it to be hit by them.
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This obviously is not intended, and harms game balance considering weapons are used to supress abnos.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [x] This PR compiles
* [x] This PR runs fine in a local test
* [x] This PR does not produce runtimes
* [x] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
fix: Removes Hookah Caterpillar from the Neutral Faction, allowing Hookah to be hit by weapons which previously it couldn't due to it bypassing faction checks. Then overrides a few procs to fix the new problem it caused by making it also target carbons.
/:cl:
<!--
Tags:
fix: Removes Hookah Caterpillar from the Neutral Faction, allowing Hookah to be hit by weapons which previously it couldn't due to it bypassing faction checks. Then overrides a few procs to fix the new problem it caused by making it also target carbons.
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
