### PR TITLE
Fixes the most evil regeneration bug of all time

### DIFF
--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -201,7 +201,7 @@
 
 	playsound(src, 'sound/machines/hiss.ogg', 50, FALSE, FALSE)
 
-	pipe_eject(H)
+	pipe_eject(H, source_area = H.source_area)
 
 	qdel(H)
 

--- a/code/modules/recycling/disposal/eject.dm
+++ b/code/modules/recycling/disposal/eject.dm
@@ -1,7 +1,7 @@
 /**
  * General proc used to expel a holder's contents through src (for bins holder is also the src).
  */
-/obj/proc/pipe_eject(obj/holder, direction, throw_em = TRUE, turf/target, throw_range = 5, throw_speed = 1)
+/obj/proc/pipe_eject(obj/holder, direction, throw_em = TRUE, turf/target, throw_range = 5, throw_speed = 1, area/source_area)
 	var/turf/src_T = get_turf(src)
 	for(var/A in holder)
 		var/atom/movable/AM = A
@@ -10,3 +10,7 @@
 		if(throw_em && !QDELETED(AM))
 			var/turf/T = target || get_offset_target_turf(loc, rand(5)-rand(5), rand(5)-rand(5))
 			AM.throw_at(T, throw_range, throw_speed)
+		if(istype(source_area))
+			source_area.Exited(AM)
+			var/area/new_area = get_area(src_T)
+			new_area.Entered(AM)

--- a/code/modules/recycling/disposal/holder.dm
+++ b/code/modules/recycling/disposal/holder.dm
@@ -12,6 +12,7 @@
 	var/destinationTag = NONE	// changes if contains a delivery container
 	var/tomail = FALSE			// contains wrapped package
 	var/hasmob = FALSE			// contains a mob
+	var/area/source_area		// LC13 Addition: Used to clean up area index stuff because apparently using disposal pipes to travel avoids calling Exited() ??
 
 /obj/structure/disposalholder/Destroy()
 	active = FALSE
@@ -19,6 +20,7 @@
 
 // initialize a holder from the contents of a disposal unit
 /obj/structure/disposalholder/proc/init(obj/machinery/disposal/D)
+	source_area = get_area(D)
 
 	//Check for any living mobs trigger hasmob.
 	//hasmob effects whether the package goes to cargo or its tagged destination.

--- a/code/modules/recycling/disposal/outlet.dm
+++ b/code/modules/recycling/disposal/outlet.dm
@@ -57,7 +57,7 @@
 	if(!H)
 		return
 
-	pipe_eject(H, dir, TRUE, target, eject_range, throw_range)
+	pipe_eject(H, dir, TRUE, target, eject_range, throw_range, source_area = H.source_area)
 
 	qdel(H)
 

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -111,7 +111,7 @@
 		target = get_offset_target_turf(T, rand(5)-rand(5), rand(5)-rand(5))
 
 	playsound(src, 'sound/machines/hiss.ogg', 50, FALSE, FALSE)
-	pipe_eject(H, direction, TRUE, target, eject_range)
+	pipe_eject(H, direction, TRUE, target, eject_range, source_area = H.source_area)
 	qdel(H)
 
 


### PR DESCRIPTION
## About The Pull Request
Not too long ago (a good few months ago actually) a refactor PR was merged that included changes to how regenerators work. Since previously they iterated over areas (which is actually iterating over the entire world), the entire area system was refactored, but this came with a very strange bug when using disposal units. 

Apparently disposal units allowed you to bypass the calling of area.Exited() on your mob when travelling between areas, which meant you never got taken off the area's living mobs list, which meant that area's regenerator would keep healing you. Furthermore you could actually repeat this to put yourself on the area's list like, 10 times and gain an unfathomable amount of regeneration.

This PR employs the most naïve fix possible, we just manually call Exited() and Entered() after ejecting stuff from the disposal system. I tried a few other solutions like manually calling Moved() or Move() but couldn't get them to work. Be my guest if you have better ideas on how to fix this.
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Maybe players shouldn't get to regen their entire health bar every tick but that's just, like, my opinion, man. Also it's probably a good idea to merge this sooner rather than later since everyone's gonna find out about this now.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
fix: Department disposal units no longer grant you eternal regeneration
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
