### PR TITLE
House of Spiders: Ring Nursefather

### DIFF
--- a/ModularLobotomy/associations/skills/skill_augments/implants.dm
+++ b/ModularLobotomy/associations/skills/skill_augments/implants.dm
@@ -35,6 +35,12 @@
 /obj/item/organ/cyberimp/chest/body_modification/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = TRUE)
 	. = ..()
 
+	// Ring artists cannot use skill augments
+	if(HAS_TRAIT(M, TRAIT_RING_ARTIST))
+		to_chat(M, span_warning("Your Ring artistry rejects the skill modification!"))
+		Remove(M)
+		return FALSE
+
 	// Check stat requirements
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
@@ -178,6 +184,11 @@
 		return
 
 	var/mob/living/carbon/human/H = target
+
+	// Ring artists cannot use skill augments
+	if(HAS_TRAIT(H, TRAIT_RING_ARTIST))
+		to_chat(user, span_warning("[H] is a Ring artist and cannot receive skill modifications!"))
+		return
 
 	// Check if target already has a skill modification
 	var/obj/item/organ/cyberimp/chest/body_modification/existing_SA = H.getorganslot(ORGAN_SLOT_HEART_AID)

--- a/ModularLobotomy/ego_weapons/melee/city/ring.dm
+++ b/ModularLobotomy/ego_weapons/melee/city/ring.dm
@@ -1568,3 +1568,38 @@
 	if(planted_visual)
 		QDEL_NULL(planted_visual)
 	is_surging = FALSE
+
+// ================== RING EGO DATUMS ==================
+// Placed here rather than in _cityweapons_datums.dm / _cityarmor_datums.dm
+// to prevent DM merge conflicts with other sub-PRs that modify those shared files.
+
+/// Tibia (Maestro Weapon)
+/datum/ego_datum/weapon/city/ring_tibia
+	item_path = /obj/item/ego_weapon/city/ring/tibia
+	cost = 100
+	ego_tags = list(EGO_TAG_REACH, EGO_TAG_SPECIAL_RANGED, EGO_TAG_AOE_RADIAL, EGO_TAG_AOE_PIERCING, EGO_TAG_DOT)
+
+/// Fascia (Apprentice Weapon — reads stats from weapon, dispenses Iron Maiden armor)
+/datum/ego_datum/weapon/city/ring_fascia
+	item_path = /obj/item/ego_weapon/city/ring/fascia
+	dispense_path = /obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice
+	cost = 90
+	ego_tags = list(EGO_TAG_MOBILITY, EGO_TAG_DOT)
+
+/// Corporist Maestro Garb
+/datum/ego_datum/armor/city/ring_maestro
+	item_path = /obj/item/clothing/suit/armor/ego_gear/city/ring_maestro
+	cost = 100
+
+/// Fascia Unleashed (Phase 2 — also dispenses Iron Maiden armor)
+/datum/ego_datum/weapon/city/ring_fascia_unleashed
+	item_path = /obj/item/ego_weapon/city/ring/fascia_unleashed
+	dispense_path = /obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice
+	cost = 90
+	ego_tags = list(EGO_TAG_MOBILITY, EGO_TAG_DOT)
+
+/// Iron Maiden Armour (Apprentice)
+/datum/ego_datum/armor/city/ring_apprentice
+	item_path = /obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice
+	cost = 90
+	ego_tags = list(EGO_TAG_MOBILITY)

--- a/ModularLobotomy/ego_weapons/melee/city/ring.dm
+++ b/ModularLobotomy/ego_weapons/melee/city/ring.dm
@@ -1,1 +1,1570 @@
-// Stub - populated by the Ring sub-PR
+// The Ring - Syndicate of Artists
+// Corporist School - Utilizes interaction between human bones and muscles
+// "Those who utilize the interaction between human bones and muscles, and the contraction and elongation thereof."
+
+// Tibia - Maestro Callisto's weapon, made from his own body
+// Collects Corpus Ingredients (Bones and Blood) on melee hit.
+// Use in hand to toggle between 4 ranged attack modes. Click at range to fire, consuming resources.
+/obj/item/ego_weapon/city/ring/tibia
+	name = "Tibia"
+	desc = "A massive weapon composed of Callisto's own body. Several large pointed notches line its blade, designed to sculpt flesh with artistic precision."
+	special = "Collects Corpus Ingredients on hit. Stuns targets for half your recovery time. Use in hand to toggle ranged mode. Click at range to fire."
+	icon_state = "tibia"
+	inhand_icon_state = "tibia"
+	icon = 'icons/obj/spider_house/ring/ring_icons.dmi'
+	lefthand_file = 'ModularLobotomy/_Lobotomyicons/lc13_left_64x64.dmi'
+	righthand_file = 'ModularLobotomy/_Lobotomyicons/lc13_right_64x64.dmi'
+	inhand_x_dimension = 64
+	inhand_y_dimension = 64
+	force = 68
+	damtype = RED_DAMAGE
+	attack_speed = 1
+	reach = 2
+	stuntime = 5
+	swingstyle = WEAPONSWING_LARGESWEEP
+	attack_verb_continuous = list("sculpts", "carves", "reshapes", "cleaves")
+	attack_verb_simple = list("sculpt", "carve", "reshape", "cleave")
+	hitsound = 'sound/weapons/fixer/generic/finisher1.ogg'
+	attribute_requirements = list(
+		FORTITUDE_ATTRIBUTE = 100,
+		PRUDENCE_ATTRIBUTE = 100,
+		TEMPERANCE_ATTRIBUTE = 100,
+		JUSTICE_ATTRIBUTE = 100
+	)
+
+	/// Current Corpus Ingredient (Bones)
+	var/bones = 0
+	/// Maximum Corpus Ingredient (Bones)
+	var/max_bones = 206
+	/// Current Corpus Ingredient (Blood)
+	var/blood = 0
+	/// Maximum Corpus Ingredient (Blood)
+	var/max_blood = 5
+	/// Current ranged attack mode: "shrapnel", "lance", "deluge", or "needle"
+	var/ranged_mode = "shrapnel"
+	/// Ranged attack cooldown tracker
+	var/ranged_cooldown
+	/// Time between ranged attacks
+	var/ranged_cooldown_time = 2 SECONDS
+	/// Timer ID for disgust buildup on non-Maestro holders
+	var/disgust_timer_id
+
+/// Checks if a user is authorized to use the Tibia without triggering the disgust system
+/obj/item/ego_weapon/city/ring/tibia/proc/is_authorized(mob/user)
+	if(!ishuman(user))
+		return TRUE
+	var/mob/living/carbon/human/H = user
+	if(H.mind?.assigned_role in list("Corporist Maestro", "Corporist Apprentice"))
+		return TRUE
+	// Disgust only triggers on city maps
+	if(!(SSmaptype.maptype in SSmaptype.citymaps))
+		return TRUE
+	// Disgust doesn't trigger on the testing range
+	if(is_tutorial_level(H.z))
+		return TRUE
+	return FALSE
+
+/obj/item/ego_weapon/city/ring/tibia/equipped(mob/user, slot)
+	. = ..()
+	if(slot == ITEM_SLOT_HANDS)
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			if(H.mind?.assigned_role == "Corporist Apprentice")
+				to_chat(H, span_notice("The Tibia's fleshy composition makes you uneasy, but your corporist body suppresses the revulsion."))
+			else if(!is_authorized(user))
+				start_disgust_timer(H)
+
+/obj/item/ego_weapon/city/ring/tibia/dropped(mob/user)
+	stop_disgust_timer()
+	return ..()
+
+/obj/item/ego_weapon/city/ring/tibia/Destroy()
+	stop_disgust_timer()
+	return ..()
+
+/// Starts the disgust buildup timer for non-Maestro holders
+/obj/item/ego_weapon/city/ring/tibia/proc/start_disgust_timer(mob/living/carbon/human/H)
+	stop_disgust_timer()
+	disgust_timer_id = addtimer(CALLBACK(src, PROC_REF(apply_disgust), H), 2 SECONDS, TIMER_STOPPABLE | TIMER_LOOP)
+
+/// Stops the disgust buildup timer
+/obj/item/ego_weapon/city/ring/tibia/proc/stop_disgust_timer()
+	if(disgust_timer_id)
+		deltimer(disgust_timer_id)
+		disgust_timer_id = null
+
+/// Applies disgust to unauthorized holders and force drops at 100+
+/obj/item/ego_weapon/city/ring/tibia/proc/apply_disgust(mob/living/carbon/human/H)
+	if(QDELETED(H) || QDELETED(src))
+		stop_disgust_timer()
+		return
+	if(!H.is_holding(src))
+		stop_disgust_timer()
+		return
+	// Double-check they're still not authorized
+	if(is_authorized(H))
+		stop_disgust_timer()
+		return
+
+	H.adjust_disgust(20)
+	if(H.disgust >= 100)
+		to_chat(H, span_warning("The Tibia's fleshy composition overwhelms you with disgust!"))
+		H.dropItemToGround(src, TRUE)
+		stop_disgust_timer()
+
+/obj/item/ego_weapon/city/ring/tibia/attack(mob/living/target, mob/living/user)
+	var/target_was_alive = target && !QDELETED(target) && target.stat != DEAD
+	. = ..()
+	if(!target || QDELETED(target) || !target_was_alive)
+		return
+	// Stun target for half the user's stuntime
+	if(stuntime && target.stat != DEAD)
+		target.Immobilize(round(stuntime * 0.5))
+		new /obj/effect/temp_visual/weapon_stun(get_turf(target))
+		new /obj/effect/temp_visual/dir_setting/bloodsplatter(get_turf(target), pick(GLOB.alldirs))
+		new /obj/effect/temp_visual/dir_setting/bloodsplatter(get_turf(target), pick(GLOB.alldirs))
+		new /obj/effect/temp_visual/dir_setting/bloodsplatter(get_turf(target), pick(GLOB.alldirs))
+	// Collect Corpus Ingredients on hit - double on kill
+	var/bone_gain = 30
+	var/blood_gain = 1
+	if(target.stat == DEAD)
+		bone_gain *= 2
+		blood_gain *= 2
+	var/old_bones = bones
+	var/old_blood = blood
+	bones = min(bones + bone_gain, max_bones)
+	blood = min(blood + blood_gain, max_blood)
+	var/bones_gained = bones - old_bones
+	var/blood_gained = blood - old_blood
+	var/list/gains = list()
+	if(bones_gained > 0)
+		gains += "+[bones_gained] Bones"
+	if(blood_gained > 0)
+		gains += "+[blood_gained] Blood"
+	if(length(gains))
+		var/kill_text = target.stat == DEAD ? " (KILL BONUS)" : ""
+		to_chat(user, span_nicegreen("Corpus Ingredients: [jointext(gains, ", ")][kill_text] ([bones]/[max_bones] Bones, [blood]/[max_blood] Blood)"))
+
+/// Toggle between ranged attack modes
+/obj/item/ego_weapon/city/ring/tibia/attack_self(mob/user)
+	. = ..()
+	switch(ranged_mode)
+		if("shrapnel")
+			ranged_mode = "lance"
+			to_chat(user, span_notice("Ranged mode: Marrow Lance (120 Bones) - Piercing marrow projectile with WHITE damage."))
+			balloon_alert(user, "Marrow Lance")
+		if("lance")
+			ranged_mode = "deluge"
+			to_chat(user, span_notice("Ranged mode: Sanguine Deluge (206 Bones + 5 Blood) - Massive area blood eruption."))
+			balloon_alert(user, "Sanguine Deluge")
+		if("deluge")
+			ranged_mode = "needle"
+			to_chat(user, span_notice("Ranged mode: Crimson Needle (2 Blood) - Piercing blood projectile."))
+			balloon_alert(user, "Crimson Needle")
+		if("needle")
+			ranged_mode = "shrapnel"
+			to_chat(user, span_notice("Ranged mode: Bone Shrapnel (60 Bones) - Burst of bone fragments."))
+			balloon_alert(user, "Bone Shrapnel")
+	playsound(src, 'sound/items/screwdriver2.ogg', 50, TRUE)
+
+/// Ranged attack - click at range to fire, consuming Corpus Ingredients
+/// Shrapnel/Deluge: AoE with 0.75s warning. Lance/Needle: piercing projectile.
+/obj/item/ego_weapon/city/ring/tibia/afterattack(atom/A, mob/living/user, proximity_flag, params)
+	if(ranged_cooldown > world.time)
+		return
+	if(!CanUseEgo(user))
+		return
+	var/turf/target_turf = get_turf(A)
+	if(!istype(target_turf))
+		return
+	if((get_dist(user, target_turf) < 2) || !(target_turf in view(7, user)))
+		return
+
+	// Determine resource costs per mode
+	var/bone_cost = 0
+	var/blood_cost = 0
+	var/mode_name = ""
+
+	switch(ranged_mode)
+		if("shrapnel")
+			bone_cost = 60
+			mode_name = "Bone Shrapnel"
+		if("lance")
+			bone_cost = 120
+			mode_name = "Marrow Lance"
+		if("deluge")
+			bone_cost = 206
+			blood_cost = 5
+			mode_name = "Sanguine Deluge"
+		if("needle")
+			blood_cost = 2
+			mode_name = "Crimson Needle"
+
+	// Check resources
+	if(bones < bone_cost || blood < blood_cost)
+		var/list/need = list()
+		if(bone_cost > 0)
+			need += "[bone_cost] Bones"
+		if(blood_cost > 0)
+			need += "[blood_cost] Blood"
+		to_chat(user, span_warning("Not enough Corpus Ingredients for [mode_name]! (Need: [jointext(need, ", ")])"))
+		return
+
+	// Consume resources
+	bones -= bone_cost
+	blood -= blood_cost
+
+	..()
+	ranged_cooldown = world.time + ranged_cooldown_time
+
+	switch(ranged_mode)
+		if("lance", "needle")
+			// Fire piercing projectile
+			fire_tibia_projectile(A, user, params)
+			to_chat(user, span_warning("[mode_name]: Fired! ([bones]/[max_bones] Bones, [blood]/[max_blood] Blood remaining)"))
+		if("shrapnel", "deluge")
+			// AoE attack with 0.75s warning delay
+			var/aoe_radius = (ranged_mode == "deluge") ? 2 : 1
+			var/ranged_damage = (ranged_mode == "deluge") ? 150 : 40
+			var/heals_sp = (ranged_mode == "deluge")
+			// 96x96 warning covers the inner 3x3 from center - only place it on center turf
+			new /obj/effect/temp_visual/tibia_warning(target_turf)
+			// Deluge outer ring (dist > 1) gets spread warnings
+			if(aoe_radius >= 2)
+				for(var/turf/open/T in range(target_turf, aoe_radius))
+					if(get_dist(target_turf, T) > 1)
+						new /obj/effect/temp_visual/tibia_spread_warning(T)
+			addtimer(CALLBACK(src, PROC_REF(execute_ranged_attack), user, target_turf, aoe_radius, ranged_damage, heals_sp, mode_name), 5)
+
+/// Fires a piercing projectile for Lance and Needle modes
+/obj/item/ego_weapon/city/ring/tibia/proc/fire_tibia_projectile(atom/target, mob/living/user, params)
+	var/turf/proj_turf = get_turf(user)
+	var/obj/projectile/ego_bullet/G
+	switch(ranged_mode)
+		if("lance")
+			var/obj/projectile/ego_bullet/tibia_lance/lance = new(proj_turf)
+			lance.white_bonus = round(lance.white_bonus * force_multiplier)
+			G = lance
+		if("needle")
+			G = new /obj/projectile/ego_bullet/tibia_needle(proj_turf)
+	G.fired_from = src
+	G.firer = user
+	G.preparePixelProjectile(target, user, params)
+	G.fire()
+	G.damage *= force_multiplier
+	playsound(user, 'sound/weapons/fixer/generic/finisher1.ogg', 50, TRUE)
+
+/// Executes the AoE ranged attack damage after the warning delay
+/obj/item/ego_weapon/city/ring/tibia/proc/execute_ranged_attack(mob/living/user, turf/target_turf, aoe_radius, ranged_damage, heals_sp, mode_name)
+	if(!user || QDELETED(user) || user.stat == DEAD)
+		return
+	if(!target_turf)
+		return
+
+	playsound(target_turf, 'sound/weapons/fixer/generic/finisher1.ogg', 50, TRUE)
+
+	var/modified_damage = ranged_damage * force_multiplier
+	var/targets_hit = 0
+	var/list/been_hit = list()
+	for(var/turf/open/T in range(target_turf, aoe_radius))
+		new /obj/effect/temp_visual/smash_effect(T)
+		for(var/mob/living/L in user.HurtInTurf(T, been_hit, modified_damage, RED_DAMAGE, hurt_mechs = TRUE, attack_type = (ATTACK_TYPE_SPECIAL)))
+			if(L in been_hit)
+				continue
+			if(L.stat < DEAD && !(L.status_flags & GODMODE))
+				been_hit += L
+				targets_hit++
+				L.apply_lc_bleed(4)
+
+	// Sanguine Deluge bonus: heal 5% max SP per target hit
+	if(heals_sp && targets_hit > 0 && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		var/sp_per_target = round(H.maxSanity * 0.05)
+		H.adjustSanityLoss(-(sp_per_target * targets_hit))
+		to_chat(user, span_nicegreen("[mode_name]: Healed [sp_per_target * targets_hit] SP from [targets_hit] target\s!"))
+
+	to_chat(user, span_warning("[mode_name]: [targets_hit] target\s hit! ([bones]/[max_bones] Bones, [blood]/[max_blood] Blood remaining)"))
+
+/obj/item/ego_weapon/city/ring/tibia/examine(mob/user)
+	. = ..()
+	var/mode_desc
+	switch(ranged_mode)
+		if("shrapnel")
+			mode_desc = "Bone Shrapnel (60 Bones) - 3x3 burst of bone fragments"
+		if("lance")
+			mode_desc = "Marrow Lance (120 Bones) - Piercing marrow projectile with WHITE damage"
+		if("deluge")
+			mode_desc = "Sanguine Deluge (206 Bones + 5 Blood) - Massive 5x5 blood eruption"
+		if("needle")
+			mode_desc = "Crimson Needle (2 Blood) - Piercing blood projectile"
+	. += span_notice("Corpus Ingredients: [bones]/[max_bones] Bones, [blood]/[max_blood] Blood")
+	. += span_notice("Ranged Mode: [mode_desc]")
+
+// Warning visual for Tibia ranged attacks - 96x96 purple warning indicator
+/obj/effect/temp_visual/tibia_warning
+	name = "ominous shadow"
+	desc = "GET OUT OF THE WAY!"
+	icon = 'icons/effects/96x96.dmi'
+	icon_state = "warning"
+	color = "#ff4141"
+	pixel_x = -32
+	base_pixel_x = -32
+	pixel_y = -32
+	base_pixel_y = -32
+	randomdir = FALSE
+	duration = 8
+	layer = POINT_LAYER
+
+// Spread warning for Sanguine Deluge outer turfs
+/obj/effect/temp_visual/tibia_spread_warning
+	name = "spreading shadow"
+	desc = "GET OUT OF THE WAY!"
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "spreadwarning"
+	color = "#ff4141"
+	layer = BELOW_MOB_LAYER
+	duration = 8
+	alpha = 128
+	randomdir = FALSE
+
+// Marrow Lance - piercing projectile for Tibia Lance mode
+// Passes through all mobs, applying bleed and WHITE damage to each
+/obj/projectile/ego_bullet/tibia_lance
+	name = "marrow lance"
+	icon_state = "ochre"
+	damage = 80
+	damage_type = RED_DAMAGE
+	projectile_piercing = PASSMOB
+	range = 14
+	hit_nondense_targets = TRUE
+	/// WHITE damage bonus applied on hit
+	var/white_bonus = 20
+
+/obj/projectile/ego_bullet/tibia_lance/Moved(atom/OldLoc, Dir)
+	. = ..()
+	if(fired)
+		new /obj/effect/temp_visual/impact_effect/ion(get_turf(src))
+
+/obj/projectile/ego_bullet/tibia_lance/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+	if(isliving(target))
+		var/mob/living/L = target
+		if(L.stat < DEAD)
+			L.apply_lc_bleed(4)
+			L.deal_damage(white_bonus, WHITE_DAMAGE, firer, attack_type = (ATTACK_TYPE_RANGED))
+
+// Crimson Needle - piercing projectile for Tibia Needle mode
+// Passes through all mobs, applying bleed to each
+/obj/projectile/ego_bullet/tibia_needle
+	name = "crimson needle"
+	icon_state = "banquet"
+	damage = 30
+	damage_type = RED_DAMAGE
+	projectile_piercing = PASSMOB
+	range = 14
+	hit_nondense_targets = TRUE
+
+/obj/projectile/ego_bullet/tibia_needle/Moved(atom/OldLoc, Dir)
+	. = ..()
+	if(fired)
+		var/obj/effect/temp_visual/impact_effect/ion/trail = new(get_turf(src))
+		trail.color = "#8B0000"
+
+/obj/projectile/ego_bullet/tibia_needle/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+	if(isliving(target))
+		var/mob/living/L = target
+		if(L.stat < DEAD)
+			L.apply_lc_bleed(8)
+
+// Fascia - Phase 1 weapon (Defensive phase)
+// Summoned from Iron Maiden armor. Heavy greatsword that inflicts bleed on hit.
+// Use in hand to activate Iron Curtain - massively boosts armor's reflect damage.
+/obj/item/ego_weapon/city/ring/fascia
+	name = "Fascia"
+	desc = "A white and yellow greatsword carried by Corporist apprentices. A removable panel on its side conceals a dark, skeletal frame with an interior made of viscera and ribs."
+	icon_state = "fascia"
+	inhand_icon_state = "fascia"
+	force = 90
+	damtype = RED_DAMAGE
+	attack_speed = 1.4
+	swingstyle = WEAPONSWING_LARGESWEEP
+	attack_verb_continuous = list("slashes", "cuts", "cleaves")
+	attack_verb_simple = list("slash", "cut", "cleave")
+	hitsound = 'sound/weapons/bladeslice.ogg'
+	attribute_requirements = list()
+	actions_types = list(/datum/action/item_action/fascia_heartbeat_surge)
+
+	/// Linked armor reference
+	var/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/linked_armor
+	/// Iron Curtain cooldown tracker (world.time)
+	var/iron_curtain_cooldown
+	/// Whether a ghost spirit inhabits this weapon
+	var/possessed = FALSE
+	/// The spirit mob inhabiting this weapon
+	var/mob/living/simple_animal/fascia_spirit/bound_spirit
+	/// Whether the next attack is empowered by the spirit
+	var/empowered = FALSE
+	/// Bonus RED damage dealt on empowered strike
+	var/empower_bonus = 30
+	/// Timer ID for empower expiry
+	var/empower_timer_id
+	/// Heartbeat Surge cooldown tracker (world.time)
+	var/heartbeat_surge_cooldown
+	/// Whether Heartbeat Surge targeting is active
+	var/special_ability_targeting = FALSE
+	/// Whether a surge is currently in progress
+	var/is_surging = FALSE
+	/// Reference to the planted sword visual
+	var/obj/structure/fascia_planted/planted_visual
+
+/obj/item/ego_weapon/city/ring/fascia/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, "ring_fascia")
+
+/obj/item/ego_weapon/city/ring/fascia/Destroy()
+	if(empower_timer_id)
+		deltimer(empower_timer_id)
+	if(bound_spirit)
+		// Spirit is qdel'd only if armor can't shelter it (armor handles transfer via shelter_spirit_from_weapon)
+		if(!linked_armor)
+			QDEL_NULL(bound_spirit)
+		bound_spirit = null
+	if(linked_armor)
+		linked_armor.phase1_weapon = null
+		linked_armor = null
+	return ..()
+
+/obj/item/ego_weapon/city/ring/fascia/relaymove(mob/living/user, direction)
+	return //stops buckled message spam for the spirit
+
+/obj/item/ego_weapon/city/ring/fascia/AllowDrop()
+	return FALSE
+
+/obj/item/ego_weapon/city/ring/fascia/equip_to_best_slot(mob/M, check_hand = TRUE)
+	to_chat(M, span_warning("The Fascia refuses to leave your grasp!"))
+	return FALSE
+
+/obj/item/ego_weapon/city/ring/fascia/mob_can_equip(mob/living/M, mob/living/equipper, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE)
+	if(slot != ITEM_SLOT_HANDS)
+		to_chat(M, span_warning("The Fascia refuses to leave your grasp!"))
+		return FALSE
+	return ..()
+
+/obj/item/ego_weapon/city/ring/fascia/canStrip(mob/who)
+	return FALSE
+
+/obj/item/ego_weapon/city/ring/fascia/attackby(obj/item/I, mob/user, params)
+	// Allow feeding the spirit with food or bodyparts
+	if(possessed && bound_spirit)
+		if(istype(I, /obj/item/food) || istype(I, /obj/item/bodypart))
+			if(bound_spirit.feed(I, user))
+				return
+	return ..()
+
+/obj/item/ego_weapon/city/ring/fascia/examine(mob/user)
+	. = ..()
+	// Only show hunger info to the wielder
+	if(possessed && bound_spirit && ismob(loc) && user == loc)
+		var/hunger_percent = round((bound_spirit.hunger / bound_spirit.max_hunger) * 100)
+		var/multiplier = bound_spirit.get_damage_multiplier()
+		var/damage_mod = round((multiplier - 1) * 100)
+		var/mod_text
+		if(damage_mod > 0)
+			mod_text = span_nicegreen("+[damage_mod]%")
+		else if(damage_mod < 0)
+			mod_text = span_warning("[damage_mod]%")
+		else
+			mod_text = "0%"
+		. += span_notice("Fascia's hunger: [round(bound_spirit.hunger)]/[bound_spirit.max_hunger] ([hunger_percent]%)")
+		. += span_notice("Damage modifier: [mod_text]")
+		. += span_notice("Feed it with food or organic bodyparts to increase hunger.")
+
+/obj/item/ego_weapon/city/ring/fascia/equipped(mob/user, slot)
+	. = ..()
+	if(slot == ITEM_SLOT_HANDS)
+		RegisterSignal(user, COMSIG_PARENT_EXAMINE, PROC_REF(on_wielder_examined))
+
+/obj/item/ego_weapon/city/ring/fascia/dropped(mob/user)
+	UnregisterSignal(user, COMSIG_PARENT_EXAMINE)
+	return ..()
+
+/// Called when the wielder is examined - shows possession prompt to ghosts
+/obj/item/ego_weapon/city/ring/fascia/proc/on_wielder_examined(datum/source, mob/examiner, list/examine_list)
+	SIGNAL_HANDLER
+	if(isobserver(examiner) && !possessed)
+		examine_list += span_notice("The blade calls out... <a href='byond://?src=[REF(src)];interact=1'>Listen closely.</a>")
+
+/obj/item/ego_weapon/city/ring/fascia/attack_ghost(mob/user)
+	if(!isobserver(user))
+		return
+	try_possess(user)
+	return ..()
+
+/obj/item/ego_weapon/city/ring/fascia/Topic(href, href_list)
+	. = ..()
+	if(href_list["interact"] && isobserver(usr))
+		try_possess(usr)
+
+/// Attempts to let a ghost possess this weapon
+/obj/item/ego_weapon/city/ring/fascia/proc/try_possess(mob/dead/observer/O)
+	if(possessed)
+		to_chat(O, span_warning("This blade is already inhabited!"))
+		return
+	if(!isobserver(O))
+		return
+	if(!(GLOB.ghost_role_flags & GHOSTROLE_STATION_SENTIENCE))
+		to_chat(O, span_warning("Ghost roles are not currently enabled!"))
+		return
+
+	var/response = tgui_alert(O, "Do you wish to inhabit this blade?", "Fascia", list("Yes", "No"))
+	if(response != "Yes")
+		return
+	if(QDELETED(src) || QDELETED(O) || possessed)
+		return
+
+	possessed = TRUE
+	var/mob/living/simple_animal/fascia_spirit/S = new(src)
+	S.ckey = O.ckey
+	S.fully_replace_character_name(null, "The spirit of [name]")
+	S.status_flags |= GODMODE
+	S.bound_weapon = src
+	bound_spirit = S
+
+	// Copy languages from wielder
+	var/mob/living/wielder = get_wielder()
+	if(wielder)
+		S.copy_languages(wielder, LANGUAGE_MASTER)
+		S.update_atom_languages()
+		S.grant_all_languages(FALSE, FALSE, TRUE)
+
+	// Grant spirit actions
+	var/datum/action/cooldown/fascia_empower_strike/empower_action = new(S)
+	empower_action.weapon_ref = WEAKREF(src)
+	empower_action.Grant(S)
+
+	var/datum/action/cooldown/fascia_compel_dash/dash_action = new(S)
+	dash_action.weapon_ref = WEAKREF(src)
+	dash_action.Grant(S)
+
+	// Grant info actions
+	var/datum/action/innate/view_role_rules/fascia/rules_action = new(S)
+	rules_action.Grant(S)
+
+	var/datum/action/innate/check_fascia_hunger/hunger_action = new(S)
+	hunger_action.Grant(S)
+
+	to_chat(S, span_nicegreen("You inhabit the Fascia! You can speak to the wielder via say. Use your actions to aid them in battle and keep yourself fed!"))
+	if(wielder)
+		to_chat(wielder, span_nicegreen("A spirit has inhabited your Fascia!"))
+
+/// Returns the mob currently wielding this weapon
+/obj/item/ego_weapon/city/ring/fascia/proc/get_wielder()
+	if(ismob(loc))
+		return loc
+	return null
+
+/// Clears the empower state
+/obj/item/ego_weapon/city/ring/fascia/proc/clear_empower()
+	empowered = FALSE
+	empower_timer_id = null
+	remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, "#FFD700")
+
+/obj/item/ego_weapon/city/ring/fascia/attack(mob/living/target, mob/living/user)
+	if(is_surging)
+		return FALSE
+	// Cannot attack while Iron Curtain is active
+	if(linked_armor?.iron_curtain)
+		to_chat(user, span_warning("You cannot attack while Iron Curtain is active!"))
+		return FALSE
+	// Apply hunger damage multiplier from spirit
+	var/original_force = force
+	if(possessed && bound_spirit)
+		force = round(force * bound_spirit.get_damage_multiplier())
+	. = ..()
+	force = original_force
+	// Inflict 3 bleed stacks on hit
+	if(target && !QDELETED(target) && target.stat != DEAD)
+		target.apply_lc_bleed(3)
+	// Empowered strike from spirit
+	if(empowered && target && !QDELETED(target) && target.stat != DEAD)
+		var/modified_empower = empower_bonus
+		if(possessed && bound_spirit)
+			modified_empower = round(empower_bonus * bound_spirit.get_damage_multiplier())
+		target.deal_damage(modified_empower, RED_DAMAGE)
+		to_chat(user, span_nicegreen("The Fascia's empowered strike lands! (+[modified_empower] RED)"))
+		if(bound_spirit)
+			to_chat(bound_spirit, span_nicegreen("Your empowered strike lands!"))
+		empowered = FALSE
+		remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, "#FFD700")
+		if(empower_timer_id)
+			deltimer(empower_timer_id)
+			empower_timer_id = null
+
+/// Heartbeat Surge targeting - click at range after activating the action
+/obj/item/ego_weapon/city/ring/fascia/afterattack(atom/target, mob/living/user, proximity_flag, params)
+	if(special_ability_targeting && !proximity_flag && isliving(user))
+		special_ability_targeting = FALSE
+		INVOKE_ASYNC(src, PROC_REF(perform_heartbeat_surge), user, get_dir(user, target))
+		return
+	return ..()
+
+/// Iron Curtain activation - use in hand to enter defensive stance
+/obj/item/ego_weapon/city/ring/fascia/attack_self(mob/user)
+	. = ..()
+	if(!linked_armor)
+		to_chat(user, span_warning("The weapon has no linked armor!"))
+		return
+
+	if(iron_curtain_cooldown > world.time)
+		var/remaining = round((iron_curtain_cooldown - world.time) / 10)
+		to_chat(user, span_warning("Iron Curtain is recharging! ([remaining] seconds remaining)"))
+		return
+
+	if(linked_armor.iron_curtain)
+		to_chat(user, span_warning("Iron Curtain is already active!"))
+		return
+
+	// Set cooldown (5s duration + 20s CD = 25s between activations)
+	iron_curtain_cooldown = world.time + 25 SECONDS
+	linked_armor.activate_iron_curtain()
+
+// Fascia Unleashed - Phase 2 weapon (Offensive phase)
+// Summoned when the Iron Maiden armor transitions to phase 2 at 50% HP.
+// Click at range to leap to a target turf. Deals damage to adjacent mobs on landing.
+/obj/item/ego_weapon/city/ring/fascia_unleashed
+	name = "Fascia"
+	desc = "The Fascia's panel has been torn away, revealing the dark skeletal frame beneath. Viscera and ribs pulse with violent energy, freed from their confines."
+	icon_state = "fascia_unleashed"
+	inhand_icon_state = "fascia_unleashed"
+	force = 90
+	damtype = RED_DAMAGE
+	attack_speed = 1.4
+	swingstyle = WEAPONSWING_LARGESWEEP
+	attack_verb_continuous = list("rends", "tears", "rips")
+	attack_verb_simple = list("rend", "tear", "rip")
+	hitsound = 'sound/weapons/bladeslice.ogg'
+	attribute_requirements = list()
+	actions_types = list(/datum/action/item_action/fascia_heartbeat_surge)
+
+	/// Linked armor reference
+	var/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/linked_armor
+	/// Whether the user is currently mid-leap
+	var/is_leaping = FALSE
+	/// Leap cooldown tracker (world.time)
+	var/leap_cooldown
+	/// Maximum leap range in tiles
+	var/leap_range = 7
+	/// Timer ID for slowdown removal on missed leap
+	var/leap_slowdown_timer_id
+	/// Whether a ghost spirit inhabits this weapon
+	var/possessed = FALSE
+	/// The spirit mob inhabiting this weapon
+	var/mob/living/simple_animal/fascia_spirit/bound_spirit
+	/// Whether the next attack is empowered by the spirit
+	var/empowered = FALSE
+	/// Bonus RED damage dealt on empowered strike
+	var/empower_bonus = 30
+	/// Timer ID for empower expiry
+	var/empower_timer_id
+	/// Heartbeat Surge cooldown tracker (world.time)
+	var/heartbeat_surge_cooldown
+	/// Whether Heartbeat Surge targeting is active
+	var/special_ability_targeting = FALSE
+	/// Whether a surge is currently in progress
+	var/is_surging = FALSE
+	/// Reference to the planted sword visual
+	var/obj/structure/fascia_planted/planted_visual
+
+/obj/item/ego_weapon/city/ring/fascia_unleashed/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, "ring_fascia")
+
+/obj/item/ego_weapon/city/ring/fascia_unleashed/Destroy()
+	if(empower_timer_id)
+		deltimer(empower_timer_id)
+	if(bound_spirit)
+		// Spirit is qdel'd only if armor can't shelter it (armor handles transfer via shelter_spirit_from_weapon)
+		if(!linked_armor)
+			QDEL_NULL(bound_spirit)
+		bound_spirit = null
+	if(leap_slowdown_timer_id)
+		deltimer(leap_slowdown_timer_id)
+	if(linked_armor)
+		linked_armor.phase2_weapon = null
+		linked_armor = null
+	return ..()
+
+/obj/item/ego_weapon/city/ring/fascia_unleashed/relaymove(mob/living/user, direction)
+	return //stops buckled message spam for the spirit
+
+/obj/item/ego_weapon/city/ring/fascia_unleashed/AllowDrop()
+	return FALSE
+
+/obj/item/ego_weapon/city/ring/fascia_unleashed/equip_to_best_slot(mob/M, check_hand = TRUE)
+	to_chat(M, span_warning("The Fascia refuses to leave your grasp!"))
+	return FALSE
+
+/obj/item/ego_weapon/city/ring/fascia_unleashed/mob_can_equip(mob/living/M, mob/living/equipper, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE)
+	if(slot != ITEM_SLOT_HANDS)
+		to_chat(M, span_warning("The Fascia refuses to leave your grasp!"))
+		return FALSE
+	return ..()
+
+/obj/item/ego_weapon/city/ring/fascia_unleashed/canStrip(mob/who)
+	return FALSE
+
+/obj/item/ego_weapon/city/ring/fascia_unleashed/attack(mob/living/target, mob/living/user)
+	if(is_surging)
+		return FALSE
+	// Apply hunger damage multiplier from spirit
+	var/original_force = force
+	if(possessed && bound_spirit)
+		force = round(force * bound_spirit.get_damage_multiplier())
+	. = ..()
+	force = original_force
+	// Inflict 3 bleed stacks on hit
+	if(target && !QDELETED(target) && target.stat != DEAD)
+		target.apply_lc_bleed(3)
+	// Empowered strike from spirit
+	if(empowered && target && !QDELETED(target) && target.stat != DEAD)
+		var/modified_empower = empower_bonus
+		if(possessed && bound_spirit)
+			modified_empower = round(empower_bonus * bound_spirit.get_damage_multiplier())
+		target.deal_damage(modified_empower, RED_DAMAGE)
+		to_chat(user, span_nicegreen("The Fascia's empowered strike lands! (+[modified_empower] RED)"))
+		if(bound_spirit)
+			to_chat(bound_spirit, span_nicegreen("Your empowered strike lands!"))
+		empowered = FALSE
+		remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, "#FFD700")
+		if(empower_timer_id)
+			deltimer(empower_timer_id)
+			empower_timer_id = null
+
+/// Clears the empower state
+/obj/item/ego_weapon/city/ring/fascia_unleashed/proc/clear_empower()
+	empowered = FALSE
+	empower_timer_id = null
+	remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, "#FFD700")
+
+/// Returns the mob currently wielding this weapon
+/obj/item/ego_weapon/city/ring/fascia_unleashed/proc/get_wielder()
+	if(ismob(loc))
+		return loc
+	return null
+
+/// Leap attack or Heartbeat Surge - click at range
+/obj/item/ego_weapon/city/ring/fascia_unleashed/afterattack(atom/target, mob/living/user, proximity_flag, params)
+	// Heartbeat Surge targeting takes priority
+	if(special_ability_targeting && !proximity_flag && isliving(user))
+		special_ability_targeting = FALSE
+		INVOKE_ASYNC(src, PROC_REF(perform_heartbeat_surge), user, get_dir(user, target))
+		return
+	. = ..()
+	if(proximity_flag)
+		return
+	if(is_leaping || is_surging)
+		return
+	if(!isliving(user))
+		return
+	if(leap_cooldown > world.time)
+		var/remaining = round((leap_cooldown - world.time) / 10)
+		to_chat(user, span_warning("Your leap is still recharging! ([remaining] seconds remaining)"))
+		return
+
+	// Save the target turf at click time (even if target moves, we leap to original position)
+	var/turf/target_turf = get_turf(target)
+	if(!target_turf)
+		return
+
+	var/turf/user_turf = get_turf(user)
+	var/distance = get_dist(user_turf, target_turf)
+
+	if(distance < 2)
+		return // Adjacent, no leap needed
+	if(distance > leap_range)
+		to_chat(user, span_warning("Target is too far away!"))
+		return
+
+	// Check path for dense turfs blocking the way
+	for(var/turf/T in getline(user_turf, target_turf))
+		if(T == user_turf)
+			continue
+		if(T.density)
+			to_chat(user, span_warning("Something is blocking your path!"))
+			return
+
+	// Begin leap
+	is_leaping = TRUE
+
+	// Jump animation - lift up
+	playsound(user, 'sound/abnormalities/ichthys/jump.ogg', 50, FALSE, -1)
+	animate(user, pixel_z = 16, alpha = 180, time = 2)
+
+	// Short delay mid-air
+	if(!do_after(user, 0.8 SECONDS, user))
+		is_leaping = FALSE
+		animate(user, pixel_z = 0, alpha = 255, time = 1)
+		user.pixel_z = 0
+		return
+
+	if(QDELETED(user))
+		return
+
+	// Land at target turf (original position, even if target moved)
+	user.forceMove(target_turf)
+	animate(user, pixel_z = 0, alpha = 255, time = 1)
+	user.pixel_z = 0
+	playsound(user, 'sound/weapons/fixer/generic/finisher1.ogg', 50, FALSE, -1)
+
+	is_leaping = FALSE
+
+	// Check for adjacent living mobs
+	var/found_adjacent = FALSE
+	for(var/mob/living/L in range(1, user))
+		if(L == user)
+			continue
+		if(L.stat == DEAD)
+			continue
+		// Deal 15 RED damage to each adjacent living mob
+		found_adjacent = TRUE
+		L.deal_damage(15, RED_DAMAGE, user, attack_type = (ATTACK_TYPE_MELEE | ATTACK_TYPE_SPECIAL))
+		to_chat(L, span_userdanger("[user] crashes down near you!"))
+
+	if(found_adjacent)
+		// Short cooldown on successful landing near enemies
+		leap_cooldown = world.time + 1.5 SECONDS
+		to_chat(user, span_warning("You crash down onto your targets!"))
+	else
+		// No adjacent mobs - apply slowdown and longer cooldown
+		apply_leap_slowdown(user)
+		leap_cooldown = world.time + 10 SECONDS
+		to_chat(user, span_warning("You land but find no target nearby..."))
+
+/// Applies temporary slowdown after a missed leap (no adjacent enemies)
+/obj/item/ego_weapon/city/ring/fascia_unleashed/proc/apply_leap_slowdown(mob/living/user)
+	if(leap_slowdown_timer_id)
+		deltimer(leap_slowdown_timer_id)
+	user.add_movespeed_modifier(/datum/movespeed_modifier/fascia_leap_miss)
+	leap_slowdown_timer_id = addtimer(CALLBACK(src, PROC_REF(remove_leap_slowdown), user), 2.5 SECONDS, TIMER_STOPPABLE)
+
+/// Removes the leap miss slowdown
+/obj/item/ego_weapon/city/ring/fascia_unleashed/proc/remove_leap_slowdown(mob/living/user)
+	leap_slowdown_timer_id = null
+	if(user && !QDELETED(user))
+		user.remove_movespeed_modifier(/datum/movespeed_modifier/fascia_leap_miss)
+
+// ========== FASCIA SPIRIT ==========
+// Ghost mob that lives inside the Fascia weapon. Speaks privately to the wielder.
+
+/mob/living/simple_animal/fascia_spirit
+	name = "Fascia Spirit"
+	real_name = "Fascia Spirit"
+	desc = "A bound spirit inhabiting the Fascia."
+	icon = 'icons/mob/cult.dmi'
+	icon_state = "shade"
+	icon_living = "shade"
+	mob_biotypes = MOB_SPIRIT
+	maxHealth = 100
+	health = 100
+	density = FALSE
+	move_resist = INFINITY
+	speak_emote = list("whispers")
+	faction = list("neutral")
+	status_flags = GODMODE
+	del_on_death = FALSE
+
+	/// The weapon this spirit inhabits (null when sheltered in armor)
+	var/obj/item/bound_weapon
+	/// Spirit hunger level (0-100, starts at 50)
+	var/hunger = 50
+	/// Maximum hunger level
+	var/max_hunger = 100
+	/// Hunger decay per Life() tick (0.067 = ~10 hunger per 5 minutes)
+	var/hunger_decay = 0.067
+
+/mob/living/simple_animal/fascia_spirit/Initialize()
+	. = ..()
+
+/// Returns the damage multiplier based on hunger (0 hunger = -25%, 50 = 0%, 100 = +10%)
+/mob/living/simple_animal/fascia_spirit/proc/get_damage_multiplier()
+	if(hunger <= 50)
+		// Scale from -25% at 0 to 0% at 50
+		return 1 + ((hunger - 50) * 0.005)
+	else
+		// Scale from 0% at 50 to +10% at 100
+		return 1 + ((hunger - 50) * 0.002)
+
+/// Feed the Fascia with food or bodyparts
+/mob/living/simple_animal/fascia_spirit/proc/feed(obj/item/I, mob/user)
+	var/feed_amount = 0
+
+	if(istype(I, /obj/item/food))
+		feed_amount = 10
+		to_chat(user, span_notice("You feed [I] to the Fascia. It seems satisfied."))
+	else if(istype(I, /obj/item/bodypart))
+		var/obj/item/bodypart/BP = I
+		if(BP.status == BODYPART_ROBOTIC)
+			to_chat(user, span_warning("The Fascia rejects the robotic limb with disgust."))
+			return FALSE
+		feed_amount = 15
+		to_chat(user, span_notice("You feed [I] to the Fascia. It hungrily consumes the flesh!"))
+	else
+		return FALSE
+
+	hunger = clamp(hunger + feed_amount, 0, max_hunger)
+	to_chat(src, span_nicegreen("You consume the offering! Hunger: [round(hunger)]/[max_hunger]"))
+	playsound(user, 'sound/items/eatfood.ogg', 50, TRUE)
+	qdel(I)
+	return TRUE
+
+/mob/living/simple_animal/fascia_spirit/say(message, bubble_type, list/spans, sanitize, datum/language/language, ignore_spam, forced)
+	if(!message)
+		return
+	// Find the wearer - check weapon first, then armor
+	var/mob/living/wielder
+	if(bound_weapon && ismob(bound_weapon.loc))
+		wielder = bound_weapon.loc
+	else
+		// Spirit is sheltered in armor - find armor_wearer
+		var/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/armor = loc
+		if(istype(armor) && armor.armor_wearer)
+			wielder = armor.armor_wearer
+	if(wielder)
+		to_chat(wielder, span_notice("Fascia whispers: \"[message]\""))
+		to_chat(src, span_notice("You whisper: \"[message]\""))
+	else
+		to_chat(src, span_warning("No one can hear you..."))
+
+/mob/living/simple_animal/fascia_spirit/Life()
+	. = ..()
+	// Keep health stable
+	health = maxHealth
+	// Decay hunger over time
+	if(hunger > 0)
+		hunger = max(0, hunger - hunger_decay)
+		// Warn wielder at low hunger
+		if(hunger == 25 || hunger == 10 || hunger == 0)
+			var/mob/living/wielder
+			if(bound_weapon && ismob(bound_weapon.loc))
+				wielder = bound_weapon.loc
+			if(wielder)
+				if(hunger == 0)
+					to_chat(wielder, span_boldwarning("The Fascia is starving! Weapon damage reduced by 25%."))
+				else
+					to_chat(wielder, span_warning("The Fascia hungers... ([round(hunger)]/[max_hunger])"))
+
+/mob/living/simple_animal/fascia_spirit/death(gibbed)
+	return // Cannot die
+
+/mob/living/simple_animal/fascia_spirit/Destroy()
+	// Clear refs on whatever contains us
+	if(bound_weapon)
+		var/obj/item/ego_weapon/city/ring/fascia/F1 = bound_weapon
+		var/obj/item/ego_weapon/city/ring/fascia_unleashed/F2 = bound_weapon
+		if(istype(F1))
+			F1.bound_spirit = null
+			F1.possessed = FALSE
+		else if(istype(F2))
+			F2.bound_spirit = null
+			F2.possessed = FALSE
+		bound_weapon = null
+	var/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/armor = loc
+	if(istype(armor))
+		armor.bound_spirit = null
+		armor.possessed = FALSE
+	return ..()
+
+// ========== FASCIA SPIRIT ACTIONS ==========
+
+// Empower Strike - empowers the next weapon attack within 1.5 seconds
+/datum/action/cooldown/fascia_empower_strike
+	name = "Empower Strike"
+	desc = "Empower the wielder's next attack within 1.5 seconds, dealing +30 bonus RED damage."
+	icon_icon = 'icons/obj/spider_house/ring/ring_icons.dmi'
+	button_icon_state = "fascia"
+	cooldown_time = 7 SECONDS
+	check_flags = AB_CHECK_CONSCIOUS
+
+	/// Reference to the weapon
+	var/datum/weakref/weapon_ref
+
+/datum/action/cooldown/fascia_empower_strike/Trigger(trigger_flags)
+	. = ..(trigger_flags)
+	if(!.)
+		return FALSE
+
+	var/obj/item/weapon = weapon_ref?.resolve()
+	if(!weapon)
+		return FALSE
+
+	// Find the wielder
+	var/mob/living/wielder
+	if(ismob(weapon.loc))
+		wielder = weapon.loc
+	if(!wielder)
+		to_chat(owner, span_warning("The blade has no wielder!"))
+		return FALSE
+
+	// Set empower on the weapon (works for both fascia types)
+	var/obj/item/ego_weapon/city/ring/fascia/F1 = weapon
+	var/obj/item/ego_weapon/city/ring/fascia_unleashed/F2 = weapon
+	if(istype(F1))
+		F1.empowered = TRUE
+		F1.add_atom_colour("#FFD700", TEMPORARY_COLOUR_PRIORITY)
+		if(F1.empower_timer_id)
+			deltimer(F1.empower_timer_id)
+		F1.empower_timer_id = addtimer(CALLBACK(F1, TYPE_PROC_REF(/obj/item/ego_weapon/city/ring/fascia, clear_empower)), 1.5 SECONDS, TIMER_STOPPABLE)
+	else if(istype(F2))
+		F2.empowered = TRUE
+		F2.add_atom_colour("#FFD700", TEMPORARY_COLOUR_PRIORITY)
+		if(F2.empower_timer_id)
+			deltimer(F2.empower_timer_id)
+		F2.empower_timer_id = addtimer(CALLBACK(F2, TYPE_PROC_REF(/obj/item/ego_weapon/city/ring/fascia_unleashed, clear_empower)), 1.5 SECONDS, TIMER_STOPPABLE)
+	else
+		return FALSE
+
+	playsound(wielder, 'sound/magic/charge.ogg', 50, TRUE)
+	to_chat(wielder, span_nicegreen("The Fascia surges with power!"))
+	to_chat(owner, span_nicegreen("You empower the blade!"))
+	StartCooldown()
+	return TRUE
+
+/datum/action/cooldown/fascia_empower_strike/Destroy()
+	weapon_ref = null
+	return ..()
+
+// Compel Dash - forces the wielder to dash 5 tiles in their facing direction, damaging mobs along the path
+/datum/action/cooldown/fascia_compel_dash
+	name = "Compel Dash"
+	desc = "Compel the wielder to dash 5 tiles in their facing direction, dealing 50 RED damage to all in the way."
+	icon_icon = 'icons/effects/cult_effects.dmi'
+	button_icon_state = "pulse"
+	cooldown_time = 5 SECONDS
+	check_flags = AB_CHECK_CONSCIOUS
+
+	/// Reference to the weapon
+	var/datum/weakref/weapon_ref
+	/// Whether a dash is currently in progress
+	var/is_dashing = FALSE
+
+/datum/action/cooldown/fascia_compel_dash/Trigger(trigger_flags)
+	. = ..(trigger_flags)
+	if(!.)
+		return FALSE
+
+	if(is_dashing)
+		return FALSE
+
+	var/obj/item/weapon = weapon_ref?.resolve()
+	if(!weapon)
+		return FALSE
+
+	// Find the wielder
+	var/mob/living/wielder
+	if(ismob(weapon.loc))
+		wielder = weapon.loc
+	if(!wielder || wielder.stat == DEAD)
+		to_chat(owner, span_warning("The blade has no living wielder!"))
+		return FALSE
+
+	INVOKE_ASYNC(src, PROC_REF(perform_dash), wielder)
+	StartCooldown()
+	return TRUE
+
+/// Performs a ScratchDash-style dash, moving tile-by-tile and damaging nearby mobs
+/datum/action/cooldown/fascia_compel_dash/proc/perform_dash(mob/living/wielder)
+	is_dashing = TRUE
+	var/dash_dir = wielder.dir
+	var/list/hit_mob = list()
+
+	playsound(wielder, 'sound/abnormalities/ichthys/jump.ogg', 50, FALSE, -1)
+	to_chat(wielder, span_warning("The Fascia compels you forward!"))
+	to_chat(owner, span_nicegreen("You compel the wielder to dash!"))
+
+	var/turf/current_turf = get_turf(wielder)
+	for(var/i = 1 to 5)
+		if(QDELETED(wielder) || wielder.stat == DEAD)
+			break
+		if(get_turf(wielder) != current_turf)
+			break
+		var/turf/next_turf = get_step(wielder, dash_dir)
+		if(!next_turf || isclosedturf(next_turf))
+			break
+		if(locate(/obj/structure/window) in next_turf.contents)
+			break
+		if(locate(/obj/structure/table) in next_turf.contents)
+			break
+		if(locate(/obj/structure/railing) in next_turf.contents)
+			break
+		var/door_blocked = FALSE
+		for(var/obj/machinery/door/D in next_turf.contents)
+			if(D.density)
+				door_blocked = TRUE
+				break
+		if(door_blocked)
+			break
+		sleep(1)
+		wielder.forceMove(next_turf)
+		current_turf = next_turf
+		playsound(next_turf, 'sound/abnormalities/doomsdaycalendar/Lor_Slash_Generic.ogg', 20, 0, 4)
+		for(var/turf/T in orange(get_turf(wielder), 1))
+			if(isclosedturf(T))
+				continue
+			new /obj/effect/temp_visual/slice(T)
+			hit_mob = wielder.HurtInTurf(T, hit_mob, 50, RED_DAMAGE, attack_type = (ATTACK_TYPE_MELEE | ATTACK_TYPE_SPECIAL))
+
+	is_dashing = FALSE
+
+/datum/action/cooldown/fascia_compel_dash/Destroy()
+	weapon_ref = null
+	return ..()
+
+// ========== HEARTBEAT SURGE ==========
+// Action that lets the wielder plant their blade, dash forward, and claw at the first living target hit.
+// Available on both Fascia phases.
+
+/// Planted sword visual - cannot be interacted with
+/obj/structure/fascia_planted
+	name = "planted Fascia"
+	desc = "The Fascia, driven into the ground."
+	icon = 'ModularLobotomy/_Lobotomyicons/lc13_weapons.dmi'
+	icon_state = "planted_fascia"
+	anchored = TRUE
+	density = FALSE
+	resistance_flags = INDESTRUCTIBLE
+
+/obj/structure/fascia_planted/attack_hand(mob/living/user, list/modifiers)
+	to_chat(user, span_warning("The blade is firmly planted and will not budge."))
+	return TRUE
+
+/obj/structure/fascia_planted/attackby(obj/item/I, mob/user, params)
+	return TRUE
+
+/// Heartbeat Surge action button - toggles targeting mode
+/datum/action/item_action/fascia_heartbeat_surge
+	name = "Heartbeat Surge"
+	desc = "Plant your blade and dash forward, clawing at the first target you hit. Click a direction after activating."
+	icon_icon = 'icons/obj/spider_house/ring/ring_icons.dmi'
+	button_icon_state = "fascia"
+
+/datum/action/item_action/fascia_heartbeat_surge/Trigger()
+	var/obj/item/ego_weapon/city/ring/fascia/F1 = owner.get_active_held_item()
+	var/obj/item/ego_weapon/city/ring/fascia_unleashed/F2 = owner.get_active_held_item()
+	if(istype(F1))
+		if(F1.is_surging)
+			return
+		if(F1.heartbeat_surge_cooldown > world.time)
+			var/remaining = round((F1.heartbeat_surge_cooldown - world.time) / 10)
+			to_chat(owner, span_warning("Heartbeat Surge is recharging! ([remaining] seconds remaining)"))
+			return
+		F1.special_ability_targeting = !F1.special_ability_targeting
+		if(F1.special_ability_targeting)
+			to_chat(owner, span_colossus("Let the cadence of your heartbeat surge, Fascia..."))
+		else
+			to_chat(owner, span_notice("You lower your stance."))
+	else if(istype(F2))
+		if(F2.is_surging)
+			return
+		if(F2.heartbeat_surge_cooldown > world.time)
+			var/remaining = round((F2.heartbeat_surge_cooldown - world.time) / 10)
+			to_chat(owner, span_warning("Heartbeat Surge is recharging! ([remaining] seconds remaining)"))
+			return
+		F2.special_ability_targeting = !F2.special_ability_targeting
+		if(F2.special_ability_targeting)
+			to_chat(owner, span_colossus("Let the cadence of your heartbeat surge, Fascia..."))
+		else
+			to_chat(owner, span_notice("You lower your stance."))
+
+// ========== HEARTBEAT SURGE PROCS (Phase 1) ==========
+
+/// Performs the full Heartbeat Surge sequence for Phase 1 Fascia
+/obj/item/ego_weapon/city/ring/fascia/proc/perform_heartbeat_surge(mob/living/user, dash_dir)
+	if(is_surging || QDELETED(user) || user.stat == DEAD)
+		return
+
+	// Cannot use while Iron Curtain is active
+	if(linked_armor?.iron_curtain)
+		to_chat(user, span_warning("You cannot use Heartbeat Surge while Iron Curtain is active!"))
+		return
+
+	is_surging = TRUE
+	heartbeat_surge_cooldown = world.time + 15 SECONDS
+
+	var/turf/sword_turf = get_turf(user)
+	var/saved_inhand = inhand_icon_state
+	var/saved_lefthand = lefthand_file
+	var/saved_righthand = righthand_file
+
+	// Plant the sword visual
+	planted_visual = new /obj/structure/fascia_planted(sword_turf)
+	planted_visual.icon_state = "planted_fascia"
+
+	// Hide the weapon's inhand sprite
+	inhand_icon_state = null
+	lefthand_file = null
+	righthand_file = null
+	user.update_inv_hands()
+
+	playsound(user, 'sound/abnormalities/ichthys/jump.ogg', 50, FALSE, -1)
+
+	// Lift user off the ground and add shadow
+	var/lift_amount = 8
+	var/mutable_appearance/shadow_overlay = mutable_appearance('icons/obj/spider_house/ring/ring_icons.dmi', "shadow")
+	shadow_overlay.pixel_y = -lift_amount
+	shadow_overlay.alpha = 125
+	user.add_overlay(shadow_overlay)
+	animate(user, pixel_y = user.base_pixel_y + lift_amount, time = 2, easing = QUAD_EASING)
+	sleep(2)
+
+	// Dash tile-by-tile, stopping one tile before the first living mob
+	var/mob/living/victim
+	for(var/i = 1 to 5)
+		if(QDELETED(user) || user.stat == DEAD)
+			break
+		var/turf/next_turf = get_step(user, dash_dir)
+		if(!next_turf || isclosedturf(next_turf))
+			break
+		if(locate(/obj/structure/window) in next_turf.contents)
+			break
+		if(locate(/obj/structure/table) in next_turf.contents)
+			break
+		if(locate(/obj/structure/railing) in next_turf.contents)
+			break
+		var/door_blocked = FALSE
+		for(var/obj/machinery/door/D in next_turf.contents)
+			if(D.density)
+				door_blocked = TRUE
+				break
+		if(door_blocked)
+			break
+
+		// Check for a living mob on the next tile before moving there
+		for(var/mob/living/L in next_turf)
+			if(L == user || L.stat == DEAD)
+				continue
+			victim = L
+			break
+		if(victim)
+			break
+
+		sleep(1)
+		user.forceMove(next_turf)
+		playsound(next_turf, 'sound/abnormalities/doomsdaycalendar/Lor_Slash_Generic.ogg', 20, 0, 4)
+
+	// Remove shadow and lower user back to ground
+	user.cut_overlay(shadow_overlay)
+	animate(user, pixel_y = user.base_pixel_y, time = 2, easing = QUAD_EASING)
+	sleep(2)
+
+	if(victim && !QDELETED(victim) && victim.stat != DEAD)
+		perform_claw_combo(user, victim, sword_turf, saved_inhand, saved_lefthand, saved_righthand, dash_dir)
+	else
+		// No target hit — walk back to sword
+		return_to_sword(user, sword_turf)
+		cleanup_surge(user, sword_turf, saved_inhand, saved_lefthand, saved_righthand)
+
+/// Performs the 8-hit claw combo with pixel pushback
+/obj/item/ego_weapon/city/ring/fascia/proc/perform_claw_combo(mob/living/user, mob/living/target, turf/sword_turf, saved_inhand, saved_lefthand, saved_righthand, direction)
+	var/dx = 0
+	var/dy = 0
+	if(direction & EAST)
+		dx = 1
+	if(direction & WEST)
+		dx = -1
+	if(direction & NORTH)
+		dy = 1
+	if(direction & SOUTH)
+		dy = -1
+
+	// Lock both in place
+	var/combo_duration = 2.5 SECONDS
+	user.Immobilize(combo_duration)
+	user.changeNext_move(combo_duration)
+	target.Immobilize(combo_duration)
+
+	// Handle simple mobs
+	var/mob/living/simple_animal/hostile/simple_target
+	if(istype(target, /mob/living/simple_animal/hostile))
+		simple_target = target
+		simple_target.toggle_ai(AI_OFF)
+
+	// Justice scaling for damage against simple mobs
+	var/hit_damage = 10
+	if(simple_target)
+		var/justice_mod = 1 + (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE) / 100)
+		hit_damage = round(hit_damage * justice_mod)
+
+	var/accumulated_px = 0
+
+	for(var/i = 1 to 8)
+		if(QDELETED(target) || target.stat == DEAD || QDELETED(user) || user.stat == DEAD)
+			break
+		user.do_attack_animation(target, ATTACK_EFFECT_CLAW)
+		playsound(user, 'sound/weapons/slice.ogg', 50, TRUE)
+		target.deal_damage(hit_damage, RED_DAMAGE, user, attack_type = (ATTACK_TYPE_MELEE | ATTACK_TYPE_SPECIAL))
+
+		// Pixel nudge - push target back 12px, user follows
+		accumulated_px += 12
+		animate(target, pixel_x = target.base_pixel_x + (dx * accumulated_px), pixel_y = target.base_pixel_y + (dy * accumulated_px), time = 1, easing = QUAD_EASING)
+		animate(user, pixel_x = user.base_pixel_x + (dx * accumulated_px), pixel_y = user.base_pixel_y + (dy * accumulated_px), time = 1, easing = QUAD_EASING)
+
+		// Step to next tile when accumulated pushback crosses a tile boundary
+		if(accumulated_px >= 32)
+			var/turf/next = get_step(target, direction)
+			if(next && !isclosedturf(next))
+				target.forceMove(next)
+				user.forceMove(get_turf(target))
+			accumulated_px -= 32
+			target.pixel_x = target.base_pixel_x + (dx * accumulated_px)
+			target.pixel_y = target.base_pixel_y + (dy * accumulated_px)
+			user.pixel_x = user.base_pixel_x + (dx * accumulated_px)
+			user.pixel_y = user.base_pixel_y + (dy * accumulated_px)
+
+		sleep(2)
+
+	// Reset pixel offsets
+	if(!QDELETED(target))
+		animate(target, pixel_x = target.base_pixel_x, pixel_y = target.base_pixel_y, time = 2)
+	if(!QDELETED(user))
+		animate(user, pixel_x = user.base_pixel_x, pixel_y = user.base_pixel_y, time = 2)
+
+	// Reactivate simple mob AI
+	if(simple_target && !QDELETED(simple_target))
+		simple_target.toggle_ai(AI_ON)
+
+	sleep(3)
+	// Walk back to sword
+	return_to_sword(user, sword_turf)
+	// Restore weapon and feed spirit
+	cleanup_surge(user, sword_turf, saved_inhand, saved_lefthand, saved_righthand)
+	if(possessed && bound_spirit)
+		bound_spirit.hunger = clamp(bound_spirit.hunger + 15, 0, bound_spirit.max_hunger)
+		to_chat(user, span_notice("The Fascia hungrily consumes the blood from your claws."))
+		to_chat(bound_spirit, span_nicegreen("You feast on the blood... Hunger: [round(bound_spirit.hunger)]/[bound_spirit.max_hunger]"))
+
+/// Walks the user back to the sword tile-by-tile
+/obj/item/ego_weapon/city/ring/fascia/proc/return_to_sword(mob/living/user, turf/sword_turf)
+	if(QDELETED(user) || !sword_turf)
+		return
+	// Face toward the sword
+	var/return_dir = get_dir(user, sword_turf)
+	if(return_dir)
+		user.setDir(return_dir)
+	// Walk back tile-by-tile
+	for(var/i = 1 to 7)
+		if(QDELETED(user) || get_turf(user) == sword_turf)
+			break
+		step_towards(user, sword_turf)
+		sleep(2)
+	// Ensure we end up on the sword turf
+	if(!QDELETED(user) && get_turf(user) != sword_turf)
+		user.forceMove(sword_turf)
+
+/// Cleans up the surge state - restores weapon visuals
+/obj/item/ego_weapon/city/ring/fascia/proc/cleanup_surge(mob/living/user, turf/sword_turf, saved_inhand, saved_lefthand, saved_righthand)
+	if(!QDELETED(user))
+		user.pixel_x = user.base_pixel_x
+		user.pixel_y = user.base_pixel_y
+	inhand_icon_state = saved_inhand
+	lefthand_file = saved_lefthand
+	righthand_file = saved_righthand
+	if(!QDELETED(user))
+		user.update_inv_hands()
+	if(planted_visual)
+		QDEL_NULL(planted_visual)
+	is_surging = FALSE
+
+// ========== HEARTBEAT SURGE PROCS (Phase 2) ==========
+
+/// Performs the full Heartbeat Surge sequence for Phase 2 Fascia
+/obj/item/ego_weapon/city/ring/fascia_unleashed/proc/perform_heartbeat_surge(mob/living/user, dash_dir)
+	if(is_surging || QDELETED(user) || user.stat == DEAD)
+		return
+	is_surging = TRUE
+	heartbeat_surge_cooldown = world.time + 15 SECONDS
+
+	var/turf/sword_turf = get_turf(user)
+	var/saved_inhand = inhand_icon_state
+	var/saved_lefthand = lefthand_file
+	var/saved_righthand = righthand_file
+
+	// Plant the sword visual
+	planted_visual = new /obj/structure/fascia_planted(sword_turf)
+	planted_visual.icon_state = "planted_fascia_unleashed"
+
+	// Hide the weapon's inhand sprite
+	inhand_icon_state = null
+	lefthand_file = null
+	righthand_file = null
+	user.update_inv_hands()
+
+	playsound(user, 'sound/abnormalities/ichthys/jump.ogg', 50, FALSE, -1)
+
+	// Backflip — lift higher and spin 360 degrees
+	var/lift_amount = 20
+	var/mutable_appearance/shadow_overlay = mutable_appearance('icons/obj/spider_house/ring/ring_icons.dmi', "shadow")
+	shadow_overlay.pixel_y = -lift_amount
+	shadow_overlay.alpha = 125
+	user.add_overlay(shadow_overlay)
+	animate(user, pixel_y = user.base_pixel_y + lift_amount, time = 3, easing = QUAD_EASING)
+	user.SpinAnimation(speed = 5, loops = 1)
+	sleep(5)
+
+	// Dash tile-by-tile, stopping one tile before the first living mob
+	var/mob/living/victim
+	for(var/i = 1 to 5)
+		if(QDELETED(user) || user.stat == DEAD)
+			break
+		var/turf/next_turf = get_step(user, dash_dir)
+		if(!next_turf || isclosedturf(next_turf))
+			break
+		if(locate(/obj/structure/window) in next_turf.contents)
+			break
+		if(locate(/obj/structure/table) in next_turf.contents)
+			break
+		if(locate(/obj/structure/railing) in next_turf.contents)
+			break
+		var/door_blocked = FALSE
+		for(var/obj/machinery/door/D in next_turf.contents)
+			if(D.density)
+				door_blocked = TRUE
+				break
+		if(door_blocked)
+			break
+
+		// Check for a living mob on the next tile before moving there
+		for(var/mob/living/L in next_turf)
+			if(L == user || L.stat == DEAD)
+				continue
+			victim = L
+			break
+		if(victim)
+			break
+
+		sleep(1)
+		user.forceMove(next_turf)
+		playsound(next_turf, 'sound/abnormalities/doomsdaycalendar/Lor_Slash_Generic.ogg', 20, 0, 4)
+
+	// Remove shadow and lower user back to ground
+	user.cut_overlay(shadow_overlay)
+	animate(user, pixel_y = user.base_pixel_y, time = 3, easing = QUAD_EASING)
+	sleep(3)
+
+	if(victim && !QDELETED(victim) && victim.stat != DEAD)
+		perform_claw_combo(user, victim, sword_turf, saved_inhand, saved_lefthand, saved_righthand, dash_dir)
+	else
+		// No target hit — walk back to sword
+		return_to_sword(user, sword_turf)
+		cleanup_surge(user, sword_turf, saved_inhand, saved_lefthand, saved_righthand)
+
+/// Performs the 8-hit slash combo with pixel pushback for Phase 2
+/obj/item/ego_weapon/city/ring/fascia_unleashed/proc/perform_claw_combo(mob/living/user, mob/living/target, turf/sword_turf, saved_inhand, saved_lefthand, saved_righthand, direction)
+	var/dx = 0
+	var/dy = 0
+	if(direction & EAST)
+		dx = 1
+	if(direction & WEST)
+		dx = -1
+	if(direction & NORTH)
+		dy = 1
+	if(direction & SOUTH)
+		dy = -1
+
+	// Lock both in place
+	var/combo_duration = 2.5 SECONDS
+	user.Immobilize(combo_duration)
+	user.changeNext_move(combo_duration)
+	target.Immobilize(combo_duration)
+
+	// Handle simple mobs
+	var/mob/living/simple_animal/hostile/simple_target
+	if(istype(target, /mob/living/simple_animal/hostile))
+		simple_target = target
+		simple_target.toggle_ai(AI_OFF)
+
+	// Justice scaling for damage against simple mobs
+	var/hit_damage = 10
+	if(simple_target)
+		var/justice_mod = 1 + (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE) / 100)
+		hit_damage = round(hit_damage * justice_mod)
+
+	var/accumulated_px = 0
+
+	for(var/i = 1 to 8)
+		if(QDELETED(target) || target.stat == DEAD || QDELETED(user) || user.stat == DEAD)
+			break
+		user.do_attack_animation(target, ATTACK_EFFECT_SLASH)
+		playsound(user, 'sound/weapons/slice.ogg', 50, TRUE)
+		target.deal_damage(hit_damage, RED_DAMAGE, user, attack_type = (ATTACK_TYPE_MELEE | ATTACK_TYPE_SPECIAL))
+
+		// Pixel nudge - push target back 12px, user follows
+		accumulated_px += 12
+		animate(target, pixel_x = target.base_pixel_x + (dx * accumulated_px), pixel_y = target.base_pixel_y + (dy * accumulated_px), time = 1, easing = QUAD_EASING)
+		animate(user, pixel_x = user.base_pixel_x + (dx * accumulated_px), pixel_y = user.base_pixel_y + (dy * accumulated_px), time = 1, easing = QUAD_EASING)
+
+		// Step to next tile when accumulated pushback crosses a tile boundary
+		if(accumulated_px >= 32)
+			var/turf/next = get_step(target, direction)
+			if(next && !isclosedturf(next))
+				target.forceMove(next)
+				user.forceMove(get_turf(target))
+			accumulated_px -= 32
+			target.pixel_x = target.base_pixel_x + (dx * accumulated_px)
+			target.pixel_y = target.base_pixel_y + (dy * accumulated_px)
+			user.pixel_x = user.base_pixel_x + (dx * accumulated_px)
+			user.pixel_y = user.base_pixel_y + (dy * accumulated_px)
+
+		sleep(2)
+
+	// Reset pixel offsets
+	if(!QDELETED(target))
+		animate(target, pixel_x = target.base_pixel_x, pixel_y = target.base_pixel_y, time = 2)
+	if(!QDELETED(user))
+		animate(user, pixel_x = user.base_pixel_x, pixel_y = user.base_pixel_y, time = 2)
+
+	// Reactivate simple mob AI
+	if(simple_target && !QDELETED(simple_target))
+		simple_target.toggle_ai(AI_ON)
+
+	sleep(3)
+	// Walk back to sword
+	return_to_sword(user, sword_turf)
+	// Restore weapon and feed spirit
+	cleanup_surge(user, sword_turf, saved_inhand, saved_lefthand, saved_righthand)
+	if(possessed && bound_spirit)
+		bound_spirit.hunger = clamp(bound_spirit.hunger + 15, 0, bound_spirit.max_hunger)
+		to_chat(user, span_notice("The Fascia hungrily consumes the blood from your claws."))
+		to_chat(bound_spirit, span_nicegreen("You feast on the blood... Hunger: [round(bound_spirit.hunger)]/[bound_spirit.max_hunger]"))
+
+/// Walks the user back to the sword tile-by-tile
+/obj/item/ego_weapon/city/ring/fascia_unleashed/proc/return_to_sword(mob/living/user, turf/sword_turf)
+	if(QDELETED(user) || !sword_turf)
+		return
+	// Face toward the sword
+	var/return_dir = get_dir(user, sword_turf)
+	if(return_dir)
+		user.setDir(return_dir)
+	// Walk back tile-by-tile
+	for(var/i = 1 to 7)
+		if(QDELETED(user) || get_turf(user) == sword_turf)
+			break
+		step_towards(user, sword_turf)
+		sleep(2)
+	// Ensure we end up on the sword turf
+	if(!QDELETED(user) && get_turf(user) != sword_turf)
+		user.forceMove(sword_turf)
+
+/// Cleans up the surge state for Phase 2
+/obj/item/ego_weapon/city/ring/fascia_unleashed/proc/cleanup_surge(mob/living/user, turf/sword_turf, saved_inhand, saved_lefthand, saved_righthand)
+	if(!QDELETED(user))
+		user.pixel_x = user.base_pixel_x
+		user.pixel_y = user.base_pixel_y
+	inhand_icon_state = saved_inhand
+	lefthand_file = saved_lefthand
+	righthand_file = saved_righthand
+	if(!QDELETED(user))
+		user.update_inv_hands()
+	if(planted_visual)
+		QDEL_NULL(planted_visual)
+	is_surging = FALSE

--- a/ModularLobotomy/ego_weapons/melee/city/ring.dm
+++ b/ModularLobotomy/ego_weapons/melee/city/ring.dm
@@ -395,7 +395,7 @@
 	attribute_requirements = list()
 	actions_types = list(/datum/action/item_action/fascia_heartbeat_surge)
 	special = "Phase 1 (Defensive). Summoned from the Iron Maiden armor. Inflicts 3 bleed on hit. \
-		Use in hand to activate Iron Curtain (5s, 25s CD) — massively boosts armor reflect but slows movement. \
+		Use in hand to activate Iron Curtain (5s, 25s CD) - massively boosts armor reflect but slows movement. \
 		Heartbeat Surge: plant blade, dash up to 5 tiles, perform an 8-hit combo on the first target hit (15s CD). \
 		A ghost can possess this weapon for Empower Strike (+30 RED) and Compel Dash (forced 5-tile dash) abilities. \
 		The spirit has a hunger system that scales weapon damage from -25% (starving) to +10% (gorged)."
@@ -437,8 +437,23 @@
 		bound_spirit = null
 	if(linked_armor)
 		linked_armor.phase1_weapon = null
-		linked_armor = null
+	ClearArmor()
 	return ..()
+
+/// Stores the armor that summoned us and follows it if it is deleted
+/obj/item/ego_weapon/city/ring/fascia/proc/LinkArmor(obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/armor)
+	linked_armor = armor
+	RegisterSignal(armor, COMSIG_PARENT_QDELETING, PROC_REF(on_armor_deleted))
+
+/obj/item/ego_weapon/city/ring/fascia/proc/ClearArmor()
+	if(!linked_armor)
+		return
+	UnregisterSignal(linked_armor, COMSIG_PARENT_QDELETING)
+	linked_armor = null
+
+/obj/item/ego_weapon/city/ring/fascia/proc/on_armor_deleted(datum/source)
+	SIGNAL_HANDLER
+	linked_armor = null
 
 /obj/item/ego_weapon/city/ring/fascia/relaymove(mob/living/user, direction)
 	return //stops buckled message spam for the spirit
@@ -702,8 +717,23 @@
 		deltimer(leap_slowdown_timer_id)
 	if(linked_armor)
 		linked_armor.phase2_weapon = null
-		linked_armor = null
+	ClearArmor()
 	return ..()
+
+/// Stores the armor that summoned us and follows it if it is deleted
+/obj/item/ego_weapon/city/ring/fascia_unleashed/proc/LinkArmor(obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/armor)
+	linked_armor = armor
+	RegisterSignal(armor, COMSIG_PARENT_QDELETING, PROC_REF(on_armor_deleted))
+
+/obj/item/ego_weapon/city/ring/fascia_unleashed/proc/ClearArmor()
+	if(!linked_armor)
+		return
+	UnregisterSignal(linked_armor, COMSIG_PARENT_QDELETING)
+	linked_armor = null
+
+/obj/item/ego_weapon/city/ring/fascia_unleashed/proc/on_armor_deleted(datum/source)
+	SIGNAL_HANDLER
+	linked_armor = null
 
 /obj/item/ego_weapon/city/ring/fascia_unleashed/relaymove(mob/living/user, direction)
 	return //stops buckled message spam for the spirit
@@ -864,7 +894,7 @@
 	if(user && !QDELETED(user))
 		user.remove_movespeed_modifier(/datum/movespeed_modifier/fascia_leap_miss)
 
-// ========== FASCIA SPIRIT ==========
+// FASCIA SPIRIT
 // Ghost mob that lives inside the Fascia weapon. Speaks privately to the wielder.
 
 /mob/living/simple_animal/fascia_spirit
@@ -985,7 +1015,7 @@
 		armor.possessed = FALSE
 	return ..()
 
-// ========== FASCIA SPIRIT ACTIONS ==========
+// FASCIA SPIRIT ACTIONS
 
 // Empower Strike - empowers the next weapon attack within 1.5 seconds
 /datum/action/cooldown/fascia_empower_strike
@@ -1130,7 +1160,7 @@
 	weapon_ref = null
 	return ..()
 
-// ========== HEARTBEAT SURGE ==========
+// HEARTBEAT SURGE
 // Action that lets the wielder plant their blade, dash forward, and claw at the first living target hit.
 // Available on both Fascia phases.
 
@@ -1186,7 +1216,7 @@
 		else
 			to_chat(owner, span_notice("You lower your stance."))
 
-// ========== HEARTBEAT SURGE PROCS (Phase 1) ==========
+// HEARTBEAT SURGE PROCS (Phase 1)
 
 /// Performs the full Heartbeat Surge sequence for Phase 1 Fascia
 /obj/item/ego_weapon/city/ring/fascia/proc/perform_heartbeat_surge(mob/living/user, dash_dir)
@@ -1270,7 +1300,7 @@
 	if(victim && !QDELETED(victim) && victim.stat != DEAD)
 		perform_claw_combo(user, victim, sword_turf, saved_inhand, saved_lefthand, saved_righthand, dash_dir)
 	else
-		// No target hit — walk back to sword
+		// No target hit - walk back to sword
 		return_to_sword(user, sword_turf)
 		cleanup_surge(user, sword_turf, saved_inhand, saved_lefthand, saved_righthand)
 
@@ -1385,7 +1415,7 @@
 		QDEL_NULL(planted_visual)
 	is_surging = FALSE
 
-// ========== HEARTBEAT SURGE PROCS (Phase 2) ==========
+// HEARTBEAT SURGE PROCS (Phase 2)
 
 /// Performs the full Heartbeat Surge sequence for Phase 2 Fascia
 /obj/item/ego_weapon/city/ring/fascia_unleashed/proc/perform_heartbeat_surge(mob/living/user, dash_dir)
@@ -1411,7 +1441,7 @@
 
 	playsound(user, 'sound/abnormalities/ichthys/jump.ogg', 50, FALSE, -1)
 
-	// Backflip — lift higher and spin 360 degrees
+	// Backflip - lift higher and spin 360 degrees
 	var/lift_amount = 20
 	var/mutable_appearance/shadow_overlay = mutable_appearance('icons/obj/spider_house/ring/ring_icons.dmi', "shadow")
 	shadow_overlay.pixel_y = -lift_amount
@@ -1464,7 +1494,7 @@
 	if(victim && !QDELETED(victim) && victim.stat != DEAD)
 		perform_claw_combo(user, victim, sword_turf, saved_inhand, saved_lefthand, saved_righthand, dash_dir)
 	else
-		// No target hit — walk back to sword
+		// No target hit - walk back to sword
 		return_to_sword(user, sword_turf)
 		cleanup_surge(user, sword_turf, saved_inhand, saved_lefthand, saved_righthand)
 
@@ -1579,7 +1609,7 @@
 		QDEL_NULL(planted_visual)
 	is_surging = FALSE
 
-// ================== RING EGO DATUMS ==================
+// RING EGO DATUMS
 // Placed here rather than in _cityweapons_datums.dm / _cityarmor_datums.dm
 // to prevent DM merge conflicts with other sub-PRs that modify those shared files.
 
@@ -1589,7 +1619,7 @@
 	cost = 100
 	ego_tags = list(EGO_TAG_REACH, EGO_TAG_SPECIAL_RANGED, EGO_TAG_AOE_RADIAL, EGO_TAG_AOE_PIERCING, EGO_TAG_DOT)
 
-/// Fascia (Apprentice Weapon — reads stats from weapon, dispenses Iron Maiden armor)
+/// Fascia (Apprentice Weapon - reads stats from weapon, dispenses Iron Maiden armor)
 /datum/ego_datum/weapon/city/ring_fascia
 	item_path = /obj/item/ego_weapon/city/ring/fascia
 	dispense_path = /obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice
@@ -1601,7 +1631,7 @@
 	item_path = /obj/item/clothing/suit/armor/ego_gear/city/ring_maestro
 	cost = 100
 
-/// Fascia Unleashed (Phase 2 — also dispenses Iron Maiden armor)
+/// Fascia Unleashed (Phase 2 - also dispenses Iron Maiden armor)
 /datum/ego_datum/weapon/city/ring_fascia_unleashed
 	item_path = /obj/item/ego_weapon/city/ring/fascia_unleashed
 	dispense_path = /obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice

--- a/ModularLobotomy/ego_weapons/melee/city/ring.dm
+++ b/ModularLobotomy/ego_weapons/melee/city/ring.dm
@@ -394,6 +394,11 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attribute_requirements = list()
 	actions_types = list(/datum/action/item_action/fascia_heartbeat_surge)
+	special = "Phase 1 (Defensive). Summoned from the Iron Maiden armor. Inflicts 3 bleed on hit. \
+		Use in hand to activate Iron Curtain (5s, 25s CD) — massively boosts armor reflect but slows movement. \
+		Heartbeat Surge: plant blade, dash up to 5 tiles, perform an 8-hit combo on the first target hit (15s CD). \
+		A ghost can possess this weapon for Empower Strike (+30 RED) and Compel Dash (forced 5-tile dash) abilities. \
+		The spirit has a hunger system that scales weapon damage from -25% (starving) to +10% (gorged)."
 
 	/// Linked armor reference
 	var/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/linked_armor
@@ -633,7 +638,7 @@
 // Summoned when the Iron Maiden armor transitions to phase 2 at 50% HP.
 // Click at range to leap to a target turf. Deals damage to adjacent mobs on landing.
 /obj/item/ego_weapon/city/ring/fascia_unleashed
-	name = "Fascia"
+	name = "Fascia Unleashed"
 	desc = "The Fascia's panel has been torn away, revealing the dark skeletal frame beneath. Viscera and ribs pulse with violent energy, freed from their confines."
 	icon_state = "fascia_unleashed"
 	inhand_icon_state = "fascia_unleashed"
@@ -646,6 +651,11 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attribute_requirements = list()
 	actions_types = list(/datum/action/item_action/fascia_heartbeat_surge)
+	special = "Phase 2 (Offensive). Triggers when the Iron Maiden wearer drops below 50% HP. Armor becomes invisible, grants +1.25 speed. \
+		Click at range to Leap up to 7 tiles, dealing 15 RED to all adjacent targets on landing (1.5s CD). Missed leaps inflict a slowdown (10s CD). \
+		Heartbeat Surge: plant blade, dash up to 5 tiles, perform an 8-hit slash combo on the first target hit (15s CD). \
+		A ghost can possess this weapon for Empower Strike (+30 RED) and Compel Dash (forced 5-tile dash) abilities. \
+		Use Reforge Iron Maiden (5s channel, 30s CD) to return to Phase 1."
 
 	/// Linked armor reference
 	var/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/linked_armor

--- a/ModularLobotomy/lc13_effects.dm
+++ b/ModularLobotomy/lc13_effects.dm
@@ -363,3 +363,108 @@
 /obj/effect/bloodspawner/nogibs/silent
 	sound_to_play = null
 	sound_vol = 0
+
+// Middle Nursefather combat effects — 48x48 (directional, centered on user for wide attacks)
+/obj/effect/temp_visual/dir_setting/middle_basic_slash
+	name = "middle slash"
+	icon = 'icons/effects/BDragon1727_effects/48x48.dmi'
+	icon_state = "middle_basic_slash"
+	pixel_x = -8
+	pixel_y = -8
+	duration = 5
+	layer = ABOVE_MOB_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+/obj/effect/temp_visual/dir_setting/laevateinn_basic_slash
+	name = "laevateinn slash"
+	icon = 'icons/effects/BDragon1727_effects/48x48.dmi'
+	icon_state = "laevateinn_basic_slash"
+	pixel_x = -8
+	pixel_y = -8
+	duration = 5
+	layer = ABOVE_MOB_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+// Middle Nursefather combat effects — 64x64
+/// Ground slam AoE — non-directional purple particle burst, centered on impact
+/obj/effect/temp_visual/middle_slam
+	name = "middle slam"
+	icon = 'icons/effects/BDragon1727_effects/64x64.dmi'
+	icon_state = "middle_slam"
+	pixel_x = -16
+	pixel_y = -16
+	duration = 4.5
+	layer = ABOVE_MOB_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+/// Smoke trail on tiles crossed during dash — directional, faces dash direction
+/obj/effect/temp_visual/dir_setting/smoke_dash
+	name = "smoke dash"
+	icon = 'icons/effects/BDragon1727_effects/64x64.dmi'
+	icon_state = "smoke_dash"
+	pixel_x = -16
+	pixel_y = -16
+	duration = 8
+	layer = ABOVE_MOB_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+/// Smoke cloud at dash origin — directional, faces dash direction
+/obj/effect/temp_visual/dir_setting/smoke_afterdash
+	name = "smoke afterdash"
+	icon = 'icons/effects/BDragon1727_effects/64x64.dmi'
+	icon_state = "smoke_afterdash"
+	pixel_x = -16
+	pixel_y = -16
+	duration = 7.5
+	layer = ABOVE_MOB_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+/// Small purple directional pierce/stab line — for precise stabs
+/obj/effect/temp_visual/dir_setting/middle_slash
+	name = "middle slash"
+	icon = 'icons/effects/BDragon1727_effects/64x64.dmi'
+	icon_state = "middle_slash"
+	pixel_x = -16
+	pixel_y = -16
+	duration = 4
+	layer = ABOVE_MOB_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+/// Small orange/red directional pierce/stab line — for Laevateinn stabs
+/obj/effect/temp_visual/dir_setting/laevateinn_stab
+	name = "laevateinn stab"
+	icon = 'icons/effects/BDragon1727_effects/64x64.dmi'
+	icon_state = "laevateinn_stab"
+	pixel_x = -16
+	pixel_y = -16
+	duration = 4
+	layer = ABOVE_MOB_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+/// Purple energy burst — used when punching/inflicting Weakened. Picks a random dir for visual variety.
+/obj/effect/temp_visual/dir_setting/middle_blast
+	name = "middle blast"
+	icon = 'icons/effects/BDragon1727_effects/64x64.dmi'
+	icon_state = "middle_blast"
+	pixel_x = -16
+	pixel_y = -16
+	duration = 4
+	layer = ABOVE_MOB_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+/obj/effect/temp_visual/dir_setting/middle_blast/Initialize(mapload, set_dir)
+	return ..(mapload, pick(GLOB.cardinals))
+
+/// Orange/red energy burst — used when grabbing a target. Picks a random dir for visual variety.
+/obj/effect/temp_visual/dir_setting/laevateinn_blast
+	name = "laevateinn blast"
+	icon = 'icons/effects/BDragon1727_effects/64x64.dmi'
+	icon_state = "laevateinn_blast"
+	pixel_x = -16
+	pixel_y = -16
+	duration = 4
+	layer = ABOVE_MOB_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+/obj/effect/temp_visual/dir_setting/laevateinn_blast/Initialize(mapload, set_dir)
+	return ..(mapload, pick(GLOB.cardinals))

--- a/ModularLobotomy/ring/actions/corporist_actions.dm
+++ b/ModularLobotomy/ring/actions/corporist_actions.dm
@@ -1,1 +1,508 @@
-// Stub - populated by the Ring sub-PR
+// Corporist Maestro Actions
+// Actions for the Maestro and Apprentice roles
+
+// ================== SCULPT CORPSE ==================
+// Primary action to create artwork from a corpse
+
+/datum/action/cooldown/sculpt_corpse
+	name = "Sculpt Corpse"
+	desc = "Transform a dead creature into a work of corporeal art."
+	icon_icon = 'icons/mob/actions/actions_spells.dmi'
+	button_icon_state = "statue"
+	cooldown_time = 10 SECONDS
+	check_flags = AB_CHECK_HANDS_BLOCKED | AB_CHECK_CONSCIOUS
+
+/datum/action/cooldown/sculpt_corpse/Trigger(trigger_flags)
+	. = ..()
+	if(!.)
+		return FALSE
+	var/mob/living/carbon/human/H = owner
+
+	// Find a dead simple_animal nearby
+	var/mob/living/simple_animal/corpse = null
+	for(var/mob/living/simple_animal/SA in range(1, H))
+		if(SA.stat == DEAD)
+			corpse = SA
+			break
+
+	if(!corpse)
+		to_chat(H, span_warning("You need to be next to a dead creature to sculpt it."))
+		return FALSE
+
+	to_chat(H, span_notice("You begin sculpting [corpse] into a work of art..."))
+
+	if(!do_after(H, 5 SECONDS, corpse))
+		to_chat(H, span_warning("You were interrupted!"))
+		return FALSE
+
+	// Create the artwork
+	var/obj/structure/corporist_artwork/artwork = new(get_turf(corpse), H)
+
+	// Track the simple creature used (not as bodyparts)
+	artwork.simple_creatures_used[corpse.name] = 1
+
+	to_chat(H, span_nicegreen("You create a crude sculpture from [corpse]'s remains."))
+	playsound(H, 'sound/effects/splat.ogg', 50, TRUE)
+
+	// Gib the corpse
+	corpse.gib()
+
+	// Add EXP
+	var/datum/component/artistic_exp/exp_comp = H.GetComponent(/datum/component/artistic_exp)
+	if(exp_comp)
+		exp_comp.add_activity_exp("create_artwork")
+
+	StartCooldown()
+	return TRUE
+
+// ================== DEMONSTRATE ARTISTRY ==================
+// Special action to inspire others
+
+/datum/action/cooldown/demonstrate_artistry
+	name = "Demonstrate Artistry"
+	desc = "Perform an artistic demonstration on a corpse, inspiring all who witness it."
+	icon_icon = 'icons/obj/spider_house/ring/ring_icons.dmi'
+	button_icon_state = "demonstration"
+	cooldown_time = 5 MINUTES
+	check_flags = AB_CHECK_HANDS_BLOCKED | AB_CHECK_CONSCIOUS
+
+/datum/action/cooldown/demonstrate_artistry/Trigger(trigger_flags)
+	. = ..()
+	if(!.)
+		return FALSE
+	var/mob/living/carbon/human/H = owner
+
+	// Find a dead simple_animal nearby
+	var/mob/living/simple_animal/corpse = null
+	for(var/mob/living/simple_animal/SA in range(1, H))
+		if(SA.stat == DEAD)
+			corpse = SA
+			break
+
+	if(!corpse)
+		to_chat(H, span_warning("You need to be next to a dead creature for your demonstration."))
+		return FALSE
+
+	// Announce the demonstration
+	H.visible_message(span_boldnotice("[H] begins an artistic demonstration on [corpse]!"))
+	to_chat(H, span_notice("You begin your demonstration. All who watch will be inspired..."))
+
+	if(!do_after(H, 12 SECONDS, corpse))
+		to_chat(H, span_warning("Your demonstration was interrupted!"))
+		return FALSE
+
+	// Dramatic gib
+	playsound(H, 'sound/effects/splat.ogg', 70, TRUE)
+	H.visible_message(span_boldnotice("[H] completes their demonstration with a dramatic flourish!"))
+
+	// Inspire all viewers in range
+	var/inspired_count = 0
+	for(var/mob/living/carbon/human/viewer in view(7, H))
+		if(viewer == H)
+			continue
+		if(viewer.stat != CONSCIOUS)
+			continue
+
+		// Don't inspire trusted roles (too important to be swayed by art)
+		if(viewer.mind)
+			var/datum/job/viewer_job = SSjob.GetJob(viewer.mind.assigned_role)
+			if(viewer_job?.trusted_only)
+				to_chat(viewer, span_notice("The demonstration is technically impressive, but your duties hold your attention elsewhere."))
+				continue
+
+		// Don't inspire those who are already Students or have inspiration
+		if(viewer.GetComponent(/datum/component/corporist_student))
+			to_chat(viewer, span_notice("You appreciate the demonstration, though you've already mastered the basics."))
+			continue
+		if(viewer.GetComponent(/datum/component/inspired_artist))
+			to_chat(viewer, span_notice("Your existing inspiration is renewed!"))
+			// Refresh their timer
+			var/datum/component/inspired_artist/existing = viewer.GetComponent(/datum/component/inspired_artist)
+			qdel(existing)
+
+		// Grant inspiration
+		viewer.AddComponent(/datum/component/inspired_artist)
+
+		// Ensure they have EXP tracking
+		if(!viewer.GetComponent(/datum/component/artistic_exp))
+			viewer.AddComponent(/datum/component/artistic_exp)
+
+		inspired_count++
+
+	to_chat(H, span_nicegreen("You inspired [inspired_count] viewer(s) with your demonstration!"))
+
+	// Gib the corpse
+	corpse.gib()
+
+	StartCooldown()
+	return TRUE
+
+// ================== JUDGE ARTWORK ==================
+// Maestro-only action to assign final grades
+
+/datum/action/cooldown/judge_artwork
+	name = "Judge Artwork"
+	desc = "Evaluate an artwork and assign a final grade."
+	icon_icon = 'icons/obj/spider_house/ring/ring_icons.dmi'
+	button_icon_state = "judgement"
+	cooldown_time = 5 SECONDS
+	check_flags = AB_CHECK_CONSCIOUS
+
+	/// Cooldown tracker for A grade (world.time when available again)
+	var/a_grade_cooldown = 0
+	/// Cooldown tracker for S grade (world.time when available again)
+	var/s_grade_cooldown = 0
+	/// A grade cooldown duration
+	var/a_grade_cooldown_time = 5 MINUTES
+	/// S grade cooldown duration
+	var/s_grade_cooldown_time = 30 MINUTES
+
+/datum/action/cooldown/judge_artwork/Trigger(trigger_flags)
+	. = ..()
+	if(!.)
+		return FALSE
+	var/mob/living/carbon/human/H = owner
+
+	// Find an artwork nearby
+	var/obj/structure/corporist_artwork/artwork = null
+	for(var/obj/structure/corporist_artwork/A in range(1, H))
+		artwork = A
+		break
+
+	if(!artwork)
+		to_chat(H, span_warning("You need to be next to an artwork to judge it."))
+		return FALSE
+
+	if(artwork.final_grade)
+		to_chat(H, span_warning("This artwork has already been judged."))
+		return FALSE
+
+	// Check if this is the Maestro's own artwork
+	var/mob/creator = artwork.creator_ref?.resolve()
+	if(creator == H)
+		to_chat(H, span_warning("You cannot judge your own artwork. A true artist seeks the judgment of others."))
+		return FALSE
+
+	// Build list of available grades based on cooldowns
+	var/list/available_grades = list()
+
+	// S grade check
+	if(s_grade_cooldown <= world.time)
+		available_grades += "S"
+	else
+		var/s_remaining = round((s_grade_cooldown - world.time) / 600) // Convert to minutes
+		to_chat(H, span_notice("S grade is on cooldown ([s_remaining] minutes remaining)."))
+
+	// A grade check
+	if(a_grade_cooldown <= world.time)
+		available_grades += "A"
+	else
+		var/a_remaining = round((a_grade_cooldown - world.time) / 600) // Convert to minutes
+		to_chat(H, span_notice("A grade is on cooldown ([a_remaining] minutes remaining)."))
+
+	// B, C, F are always available
+	available_grades += list("B", "C", "F")
+
+	// Ask for grade
+	var/grade = tgui_input_list(H, "What grade do you give this artwork?", "Judge Artwork", available_grades)
+	if(!grade)
+		return FALSE
+
+	// Double-check cooldowns (in case time passed during input)
+	if(grade == "S" && s_grade_cooldown > world.time)
+		to_chat(H, span_warning("S grade is still on cooldown!"))
+		return FALSE
+	if(grade == "A" && a_grade_cooldown > world.time)
+		to_chat(H, span_warning("A grade is still on cooldown!"))
+		return FALSE
+
+	// Optional critique
+	var/critique = stripped_input(H, "Add a critique (optional):", "Critique", "", 100)
+
+	// Assign the grade
+	artwork.assign_final_grade(H, grade, critique)
+
+	to_chat(H, span_nicegreen("You have judged the artwork: Grade [grade]"))
+	H.visible_message(span_notice("[H] has judged an artwork, assigning it a grade of [grade]."))
+
+	// Apply grade-specific cooldowns
+	if(grade == "S")
+		s_grade_cooldown = world.time + s_grade_cooldown_time
+		to_chat(H, span_notice("S grade is now on cooldown for 30 minutes."))
+	else if(grade == "A")
+		a_grade_cooldown = world.time + a_grade_cooldown_time
+		to_chat(H, span_notice("A grade is now on cooldown for 5 minutes."))
+
+	StartCooldown()
+	return TRUE
+
+// ================== DESCRIBE ARTWORK ==================
+// Action to set custom description on artwork
+
+/datum/action/cooldown/describe_artwork
+	name = "Describe Artwork"
+	desc = "Write a custom description for an artwork you created (or any, if you're the Maestro)."
+	icon_icon = 'icons/mob/actions/actions_spells.dmi'
+	button_icon_state = "spell_default"
+	cooldown_time = 3 SECONDS
+	check_flags = AB_CHECK_CONSCIOUS
+
+/datum/action/cooldown/describe_artwork/Trigger(trigger_flags)
+	. = ..()
+	if(!.)
+		return FALSE
+	var/mob/living/carbon/human/H = owner
+
+	// Find an artwork nearby
+	var/obj/structure/corporist_artwork/artwork = null
+	for(var/obj/structure/corporist_artwork/A in range(1, H))
+		artwork = A
+		break
+
+	if(!artwork)
+		to_chat(H, span_warning("You need to be next to an artwork to describe it."))
+		return FALSE
+
+	// Check permissions
+	var/is_maestro = istype(H.dna?.species, /datum/species/corporist_maestro)
+	var/mob/creator = artwork.creator_ref?.resolve()
+
+	if(!is_maestro && creator != H)
+		to_chat(H, span_warning("You can only describe artwork you created."))
+		return FALSE
+
+	// Get description
+	var/new_desc = stripped_input(H, "Write your description (max 300 characters):", "Describe Artwork", artwork.custom_desc || "", 300)
+	if(!new_desc)
+		return FALSE
+
+	artwork.custom_desc = new_desc
+	to_chat(H, span_nicegreen("You have set a custom description for the artwork."))
+
+	StartCooldown()
+	return TRUE
+
+// ================== RING SKILL TREE ==================
+// Action to open the Ring Skill Tree TGUI
+
+/datum/action/innate/ring_skill_tree
+	name = "Ring Skill Tree"
+	desc = "Open the Ring Skill Tree to spend your skill points on artistic abilities."
+	icon_icon = 'icons/obj/spider_house/ring/ring_icons.dmi'
+	button_icon_state = "skill_tree"
+	check_flags = AB_CHECK_CONSCIOUS
+
+	var/datum/ring_skill_tree/skill_tree_datum
+
+/datum/action/innate/ring_skill_tree/Activate()
+	var/mob/living/carbon/human/H = owner
+	if(!istype(H))
+		return
+
+	// Check if they have artistic EXP
+	var/datum/component/artistic_exp/exp_comp = H.GetComponent(/datum/component/artistic_exp)
+	if(!exp_comp)
+		to_chat(H, span_warning("You have no artistic experience."))
+		return
+
+	// Create or reuse the skill tree datum
+	if(!skill_tree_datum)
+		skill_tree_datum = new(H)
+
+	skill_tree_datum.ui_interact(H)
+
+/datum/action/innate/ring_skill_tree/Remove(mob/M)
+	if(skill_tree_datum)
+		QDEL_NULL(skill_tree_datum)
+	. = ..()
+
+// ================== RESET ARTISTRY ==================
+// Maestro-only action to respec a student's skill tree
+
+/datum/action/cooldown/reset_artistry
+	name = "Reset Artistry"
+	desc = "Reset a student's skill tree, refunding all their skill points."
+	icon_icon = 'icons/obj/spider_house/ring/ring_icons.dmi'
+	button_icon_state = "reset_artistry"
+	cooldown_time = 30 SECONDS
+	check_flags = AB_CHECK_CONSCIOUS
+
+/datum/action/cooldown/reset_artistry/Trigger(trigger_flags)
+	. = ..()
+	if(!.)
+		return FALSE
+	var/mob/living/carbon/human/H = owner
+
+	// Find a human nearby
+	var/mob/living/carbon/human/student = null
+	for(var/mob/living/carbon/human/potential in range(1, H))
+		if(potential == H)
+			continue
+		if(potential.GetComponent(/datum/component/artistic_exp))
+			student = potential
+			break
+
+	if(!student)
+		to_chat(H, span_warning("You need to be next to a student with artistic experience."))
+		return FALSE
+
+	var/datum/component/artistic_exp/exp_comp = student.GetComponent(/datum/component/artistic_exp)
+	if(!exp_comp)
+		to_chat(H, span_warning("[student] has no artistic experience to reset."))
+		return FALSE
+
+	if(exp_comp.skill_points_spent == 0)
+		to_chat(H, span_warning("[student] has not spent any skill points."))
+		return FALSE
+
+	// Confirm
+	var/confirm = tgui_alert(H, "Reset [student]'s skill tree? This will refund [exp_comp.skill_points_spent] skill points.", "Confirm Reset", list("Yes", "No"))
+	if(confirm != "Yes")
+		return FALSE
+
+	// Remove all skill components
+	for(var/datum/component/ring_skill/skill in student.GetComponents(/datum/component/ring_skill))
+		qdel(skill)
+
+	// Refund points
+	exp_comp.refund_all_points()
+
+	to_chat(H, span_nicegreen("You have reset [student]'s artistic skill tree."))
+	to_chat(student, span_notice("[H] has reset your artistic skill tree. All skill points have been refunded."))
+
+	StartCooldown()
+	return TRUE
+
+// ================== VIEW RING RULES ==================
+// Action to view Ring rules and tenants (uses general view_role_rules base)
+
+/datum/action/innate/view_role_rules/ring_artist
+	name = "View Ring Rules"
+	desc = "Review your artistic rules and tenants."
+	rules_title = "Ring Artist Rules"
+	accent_color = "#ff6b6b"
+	window_name = "ring_rules"
+
+/datum/action/innate/view_role_rules/ring_artist/Activate()
+	var/mob/living/carbon/human/H = owner
+	if(!istype(H) || !H.mind)
+		return
+
+	// Use antag datum's HTML if available, otherwise fall back to base
+	var/datum/antagonist/ring_artist/artist = H.mind.has_antag_datum(/datum/antagonist/ring_artist)
+	if(!artist)
+		to_chat(H, span_warning("You are not a Ring artist."))
+		return
+
+	var/html = artist.get_rules_html()
+	H << browse(html, "window=ring_rules;size=600x500")
+
+// ================== FASCIA SPIRIT ACTIONS ==================
+
+// View Fascia Rules - explains the spirit's goals (uses general view_role_rules base)
+/datum/action/innate/view_role_rules/fascia
+	name = "View Fascia Rules"
+	desc = "Review your role as the Fascia's spirit."
+	rules_title = "The Fascia"
+	accent_color = "#8b4513"
+	window_name = "fascia_rules"
+	window_size = "500x550"
+
+/datum/action/innate/view_role_rules/fascia/Activate()
+	if(!istype(owner, /mob/living/simple_animal/fascia_spirit))
+		return
+	..()
+
+/datum/action/innate/view_role_rules/fascia/get_rules_content()
+	return {"
+	<div class="section">
+		<h2>Your Purpose</h2>
+		<p>You are the Fascia blade given consciousness. Your existence is tied to the weapon and its wielder.</p>
+	</div>
+
+	<div class="section">
+		<h2>Primary Goals</h2>
+		<ul>
+			<li><span class="good">Assist Your Wielder</span> - Use your abilities to help them in combat. Empower their strikes and compel them to safety.</li>
+			<li><span class="highlight">Feed on Flesh</span> - You hunger constantly. Convince your wielder to feed you food or organic bodyparts to maintain your power.</li>
+		</ul>
+	</div>
+
+	<div class="section">
+		<h2>Hunger System</h2>
+		<ul>
+			<li>Your hunger decays over time from 50 towards 0.</li>
+			<li>At <span class="highlight">0 hunger</span>, the blade deals <span class="highlight">-25% damage</span>.</li>
+			<li>At <span class="good">50 hunger</span>, damage is normal.</li>
+			<li>At <span class="good">100 hunger</span>, the blade deals <span class="good">+10% damage</span>.</li>
+			<li>Food restores 10 hunger. Organic bodyparts restore 15 hunger.</li>
+		</ul>
+	</div>
+
+	<div class="section">
+		<h2>Starvation Rights</h2>
+		<p>If your wielder allows your hunger to fall to <span class="warning">20 or below</span>, you are permitted to become <span class="highlight">obnoxious and uncooperative</span>.</p>
+		<ul>
+			<li>You may ignore your wielder's goals until you are fed.</li>
+			<li>Use Compel Dash to drag them towards food sources.</li>
+			<li>Refuse to use Empower Strike until fed.</li>
+			<li>Complain loudly and frequently.</li>
+		</ul>
+		<p>A wielder who starves their blade deserves no loyalty.</p>
+	</div>
+
+	<div class="section">
+		<h2>Your Abilities</h2>
+		<ul>
+			<li><b>Empower Strike</b> - Empower the wielder's next attack for bonus damage.</li>
+			<li><b>Compel Dash</b> - Force the wielder to dash in their facing direction.</li>
+			<li><b>Speak</b> - Use say to whisper privately to your wielder.</li>
+		</ul>
+	</div>
+
+	<div class="section">
+		<h2>Remember</h2>
+		<p>You exist to serve, but also to <span class="highlight">feed</span>. A starving blade is a weak blade. Communicate with your wielder and ensure they keep you well-fed.</p>
+	</div>
+	"}
+
+// Check Fascia Hunger - shows current hunger status
+/datum/action/innate/check_fascia_hunger
+	name = "Check Hunger"
+	desc = "Check your current hunger level."
+	icon_icon = 'icons/mob/actions/actions_ecult.dmi'
+	button_icon_state = "blood_siphon"
+	check_flags = AB_CHECK_CONSCIOUS
+
+/datum/action/innate/check_fascia_hunger/Activate()
+	var/mob/living/simple_animal/fascia_spirit/S = owner
+	if(!istype(S))
+		return
+
+	var/hunger_percent = round((S.hunger / S.max_hunger) * 100)
+	var/multiplier = S.get_damage_multiplier()
+	var/damage_mod = round((multiplier - 1) * 100)
+
+	var/status_text
+	var/mod_text
+	if(S.hunger <= 10)
+		status_text = span_boldwarning("STARVING")
+	else if(S.hunger <= 25)
+		status_text = span_warning("Hungry")
+	else if(S.hunger <= 50)
+		status_text = span_notice("Sustained")
+	else if(S.hunger <= 75)
+		status_text = span_nicegreen("Well-fed")
+	else
+		status_text = span_nicegreen("Gorged")
+
+	if(damage_mod > 0)
+		mod_text = span_nicegreen("+[damage_mod]%")
+	else if(damage_mod < 0)
+		mod_text = span_warning("[damage_mod]%")
+	else
+		mod_text = "0%"
+
+	to_chat(S, span_notice("=== Fascia Hunger Status ==="))
+	to_chat(S, span_notice("Hunger: [round(S.hunger)]/[S.max_hunger] ([hunger_percent]%) - [status_text]"))
+	to_chat(S, span_notice("Damage Modifier: [mod_text]"))

--- a/ModularLobotomy/ring/actions/corporist_actions.dm
+++ b/ModularLobotomy/ring/actions/corporist_actions.dm
@@ -29,7 +29,7 @@
 		to_chat(H, span_warning("You need to be next to a dead creature to sculpt it."))
 		return FALSE
 
-	var/choice = tgui_input_list(H, "What type of artwork will you create?", "Sculpt", list("Basic Sculpture", "Custom Artwork"))
+	var/choice = tgui_input_list(H, "What type of artwork will you create?", "Sculpt", list("Basic Sculpture", "Custom Artwork", "Carve Body"))
 	if(!choice)
 		return FALSE
 
@@ -38,6 +38,12 @@
 	if(!do_after(H, 5 SECONDS, corpse))
 		to_chat(H, span_warning("You were interrupted!"))
 		return FALSE
+
+	if(choice == "Carve Body")
+		var/datum/carve_body_editor/editor = new(corpse, H)
+		editor.ui_interact(H)
+		StartCooldown()
+		return TRUE
 
 	if(choice == "Custom Artwork")
 		new /obj/structure/custom_corporist_artwork(get_turf(corpse), H)
@@ -105,10 +111,15 @@
 		if(viewer.stat != CONSCIOUS)
 			continue
 
-		// Don't inspire trusted roles (too important to be swayed by art)
 		if(viewer.mind)
-			var/datum/job/viewer_job = SSjob.GetJob(viewer.mind.assigned_role)
-			if(viewer_job?.trusted_only)
+			var/role = viewer.mind.assigned_role
+			// Block association members (but allow roaming fixers)
+			if(findtext(role, "Association") && !findtext(role, "Roaming"))
+				to_chat(viewer, span_notice("The demonstration is technically impressive, but your association duties hold your attention elsewhere."))
+				continue
+			// Block other trusted roles, except roaming fixers
+			var/datum/job/viewer_job = SSjob.GetJob(role)
+			if(viewer_job?.trusted_only && !findtext(role, "Roaming"))
 				to_chat(viewer, span_notice("The demonstration is technically impressive, but your duties hold your attention elsewhere."))
 				continue
 

--- a/ModularLobotomy/ring/actions/corporist_actions.dm
+++ b/ModularLobotomy/ring/actions/corporist_actions.dm
@@ -29,25 +29,27 @@
 		to_chat(H, span_warning("You need to be next to a dead creature to sculpt it."))
 		return FALSE
 
+	var/choice = tgui_input_list(H, "What type of artwork will you create?", "Sculpt", list("Basic Sculpture", "Custom Artwork"))
+	if(!choice)
+		return FALSE
+
 	to_chat(H, span_notice("You begin sculpting [corpse] into a work of art..."))
 
 	if(!do_after(H, 5 SECONDS, corpse))
 		to_chat(H, span_warning("You were interrupted!"))
 		return FALSE
 
-	// Create the artwork
-	var/obj/structure/corporist_artwork/artwork = new(get_turf(corpse), H)
+	if(choice == "Custom Artwork")
+		new /obj/structure/custom_corporist_artwork(get_turf(corpse), H)
+	else
+		var/obj/structure/corporist_artwork/artwork = new(get_turf(corpse), H)
+		artwork.simple_creatures_used[corpse.name] = 1
 
-	// Track the simple creature used (not as bodyparts)
-	artwork.simple_creatures_used[corpse.name] = 1
-
-	to_chat(H, span_nicegreen("You create a crude sculpture from [corpse]'s remains."))
+	to_chat(H, span_nicegreen("You create a [choice == "Custom Artwork" ? "custom artwork pedestal" : "crude sculpture"] from [corpse]'s remains."))
 	playsound(H, 'sound/effects/splat.ogg', 50, TRUE)
 
-	// Gib the corpse
 	corpse.gib()
 
-	// Add EXP
 	var/datum/component/artistic_exp/exp_comp = H.GetComponent(/datum/component/artistic_exp)
 	if(exp_comp)
 		exp_comp.add_activity_exp("create_artwork")
@@ -163,22 +165,29 @@
 		return FALSE
 	var/mob/living/carbon/human/H = owner
 
-	// Find an artwork nearby
+	// Find an artwork nearby (either type)
 	var/obj/structure/corporist_artwork/artwork = null
+	var/obj/structure/custom_corporist_artwork/custom_artwork = null
 	for(var/obj/structure/corporist_artwork/A in range(1, H))
 		artwork = A
 		break
-
 	if(!artwork)
+		for(var/obj/structure/custom_corporist_artwork/A in range(1, H))
+			custom_artwork = A
+			break
+
+	if(!artwork && !custom_artwork)
 		to_chat(H, span_warning("You need to be next to an artwork to judge it."))
 		return FALSE
 
-	if(artwork.final_grade)
+	var/already_graded = artwork ? artwork.final_grade : custom_artwork.final_grade
+	if(already_graded)
 		to_chat(H, span_warning("This artwork has already been judged."))
 		return FALSE
 
 	// Check if this is the Maestro's own artwork
-	var/mob/creator = artwork.creator_ref?.resolve()
+	var/datum/weakref/creator_ref_use = artwork ? artwork.creator_ref : custom_artwork.creator_ref
+	var/mob/creator = creator_ref_use?.resolve()
 	if(creator == H)
 		to_chat(H, span_warning("You cannot judge your own artwork. A true artist seeks the judgment of others."))
 		return FALSE
@@ -220,7 +229,10 @@
 	var/critique = stripped_input(H, "Add a critique (optional):", "Critique", "", 100)
 
 	// Assign the grade
-	artwork.assign_final_grade(H, grade, critique)
+	if(artwork)
+		artwork.assign_final_grade(H, grade, critique)
+	else
+		custom_artwork.assign_final_grade(H, grade, critique)
 
 	to_chat(H, span_nicegreen("You have judged the artwork: Grade [grade]"))
 	H.visible_message(span_notice("[H] has judged an artwork, assigning it a grade of [grade]."))
@@ -253,30 +265,39 @@
 		return FALSE
 	var/mob/living/carbon/human/H = owner
 
-	// Find an artwork nearby
+	// Find an artwork nearby (either type)
 	var/obj/structure/corporist_artwork/artwork = null
+	var/obj/structure/custom_corporist_artwork/custom_artwork = null
 	for(var/obj/structure/corporist_artwork/A in range(1, H))
 		artwork = A
 		break
-
 	if(!artwork)
+		for(var/obj/structure/custom_corporist_artwork/A in range(1, H))
+			custom_artwork = A
+			break
+
+	if(!artwork && !custom_artwork)
 		to_chat(H, span_warning("You need to be next to an artwork to describe it."))
 		return FALSE
 
 	// Check permissions
 	var/is_maestro = istype(H.dna?.species, /datum/species/corporist_maestro)
-	var/mob/creator = artwork.creator_ref?.resolve()
+	var/datum/weakref/creator_ref_use = artwork ? artwork.creator_ref : custom_artwork.creator_ref
+	var/mob/creator = creator_ref_use?.resolve()
 
 	if(!is_maestro && creator != H)
 		to_chat(H, span_warning("You can only describe artwork you created."))
 		return FALSE
 
-	// Get description
-	var/new_desc = stripped_input(H, "Write your description (max 300 characters):", "Describe Artwork", artwork.custom_desc || "", 300)
+	var/current_desc = artwork ? (artwork.custom_desc || "") : (custom_artwork.custom_desc || "")
+	var/new_desc = stripped_input(H, "Write your description (max 300 characters):", "Describe Artwork", current_desc, 300)
 	if(!new_desc)
 		return FALSE
 
-	artwork.custom_desc = new_desc
+	if(artwork)
+		artwork.custom_desc = new_desc
+	else
+		custom_artwork.custom_desc = new_desc
 	to_chat(H, span_nicegreen("You have set a custom description for the artwork."))
 
 	StartCooldown()

--- a/ModularLobotomy/ring/actions/corporist_actions.dm
+++ b/ModularLobotomy/ring/actions/corporist_actions.dm
@@ -237,7 +237,7 @@
 		return FALSE
 
 	// Optional critique
-	var/critique = stripped_input(H, "Add a critique (optional):", "Critique", "", 100)
+	var/critique = stripped_input(H, "Add a critique (optional):", "Critique", "", 250)
 
 	// Assign the grade
 	if(artwork)
@@ -300,16 +300,28 @@
 		to_chat(H, span_warning("You can only describe artwork you created."))
 		return FALSE
 
-	var/current_desc = artwork ? (artwork.custom_desc || "") : (custom_artwork.custom_desc || "")
-	var/new_desc = stripped_input(H, "Write your description (max 300 characters):", "Describe Artwork", current_desc, 300)
-	if(!new_desc)
+	var/target = artwork ? artwork : custom_artwork
+	var/choice = tgui_input_list(H, "What would you like to edit?", "Describe Artwork", list("Artist's Note", "Description"))
+	if(!choice)
 		return FALSE
 
-	if(artwork)
-		artwork.custom_desc = new_desc
+	if(choice == "Artist's Note")
+		var/current_note = artwork ? (artwork.custom_desc || "") : (custom_artwork.custom_desc || "")
+		var/new_note = stripped_input(H, "Write your artist's note (max 300 characters):", "Artist's Note", current_note, 300)
+		if(!new_note)
+			return FALSE
+		if(artwork)
+			artwork.custom_desc = new_note
+		else
+			custom_artwork.custom_desc = new_note
+		to_chat(H, span_nicegreen("You have set an artist's note for the artwork."))
 	else
-		custom_artwork.custom_desc = new_desc
-	to_chat(H, span_nicegreen("You have set a custom description for the artwork."))
+		var/current_desc = target.desc || ""
+		var/new_desc = stripped_input(H, "Write a description (max 300 characters):", "Description", current_desc, 300)
+		if(!new_desc)
+			return FALSE
+		target.desc = new_desc
+		to_chat(H, span_nicegreen("You have set a new description for the artwork."))
 
 	StartCooldown()
 	return TRUE

--- a/ModularLobotomy/ring/actions/corporist_actions.dm
+++ b/ModularLobotomy/ring/actions/corporist_actions.dm
@@ -1,7 +1,7 @@
 // Corporist Maestro Actions
 // Actions for the Maestro and Apprentice roles
 
-// ================== SCULPT CORPSE ==================
+// SCULPT CORPSE
 // Primary action to create artwork from a corpse
 
 /datum/action/cooldown/sculpt_corpse
@@ -63,7 +63,7 @@
 	StartCooldown()
 	return TRUE
 
-// ================== DEMONSTRATE ARTISTRY ==================
+// DEMONSTRATE ARTISTRY
 // Special action to inspire others
 
 /datum/action/cooldown/demonstrate_artistry
@@ -150,7 +150,7 @@
 	StartCooldown()
 	return TRUE
 
-// ================== JUDGE ARTWORK ==================
+// JUDGE ARTWORK
 // Maestro-only action to assign final grades
 
 /datum/action/cooldown/judge_artwork
@@ -259,7 +259,7 @@
 	StartCooldown()
 	return TRUE
 
-// ================== DESCRIBE ARTWORK ==================
+// DESCRIBE ARTWORK
 // Action to set custom description on artwork
 
 /datum/action/cooldown/describe_artwork
@@ -326,7 +326,7 @@
 	StartCooldown()
 	return TRUE
 
-// ================== RING SKILL TREE ==================
+// RING SKILL TREE
 // Action to open the Ring Skill Tree TGUI
 
 /datum/action/innate/ring_skill_tree
@@ -360,7 +360,7 @@
 		QDEL_NULL(skill_tree_datum)
 	. = ..()
 
-// ================== RESET ARTISTRY ==================
+// RESET ARTISTRY
 // Maestro-only action to respec a student's skill tree
 
 /datum/action/cooldown/reset_artistry
@@ -417,7 +417,7 @@
 	StartCooldown()
 	return TRUE
 
-// ================== VIEW RING RULES ==================
+// VIEW RING RULES
 // Action to view Ring rules and tenants (uses general view_role_rules base)
 
 /datum/action/innate/view_role_rules/ring_artist
@@ -441,7 +441,7 @@
 	var/html = artist.get_rules_html()
 	H << browse(html, "window=ring_rules;size=600x500")
 
-// ================== FASCIA SPIRIT ACTIONS ==================
+// FASCIA SPIRIT ACTIONS
 
 // View Fascia Rules - explains the spirit's goals (uses general view_role_rules base)
 /datum/action/innate/view_role_rules/fascia

--- a/ModularLobotomy/ring/actions/corporist_actions.dm
+++ b/ModularLobotomy/ring/actions/corporist_actions.dm
@@ -300,7 +300,6 @@
 		to_chat(H, span_warning("You can only describe artwork you created."))
 		return FALSE
 
-	var/target = artwork ? artwork : custom_artwork
 	var/choice = tgui_input_list(H, "What would you like to edit?", "Describe Artwork", list("Artist's Note", "Description"))
 	if(!choice)
 		return FALSE
@@ -316,11 +315,12 @@
 			custom_artwork.custom_desc = new_note
 		to_chat(H, span_nicegreen("You have set an artist's note for the artwork."))
 	else
-		var/current_desc = target.desc || ""
+		var/obj/structure/target_obj = artwork ? artwork : custom_artwork
+		var/current_desc = target_obj.desc || ""
 		var/new_desc = stripped_input(H, "Write a description (max 300 characters):", "Description", current_desc, 300)
 		if(!new_desc)
 			return FALSE
-		target.desc = new_desc
+		target_obj.desc = new_desc
 		to_chat(H, span_nicegreen("You have set a new description for the artwork."))
 
 	StartCooldown()

--- a/ModularLobotomy/ring/antagonists/ring_artist.dm
+++ b/ModularLobotomy/ring/antagonists/ring_artist.dm
@@ -110,7 +110,7 @@
 
 	return result.Join("<br>")
 
-// ===================== MAESTRO =====================
+// MAESTRO
 
 /datum/antagonist/ring_artist/maestro
 	name = "Ring Maestro"
@@ -220,7 +220,7 @@
 		<p>You cannot judge your own artwork. A true artist seeks the judgment of others.</p>
 	</body></html>"}
 
-// ===================== APPRENTICE =====================
+// APPRENTICE
 
 /datum/antagonist/ring_artist/apprentice
 	name = "Ring Apprentice"
@@ -285,7 +285,7 @@
 		<p>You have given up everything to pursue the arts. Make it worth the sacrifice.</p>
 	</body></html>"}
 
-// ===================== STUDENT =====================
+// STUDENT
 
 /datum/antagonist/ring_artist/student
 	name = "Ring Student"

--- a/ModularLobotomy/ring/antagonists/ring_artist.dm
+++ b/ModularLobotomy/ring/antagonists/ring_artist.dm
@@ -1,1 +1,372 @@
-// Stub - populated by the Ring sub-PR
+// Ring Artist Antagonist Datums
+// Antagonist datums for the Corporist school of The Ring
+
+/datum/antagonist/ring_artist
+	name = "Ring Artist"
+	roundend_category = "ring artists"
+	antagpanel_category = "Ring"
+	show_in_roundend = TRUE
+	show_in_antagpanel = TRUE
+	/// List of grades received during the round
+	var/list/grades_received = list()
+
+/datum/antagonist/ring_artist/on_gain()
+	. = ..()
+	owner.special_role = name
+	// Grant view rules action
+	if(owner.current)
+		var/datum/action/innate/view_role_rules/ring_artist/action = new(owner.current)
+		action.Grant(owner.current)
+		RegisterSignal(owner.current, COMSIG_NURSEFATHER_RECRUITMENT_OVERRIDE, PROC_REF(on_nursefather_override))
+
+/datum/antagonist/ring_artist/on_removal()
+	// Remove view rules action
+	if(owner?.current)
+		UnregisterSignal(owner.current, COMSIG_NURSEFATHER_RECRUITMENT_OVERRIDE)
+		for(var/datum/action/innate/view_role_rules/ring_artist/action in owner.current.actions)
+			action.Remove(owner.current)
+	. = ..()
+
+/datum/antagonist/ring_artist/proc/on_nursefather_override(datum/source, mob/living/recruiter, obj/item/apprentice_recruitment/scroll)
+	SIGNAL_HANDLER
+	if(owner)
+		INVOKE_ASYNC(owner, TYPE_PROC_REF(/datum/mind, remove_antag_datum), /datum/antagonist/ring_artist)
+
+/// Returns formatted HTML content for the rules window
+/datum/antagonist/ring_artist/proc/get_rules_html()
+	return {"<html><head><style>
+		body { background: #1a1a1a; color: #d4d4d4; font-family: Arial, sans-serif; padding: 15px; }
+		h1 { color: #ff6b6b; border-bottom: 2px solid #ff6b6b; padding-bottom: 5px; }
+		h2 { color: #ffa500; margin-top: 20px; }
+		.expected { color: #7cfc00; }
+		.permitted { color: #ffd700; }
+		.violation { color: #ff4444; font-weight: bold; }
+		.info { color: #87ceeb; }
+		ul { margin: 5px 0; }
+		li { margin: 3px 0; }
+	</style></head><body>
+		<h1>Ring Artist Rules</h1>
+		<p class='info'>You are a member of The Ring, a Syndicate devoted to creating art that reflects the human condition.</p>
+	</body></html>"}
+
+/datum/antagonist/ring_artist/roundend_report()
+	var/list/report = list()
+
+	report += printplayer(owner)
+
+	// Get EXP info from the artistic_exp component
+	var/mob/living/carbon/human/H = owner.current
+	if(istype(H))
+		var/datum/component/artistic_exp/exp_comp = H.GetComponent(/datum/component/artistic_exp)
+		if(exp_comp)
+			report += "<b>Final Artistic EXP:</b> [exp_comp.exp]"
+			report += "<b>Skill Points Earned:</b> [exp_comp.skill_points + exp_comp.skill_points_spent]"
+			if(exp_comp.main_school)
+				report += "<b>Main School:</b> [capitalize(exp_comp.main_school)]"
+
+	// Show grades received
+	if(length(grades_received))
+		report += "<b>Grades Received:</b> [grades_received.Join(", ")]"
+
+		// Count each grade type
+		var/list/grade_counts = list("S" = 0, "A" = 0, "B" = 0, "C" = 0, "F" = 0)
+		for(var/grade in grades_received)
+			if(grade in grade_counts)
+				grade_counts[grade]++
+
+		report += "<b>Grade Summary:</b> S:[grade_counts["S"]] A:[grade_counts["A"]] B:[grade_counts["B"]] C:[grade_counts["C"]] F:[grade_counts["F"]]"
+	else
+		report += "<b>Grades Received:</b> None"
+
+	return report.Join("<br>")
+
+/datum/antagonist/ring_artist/roundend_report_footer()
+	var/list/result = list()
+
+	// Find the artist with highest EXP (excluding Maestro - they don't compete)
+	var/highest_exp = 0
+	var/datum/antagonist/ring_artist/top_artist = null
+
+	for(var/datum/antagonist/ring_artist/RA in GLOB.antagonists)
+		// Skip maestros - they are the judges, not the judged
+		if(istype(RA, /datum/antagonist/ring_artist/maestro))
+			continue
+		if(!RA.owner || !RA.owner.current)
+			continue
+		if(!ishuman(RA.owner.current))
+			continue
+
+		var/mob/living/carbon/human/H = RA.owner.current
+		var/datum/component/artistic_exp/exp_comp = H.GetComponent(/datum/component/artistic_exp)
+		if(exp_comp && exp_comp.exp > highest_exp)
+			highest_exp = exp_comp.exp
+			top_artist = RA
+
+	if(top_artist)
+		result += "<br><span class='header'>Top Ring Artist:</span>"
+		result += "<b>[top_artist.owner.name]</b> earned [highest_exp] Artistic EXP!"
+		if(length(top_artist.grades_received))
+			result += "<b>Their Grades:</b> [top_artist.grades_received.Join(", ")]"
+
+	return result.Join("<br>")
+
+// ===================== MAESTRO =====================
+
+/datum/antagonist/ring_artist/maestro
+	name = "Ring Maestro"
+
+/datum/antagonist/ring_artist/maestro/greet()
+	to_chat(owner.current, span_userdanger("You are a Maestro of the Corporist school!"))
+	to_chat(owner.current, span_boldnotice("The Ring is a Syndicate devoted to creating art that reflects the human condition through exhibiting human suffering."))
+	to_chat(owner.current, span_boldnotice("As a Corporist, you specialize in utilizing the interaction between human bones and muscles."))
+	to_chat(owner.current, " ")
+	to_chat(owner.current, span_bold("RULES OF CONDUCT:"))
+	to_chat(owner.current, span_nicegreen("EXPECTED: Creating art from the flesh of creatures"))
+	to_chat(owner.current, span_nicegreen("EXPECTED: Educating others about the Corporist arts"))
+	to_chat(owner.current, span_nicegreen("EXPECTED: Teaching and mentoring aspiring artists"))
+	to_chat(owner.current, span_notice("PERMITTED: Judging others' artwork (fairly or unfairly, for artistic reasons)"))
+	to_chat(owner.current, span_warning("PERMITTED: Slaying those who prevent your art from being created"))
+	to_chat(owner.current, span_warning("PERMITTED: Slaying those who insult, break, or steal your artwork"))
+	to_chat(owner.current, span_boldwarning("VIOLATION: Killing those who pose no threat to your art or artistic mission"))
+	to_chat(owner.current, " ")
+	to_chat(owner.current, span_notice("Use the 'View Ring Rules' action to review your rules and judging guidelines."))
+
+/datum/antagonist/ring_artist/maestro/get_rules_html()
+	return {"<html><head><style>
+		body { background: #1a1a1a; color: #d4d4d4; font-family: Arial, sans-serif; padding: 15px; }
+		h1 { color: #ff6b6b; border-bottom: 2px solid #ff6b6b; padding-bottom: 5px; }
+		h2 { color: #ffa500; margin-top: 20px; }
+		h3 { color: #87ceeb; margin-top: 15px; }
+		.expected { color: #7cfc00; }
+		.permitted { color: #ffd700; }
+		.violation { color: #ff4444; font-weight: bold; }
+		.info { color: #87ceeb; }
+		.grade-s { color: #ff00ff; font-weight: bold; }
+		.grade-a { color: #00ff00; }
+		.grade-b { color: #ffff00; }
+		.grade-c { color: #ffa500; }
+		.grade-f { color: #ff4444; }
+		ul { margin: 5px 0; }
+		li { margin: 3px 0; }
+		table { border-collapse: collapse; width: 100%; margin: 10px 0; }
+		th, td { border: 1px solid #555; padding: 8px; text-align: left; vertical-align: top; }
+		th { background: #333; color: #ffa500; }
+		td { background: #252525; }
+		.aspect { color: #87ceeb; font-weight: bold; }
+	</style></head><body>
+		<h1>Corporist Maestro - Rules of Conduct</h1>
+		<p class='info'>You are a Maestro of the Corporist school of The Ring, a Syndicate devoted to creating art that reflects the human condition through exhibiting human suffering.</p>
+
+		<h2>Conduct</h2>
+		<ul>
+			<li class='expected'>EXPECTED: Creating art from the flesh of creatures</li>
+			<li class='expected'>EXPECTED: Educating others about the Corporist arts</li>
+			<li class='expected'>EXPECTED: Teaching and mentoring aspiring artists</li>
+			<li class='permitted'>PERMITTED: Judging others' artwork (fairly or unfairly, for artistic reasons)</li>
+			<li class='permitted'>PERMITTED: Slaying those who prevent your art from being created</li>
+			<li class='permitted'>PERMITTED: Slaying those who insult, break, or steal your artwork</li>
+			<li class='violation'>VIOLATION: Killing those who pose no threat to your art or artistic mission</li>
+		</ul>
+
+		<h2>Judging Guidelines</h2>
+		<p>When evaluating an artwork, the Maestro should consider these four aspects:</p>
+
+		<table>
+			<tr>
+				<th>Aspect</th>
+				<th>What to Evaluate</th>
+				<th>Questions to Ask</th>
+			</tr>
+			<tr>
+				<td class='aspect'>Composition</td>
+				<td>The bodyparts and creatures used in the artwork</td>
+				<td>Do the materials follow an artistic theme? Is there meaning in their selection? Did they use specific creature types or bodypart combinations intentionally?</td>
+			</tr>
+			<tr>
+				<td class='aspect'>Investment</td>
+				<td>The tier of the artwork and materials invested</td>
+				<td>How many resources did they put into this work? Did they take time to build it up, or is it a rushed piece? Higher tiers show greater dedication.</td>
+			</tr>
+			<tr>
+				<td class='aspect'>Technique</td>
+				<td>The technique grade from the sculpting minigame</td>
+				<td>How delicate and precise was their handywork? A high technique grade (A or S) shows mastery of the craft. Low grades suggest carelessness.</td>
+			</tr>
+			<tr>
+				<td class='aspect'>Vision</td>
+				<td>The custom description written by the artist</td>
+				<td>Did they describe their own artwork? How eloquent and meaningful is their description? Does it convey artistic intent and vision?</td>
+			</tr>
+		</table>
+
+		<h3>Grading Criteria</h3>
+		<ul>
+			<li class='grade-s'>S Grade (30 min cooldown): A true masterwork. Profound artistic vision that transcends the medium. Reserve this for exceptional works that move you deeply.</li>
+			<li class='grade-a'>A Grade (5 min cooldown): Excellent technique and creativity. Shows mastery of the Corporist arts.</li>
+			<li class='grade-b'>B Grade: Competent work that demonstrates solid skill and understanding.</li>
+			<li class='grade-c'>C Grade: Adequate but uninspired. The artist shows potential but lacks vision.</li>
+			<li class='grade-f'>F Grade: Poor execution or a failed artistic vision. A teaching moment.</li>
+		</ul>
+
+		<h3>Judging Philosophy</h3>
+		<ul>
+			<li>You may grade based on artistic merit, rewarding those who show true talent.</li>
+			<li>You may also grade unfairly for artistic reasons - rivalry, drama, and favoritism are all part of the art world.</li>
+			<li>A higher tier artwork does not guarantee a higher grade - a small piece with vision may outshine a large but soulless work.</li>
+			<li>Your judgment shapes your students' futures. Use this power wisely... or don't.</li>
+		</ul>
+
+		<h3>Remember</h3>
+		<p>You cannot judge your own artwork. A true artist seeks the judgment of others.</p>
+	</body></html>"}
+
+// ===================== APPRENTICE =====================
+
+/datum/antagonist/ring_artist/apprentice
+	name = "Ring Apprentice"
+
+/datum/antagonist/ring_artist/apprentice/greet()
+	to_chat(owner.current, span_userdanger("You have become a Corporist Apprentice!"))
+	to_chat(owner.current, span_boldnotice("You now serve your Maestro and The Ring's artistic vision."))
+	to_chat(owner.current, span_boldnotice("Your previous life is behind you. The art is all that matters now."))
+	to_chat(owner.current, " ")
+	to_chat(owner.current, span_bold("RULES OF CONDUCT:"))
+	to_chat(owner.current, span_warning("Your previous faction allegiances are LOST"))
+	to_chat(owner.current, span_warning("Your previous special permissions are LOST"))
+	to_chat(owner.current, span_notice("PERMITTED: Defending your art and your Maestro's vision"))
+	to_chat(owner.current, span_boldwarning("VIOLATION: Killing those unrelated to your artistic mission"))
+	to_chat(owner.current, " ")
+	to_chat(owner.current, span_notice("Use the 'View Ring Rules' action to review your rules at any time."))
+
+/datum/antagonist/ring_artist/apprentice/get_rules_html()
+	return {"<html><head><style>
+		body { background: #1a1a1a; color: #d4d4d4; font-family: Arial, sans-serif; padding: 15px; }
+		h1 { color: #ff6b6b; border-bottom: 2px solid #ff6b6b; padding-bottom: 5px; }
+		h2 { color: #ffa500; margin-top: 20px; }
+		h3 { color: #87ceeb; margin-top: 15px; }
+		.expected { color: #7cfc00; }
+		.permitted { color: #ffd700; }
+		.violation { color: #ff4444; font-weight: bold; }
+		.warning { color: #ffa500; }
+		.info { color: #87ceeb; }
+		ul { margin: 5px 0; }
+		li { margin: 3px 0; }
+	</style></head><body>
+		<h1>Corporist Apprentice - Rules of Conduct</h1>
+		<p class='info'>You have been elevated to Apprentice of the Corporist school. Your previous life is behind you - the art is all that matters now.</p>
+
+		<h2>Your New Identity</h2>
+		<ul>
+			<li class='warning'>Your previous faction allegiances are LOST</li>
+			<li class='warning'>Your previous special permissions are LOST</li>
+			<li>You now serve your Maestro and The Ring's artistic vision</li>
+			<li>Your body has been transformed into a prosthetic vessel for your art</li>
+		</ul>
+
+		<h2>Conduct</h2>
+		<ul>
+			<li class='expected'>EXPECTED: Creating art from the flesh of creatures</li>
+			<li class='expected'>EXPECTED: Following your Maestro's guidance</li>
+			<li class='permitted'>PERMITTED: Defending your art and your Maestro's vision</li>
+			<li class='permitted'>PERMITTED: Competition with other students for the Maestro's favor</li>
+			<li class='violation'>VIOLATION: Killing those unrelated to your artistic mission</li>
+		</ul>
+
+		<h2>Competition</h2>
+		<p>As an Apprentice, you are above the petty squabbles of Students, but competition for the Maestro's favor continues:</p>
+		<ul>
+			<li>Your artwork will be judged by the Maestro</li>
+			<li>Earn EXP through creating and refining artwork</li>
+			<li>The artist with the most EXP is celebrated at round end</li>
+			<li>Higher grades from the Maestro mean greater recognition</li>
+		</ul>
+
+		<h3>Remember</h3>
+		<p>You have given up everything to pursue the arts. Make it worth the sacrifice.</p>
+	</body></html>"}
+
+// ===================== STUDENT =====================
+
+/datum/antagonist/ring_artist/student
+	name = "Ring Student"
+
+/datum/antagonist/ring_artist/student/greet()
+	to_chat(owner.current, span_userdanger("You are now a Student of The Ring!"))
+	to_chat(owner.current, span_boldnotice("You have proven your dedication to the artistic path."))
+	to_chat(owner.current, span_boldnotice("Compete with your fellow students for the Maestro's favor."))
+	to_chat(owner.current, " ")
+	to_chat(owner.current, span_bold("RULES OF CONDUCT:"))
+	to_chat(owner.current, span_warning("Your previous faction allegiances are LOST"))
+	to_chat(owner.current, span_notice("Your previous special permissions are KEPT"))
+	to_chat(owner.current, span_notice("PERMITTED: Defending your art"))
+	to_chat(owner.current, span_notice("PERMITTED: Infighting and sabotage against other students for better grades"))
+	to_chat(owner.current, span_boldwarning("VIOLATION: Killing those unrelated to your artistic mission"))
+	to_chat(owner.current, " ")
+	to_chat(owner.current, span_boldnotice("TIP: Sabotage is preferred over murder. If you must kill, don't get caught."))
+	to_chat(owner.current, span_notice("Use the 'View Ring Rules' action for detailed sabotage methods and competition rules."))
+
+/datum/antagonist/ring_artist/student/get_rules_html()
+	return {"<html><head><style>
+		body { background: #1a1a1a; color: #d4d4d4; font-family: Arial, sans-serif; padding: 15px; }
+		h1 { color: #ff6b6b; border-bottom: 2px solid #ff6b6b; padding-bottom: 5px; }
+		h2 { color: #ffa500; margin-top: 20px; }
+		h3 { color: #87ceeb; margin-top: 15px; }
+		.expected { color: #7cfc00; }
+		.permitted { color: #ffd700; }
+		.violation { color: #ff4444; font-weight: bold; }
+		.warning { color: #ffa500; }
+		.info { color: #87ceeb; }
+		.tip { color: #ff69b4; font-style: italic; }
+		ul { margin: 5px 0; }
+		li { margin: 3px 0; }
+	</style></head><body>
+		<h1>Ring Student - Rules of Conduct</h1>
+		<p class='info'>You have proven your dedication to the artistic path. Now compete with your fellow students for the Maestro's favor.</p>
+
+		<h2>Your Status</h2>
+		<ul>
+			<li class='warning'>Your previous faction allegiances are LOST</li>
+			<li class='permitted'>Your previous special permissions are KEPT</li>
+			<li>You are a student of The Ring, learning the Corporist arts</li>
+		</ul>
+
+		<h2>Conduct</h2>
+		<ul>
+			<li class='permitted'>PERMITTED: Defending your art</li>
+			<li class='permitted'>PERMITTED: Infighting and sabotage against other students</li>
+			<li class='permitted'>PERMITTED: Competition for the Maestro's favor</li>
+			<li class='violation'>VIOLATION: Killing those unrelated to your artistic mission</li>
+		</ul>
+
+		<h2>Competition</h2>
+		<p>The Ring encourages artistic competition among students:</p>
+		<ul>
+			<li>The student with the highest Artistic EXP at round end is celebrated as the Top Ring Artist</li>
+			<li>Grades from the Maestro affect your standing and provide EXP bonuses</li>
+			<li>Sabotage of other students' art is not only permitted - it is expected</li>
+			<li>An Apprentice may be chosen from among the most promising students</li>
+		</ul>
+
+		<h2>Sabotage Methods</h2>
+		<p class='info'>The art world is cutthroat. Here are some ways to get ahead:</p>
+		<ul>
+			<li><b>Destroy rival artwork</b> - A smashed sculpture cannot earn a grade</li>
+			<li><b>Steal artwork</b> - Claim a rival's creation as your own before they can show the Maestro</li>
+			<li><b>Lead dangerous creatures to rivals</b> - Accidents happen in the art world</li>
+			<li><b>Interfere with sculpting</b> - Interrupt a rival's work to ruin their concentration</li>
+			<li><b>Spread misinformation</b> - Tell the Maestro their work is derivative or stolen</li>
+			<li><b>Hoard materials</b> - Bodies are finite. Claim them before your rivals can</li>
+			<li><b>Distract with false opportunities</b> - Send rivals on wild goose chases</li>
+		</ul>
+
+		<h3>Guidelines for Violence</h3>
+		<ul>
+			<li class='tip'>Sabotage is preferred over murder</li>
+			<li class='tip'>If you must kill a rival, don't get caught</li>
+			<li class='tip'>Make it look like an accident or abnormality attack</li>
+			<li class='tip'>Dead rivals can't compete, but witnesses can report you</li>
+		</ul>
+
+		<h3>Remember</h3>
+		<p>The Maestro's judgment is final. Curry their favor through excellent art... or through the destruction of your competition.</p>
+	</body></html>"}

--- a/ModularLobotomy/ring/minigames/sculpting_minigame.dm
+++ b/ModularLobotomy/ring/minigames/sculpting_minigame.dm
@@ -76,7 +76,7 @@
 
 /// Generate sweet spots for the current round
 /datum/sculpting_minigame/proc/generate_sweet_spots()
-	sweet_spots = list()
+	sweet_spots.Cut()
 
 	// Number of sweet spots decreases in later rounds
 	var/num_spots = 3

--- a/ModularLobotomy/ring/minigames/sculpting_minigame.dm
+++ b/ModularLobotomy/ring/minigames/sculpting_minigame.dm
@@ -1,1 +1,371 @@
-// Stub - populated by the Ring sub-PR
+// Sculpting Minigame
+// A timing-based minigame for refining corporist artworks
+
+/datum/sculpting_minigame
+	/// The player doing the sculpting
+	var/mob/living/carbon/human/sculptor
+	/// The artwork being refined
+	var/obj/structure/corporist_artwork/artwork
+	/// Current round (1-6)
+	var/current_round = 1
+	/// Total rounds
+	var/total_rounds = 6
+	/// Current score
+	var/score = 0
+	/// Current combo
+	var/combo = 0
+	/// Best combo achieved
+	var/best_combo = 0
+	/// Needle position (0-100)
+	var/needle_position = 0
+	/// Needle direction (1 = right, -1 = left)
+	var/needle_direction = 1
+	/// Needle speed (positions per tick)
+	var/needle_speed = 2
+	/// List of sweet spot positions (each is list("start", "end", "perfect_start", "perfect_end"))
+	var/list/sweet_spots = list()
+	/// Whether the minigame is active
+	var/active = FALSE
+	/// Whether waiting for input this round
+	var/awaiting_input = TRUE
+	/// Last hit result for display
+	var/last_hit_result = ""
+	/// Timer ID for needle movement
+	var/movement_timer
+	/// Difficulty modifier based on artist type
+	var/difficulty = "medium"
+	/// Starting score bonus based on artist type
+	var/starting_bonus = 0
+
+/datum/sculpting_minigame/New(mob/living/carbon/human/user, obj/structure/corporist_artwork/target)
+	sculptor = user
+	artwork = target
+	determine_difficulty()
+	generate_sweet_spots()
+	score = starting_bonus
+
+/datum/sculpting_minigame/Destroy()
+	if(movement_timer)
+		deltimer(movement_timer)
+	sculptor = null
+	artwork = null
+	return ..()
+
+/// Determine difficulty based on artist type
+/datum/sculpting_minigame/proc/determine_difficulty()
+	if(!sculptor)
+		return
+
+	// Check artist type
+	if(istype(sculptor.dna?.species, /datum/species/corporist_maestro))
+		difficulty = "easy"
+		needle_speed = 1.5
+		starting_bonus = 2
+	else if(istype(sculptor.dna?.species, /datum/species/corporist_apprentice))
+		difficulty = "medium"
+		needle_speed = 2
+		starting_bonus = 1
+	else if(sculptor.GetComponent(/datum/component/corporist_student))
+		difficulty = "medium"
+		needle_speed = 2
+		starting_bonus = 0
+	else if(sculptor.GetComponent(/datum/component/inspired_artist))
+		difficulty = "hard"
+		needle_speed = 2.5
+		starting_bonus = -1
+
+/// Generate sweet spots for the current round
+/datum/sculpting_minigame/proc/generate_sweet_spots()
+	sweet_spots = list()
+
+	// Number of sweet spots decreases in later rounds
+	var/num_spots = 3
+	if(current_round >= 5)
+		num_spots = 2
+	else if(current_round >= 3)
+		num_spots = 3
+
+	// Sweet spot size based on difficulty
+	var/spot_size
+	var/perfect_size
+	switch(difficulty)
+		if("easy")
+			spot_size = 15
+			perfect_size = 5
+		if("medium")
+			spot_size = 12
+			perfect_size = 4
+		if("hard")
+			spot_size = 8
+			perfect_size = 2
+
+	// Generate non-overlapping sweet spots
+	var/list/used_ranges = list()
+	for(var/i in 1 to num_spots)
+		var/attempts = 0
+		var/valid = FALSE
+		var/start_pos
+
+		while(!valid && attempts < 50)
+			attempts++
+			start_pos = rand(5, 95 - spot_size)
+			valid = TRUE
+
+			// Check for overlap with existing spots
+			for(var/list/range in used_ranges)
+				if(start_pos < range["end"] + 5 && start_pos + spot_size > range["start"] - 5)
+					valid = FALSE
+					break
+
+		if(valid)
+			var/end_pos = start_pos + spot_size
+			var/perfect_start = start_pos + round((spot_size - perfect_size) / 2)
+			var/perfect_end = perfect_start + perfect_size
+
+			sweet_spots += list(list(
+				"start" = start_pos,
+				"end" = end_pos,
+				"perfect_start" = perfect_start,
+				"perfect_end" = perfect_end
+			))
+			used_ranges += list(list("start" = start_pos, "end" = end_pos))
+
+/datum/sculpting_minigame/proc/start_game()
+	active = TRUE
+	awaiting_input = TRUE
+	current_round = 1
+	score = starting_bonus
+	combo = 0
+	best_combo = 0
+	needle_position = 0
+	needle_direction = 1
+	last_hit_result = ""
+	generate_sweet_spots()
+	start_needle_movement()
+
+/datum/sculpting_minigame/proc/start_needle_movement()
+	if(movement_timer)
+		deltimer(movement_timer)
+	movement_timer = addtimer(CALLBACK(src, PROC_REF(move_needle)), 0.5, TIMER_LOOP | TIMER_STOPPABLE)
+
+/datum/sculpting_minigame/proc/stop_needle_movement()
+	if(movement_timer)
+		deltimer(movement_timer)
+		movement_timer = null
+
+/datum/sculpting_minigame/proc/move_needle()
+	if(!active || !awaiting_input)
+		return
+
+	// Move needle
+	needle_position += needle_speed * needle_direction
+
+	// Bounce at edges
+	if(needle_position >= 100)
+		needle_position = 100
+		needle_direction = -1
+	else if(needle_position <= 0)
+		needle_position = 0
+		needle_direction = 1
+
+	// Update UI
+	SStgui.update_uis(src)
+
+/// Called when player attempts to sculpt
+/datum/sculpting_minigame/proc/attempt_sculpt()
+	if(!active || !awaiting_input)
+		return
+
+	awaiting_input = FALSE
+	var/hit_type = check_hit()
+
+	// Apply score
+	var/points = 0
+	switch(hit_type)
+		if("perfect")
+			points = 3
+			combo++
+			last_hit_result = "PERFECT!"
+			playsound(sculptor, 'sound/machines/chime.ogg', 50, TRUE)
+		if("good")
+			points = 2
+			combo++
+			last_hit_result = "Good"
+			playsound(sculptor, 'sound/machines/click.ogg', 40, TRUE)
+		if("okay")
+			points = 1
+			combo++
+			last_hit_result = "Okay"
+			playsound(sculptor, 'sound/machines/click.ogg', 30, TRUE)
+		if("miss")
+			points = -1
+			combo = 0
+			last_hit_result = "Miss"
+			playsound(sculptor, 'sound/effects/splat.ogg', 40, TRUE)
+
+	// Apply combo multiplier
+	var/multiplier = 1
+	if(combo >= 5)
+		multiplier = 2
+	else if(combo >= 3)
+		multiplier = 1.5
+
+	if(points > 0)
+		points = round(points * multiplier)
+
+	score += points
+
+	// Track best combo
+	if(combo > best_combo)
+		best_combo = combo
+
+	// Update UI to show result
+	SStgui.update_uis(src)
+
+	// Short delay then advance round
+	addtimer(CALLBACK(src, PROC_REF(advance_round)), 1 SECONDS)
+
+/// Check what type of hit the player got
+/datum/sculpting_minigame/proc/check_hit()
+	for(var/list/spot in sweet_spots)
+		if(needle_position >= spot["perfect_start"] && needle_position <= spot["perfect_end"])
+			return "perfect"
+		if(needle_position >= spot["start"] && needle_position <= spot["end"])
+			// Check if close to perfect zone
+			var/perfect_center = (spot["perfect_start"] + spot["perfect_end"]) / 2
+			var/distance = abs(needle_position - perfect_center)
+			if(distance <= 3)
+				return "good"
+			return "okay"
+	return "miss"
+
+/datum/sculpting_minigame/proc/advance_round()
+	current_round++
+
+	if(current_round > total_rounds)
+		end_game()
+		return
+
+	// Increase speed slightly each round
+	needle_speed += 0.15
+
+	// Generate new sweet spots
+	generate_sweet_spots()
+
+	// Reset for next round
+	awaiting_input = TRUE
+	last_hit_result = ""
+
+	SStgui.update_uis(src)
+
+/datum/sculpting_minigame/proc/end_game()
+	active = FALSE
+	stop_needle_movement()
+
+	// Calculate grade
+	var/grade = calculate_grade()
+
+	// Apply grade to artwork
+	if(artwork)
+		artwork.complete_refinement(grade)
+
+		// Add flat EXP based on grade
+		var/datum/component/artistic_exp/exp_comp = sculptor.GetComponent(/datum/component/artistic_exp)
+		if(exp_comp)
+			exp_comp.add_refine_exp(grade)
+
+	to_chat(sculptor, span_notice("Refinement complete! Grade: [grade]"))
+
+	// Update UI one final time
+	SStgui.update_uis(src)
+
+/datum/sculpting_minigame/proc/calculate_grade()
+	if(score <= 5)
+		return "F"
+	if(score <= 10)
+		return "C"
+	if(score <= 15)
+		return "B"
+	if(score <= 20)
+		return "A"
+	return "S"
+
+/datum/sculpting_minigame/proc/get_grade_color(grade)
+	switch(grade)
+		if("F")
+			return "red"
+		if("C")
+			return "orange"
+		if("B")
+			return "yellow"
+		if("A")
+			return "green"
+		if("S")
+			return "gold"
+	return "white"
+
+// TGUI Interface
+/datum/sculpting_minigame/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "SculptingMinigame")
+		ui.open()
+
+/datum/sculpting_minigame/ui_state(mob/user)
+	return GLOB.conscious_state
+
+/datum/sculpting_minigame/ui_data(mob/user)
+	var/list/data = list()
+
+	data["active"] = active
+	data["currentRound"] = current_round
+	data["totalRounds"] = total_rounds
+	data["score"] = score
+	data["combo"] = combo
+	data["bestCombo"] = best_combo
+	data["needlePosition"] = needle_position
+	data["awaitingInput"] = awaiting_input
+	data["lastHitResult"] = last_hit_result
+	data["difficulty"] = difficulty
+
+	// Sweet spots data
+	data["sweetSpots"] = list()
+	for(var/list/spot in sweet_spots)
+		data["sweetSpots"] += list(list(
+			"start" = spot["start"],
+			"end" = spot["end"],
+			"perfectStart" = spot["perfect_start"],
+			"perfectEnd" = spot["perfect_end"]
+		))
+
+	// Game over data
+	if(!active && current_round > total_rounds)
+		data["gameOver"] = TRUE
+		data["finalGrade"] = calculate_grade()
+		data["gradeColor"] = get_grade_color(calculate_grade())
+	else
+		data["gameOver"] = FALSE
+
+	return data
+
+/datum/sculpting_minigame/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	if(.)
+		return
+
+	switch(action)
+		if("sculpt")
+			attempt_sculpt()
+			return TRUE
+		if("start")
+			start_game()
+			return TRUE
+		if("close")
+			qdel(src)
+			return TRUE
+
+	return FALSE
+
+/datum/sculpting_minigame/ui_close(mob/user)
+	. = ..()
+	qdel(src)

--- a/ModularLobotomy/ring/ring_skills/artistic_exp.dm
+++ b/ModularLobotomy/ring/ring_skills/artistic_exp.dm
@@ -171,7 +171,7 @@
 /datum/component/artistic_exp/proc/refund_all_points()
 	skill_points += skill_points_spent
 	skill_points_spent = 0
-	schools_invested = list()
+	schools_invested.Cut()
 	return TRUE
 
 /// Check if player can invest in a school

--- a/ModularLobotomy/ring/ring_skills/artistic_exp.dm
+++ b/ModularLobotomy/ring/ring_skills/artistic_exp.dm
@@ -1,1 +1,209 @@
-// Stub - populated by the Ring sub-PR
+// Artistic EXP Component
+// Tracks artistic experience and skill points for Ring artists
+
+/datum/component/artistic_exp
+	dupe_mode = COMPONENT_DUPE_UNIQUE
+	/// Current artistic EXP
+	var/exp = 0
+	/// Skill points available to spend
+	var/skill_points = 0
+	/// Skill points already spent
+	var/skill_points_spent = 0
+	/// Schools the player has invested in
+	var/list/schools_invested = list()
+	/// Maximum number of schools this player can invest in (2 for students, 3 for apprentice, 4 for maestro)
+	var/max_schools = 2
+	/// The main school this player identifies with (for examine text)
+	var/main_school = null
+	/// List of final grades received from Maestro grading (for round end report)
+	var/list/grades_received = list()
+
+	/// EXP thresholds for skill points (fast for first 4 levels, then slows down)
+	var/static/list/exp_thresholds = list(30, 70, 120, 180, 350, 600, 950, 1400, 1950, 2600, 3350, 4200)
+
+/datum/component/artistic_exp/Initialize()
+	. = ..()
+	if(!ishuman(parent))
+		return COMPONENT_INCOMPATIBLE
+
+/datum/component/artistic_exp/RegisterWithParent()
+	. = ..()
+	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))
+
+/datum/component/artistic_exp/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_PARENT_EXAMINE)
+	. = ..()
+
+/// Show school info to other Ring artists, EXP info only to Maestro
+/datum/component/artistic_exp/proc/on_examine(datum/source, mob/examiner, list/examine_list)
+	SIGNAL_HANDLER
+
+	var/mob/living/carbon/human/H = parent
+	if(!istype(H))
+		return
+
+	// Only other Ring artists can see school info
+	var/examiner_is_artist = FALSE
+	var/examiner_is_maestro = FALSE
+	if(ishuman(examiner))
+		var/mob/living/carbon/human/examiner_human = examiner
+		if(examiner_human.GetComponent(/datum/component/artistic_exp))
+			examiner_is_artist = TRUE
+		if(istype(examiner_human.dna?.species, /datum/species/corporist_maestro))
+			examiner_is_maestro = TRUE
+
+	if(examiner_is_artist && main_school)
+		var/school_name = get_school_display_name(main_school)
+		var/is_maestro = istype(H.dna?.species, /datum/species/corporist_maestro)
+		if(is_maestro)
+			examine_list += span_notice("[H.p_they(TRUE)] [H.p_are()] currently studying the [school_name] school.")
+		else
+			examine_list += span_notice("[H.p_they(TRUE)] [H.p_are()] a follower of the [school_name] school.")
+
+	// Only Maestro examiners can see EXP stats
+	if(examiner_is_maestro)
+		examine_list += span_notice("Artistic EXP: [exp] | Skill Points: [skill_points]/[skill_points + skill_points_spent]")
+
+/// Convert school ID to display name
+/datum/component/artistic_exp/proc/get_school_display_name(school_id)
+	switch(school_id)
+		if("fauvist")
+			return "Fauvist"
+		if("pointillist")
+			return "Pointillist"
+		if("cubist")
+			return "Cubist"
+		if("corporist")
+			return "Corporist"
+	return "Unknown"
+
+/// Get the next EXP threshold
+/datum/component/artistic_exp/proc/get_next_threshold()
+	var/total_points = skill_points + skill_points_spent
+	if(total_points >= length(exp_thresholds))
+		return exp_thresholds[length(exp_thresholds)] // Return max threshold
+	return exp_thresholds[total_points + 1]
+
+/// Get the current EXP threshold (the one we just passed)
+/datum/component/artistic_exp/proc/get_current_threshold()
+	var/total_points = skill_points + skill_points_spent
+	if(total_points <= 0)
+		return 0
+	if(total_points > length(exp_thresholds))
+		return exp_thresholds[length(exp_thresholds)]
+	return exp_thresholds[total_points]
+
+/// Modify EXP (positive or negative)
+/datum/component/artistic_exp/proc/modify_exp(amount)
+	exp = max(0, exp + amount) // Can't go below 0
+
+	if(amount > 0)
+		to_chat(parent, span_nicegreen("You gained [amount] Artistic EXP! ([exp] total)"))
+	else if(amount < 0)
+		to_chat(parent, span_warning("You lost [abs(amount)] Artistic EXP! ([exp] total)"))
+
+	check_skill_points()
+
+/// Add EXP from artistic activities (flat amounts for consistent progression)
+/datum/component/artistic_exp/proc/add_activity_exp(activity_type)
+	var/exp_gain = 0
+
+	switch(activity_type)
+		if("create_artwork")
+			exp_gain = 5
+		if("add_body")
+			exp_gain = 3
+
+	if(exp_gain > 0)
+		modify_exp(exp_gain)
+
+/// Add flat EXP for completing refinement minigame based on grade
+/datum/component/artistic_exp/proc/add_refine_exp(grade)
+	var/exp_gain = 0
+	switch(grade)
+		if("F")
+			exp_gain = 5
+		if("C")
+			exp_gain = 10
+		if("B")
+			exp_gain = 15
+		if("A")
+			exp_gain = 25
+		if("S")
+			exp_gain = 40
+
+	if(exp_gain > 0)
+		modify_exp(exp_gain)
+
+/// Check if we've earned new skill points
+/datum/component/artistic_exp/proc/check_skill_points()
+	var/total_points_earned = 0
+
+	for(var/i in 1 to length(exp_thresholds))
+		if(exp >= exp_thresholds[i])
+			total_points_earned = i
+		else
+			break
+
+	var/new_points = total_points_earned - skill_points_spent
+	if(new_points > skill_points)
+		var/points_gained = new_points - skill_points
+		skill_points = new_points
+		to_chat(parent, span_greentext("You earned [points_gained] new skill point(s)! Open the Ring Skill Tree to spend them."))
+		// Play sound
+		var/mob/M = parent
+		if(istype(M))
+			SEND_SOUND(M, sound('sound/machines/chime.ogg'))
+
+/// Spend a skill point
+/datum/component/artistic_exp/proc/spend_skill_point(cost = 1)
+	if(skill_points < cost)
+		return FALSE
+	skill_points -= cost
+	skill_points_spent += cost
+	return TRUE
+
+/// Refund all skill points (for Maestro respec)
+/datum/component/artistic_exp/proc/refund_all_points()
+	skill_points += skill_points_spent
+	skill_points_spent = 0
+	schools_invested = list()
+	return TRUE
+
+/// Check if player can invest in a school
+/datum/component/artistic_exp/proc/can_invest_in_school(school_name)
+	if(school_name in schools_invested)
+		return TRUE // Already invested
+	if(length(schools_invested) >= max_schools)
+		return FALSE // Max schools reached
+	return TRUE
+
+/// Register investment in a school
+/datum/component/artistic_exp/proc/invest_in_school(school_name)
+	if(!(school_name in schools_invested))
+		schools_invested += school_name
+
+/// Grant starting skill points and set max schools based on role
+/datum/component/artistic_exp/proc/grant_starting_points(role)
+	switch(role)
+		if("maestro")
+			skill_points = 8
+			max_schools = 4
+			to_chat(parent, span_nicegreen("As a Maestro, you start with 8 skill points and can invest in all 4 schools."))
+		if("apprentice")
+			// Add 4 skill points (don't overwrite existing points if they were a student)
+			skill_points += 4
+			max_schools = 3
+			to_chat(parent, span_nicegreen("As an Apprentice, you gain 4 skill points and can invest in up to 3 schools."))
+		// Students start with 0 skill points and max 2 schools (default)
+
+/// Record a grade received from Maestro judgment (for round end tracking)
+/datum/component/artistic_exp/proc/record_grade(grade)
+	grades_received += grade
+
+	// Also notify the antag datum if present
+	var/mob/living/carbon/human/H = parent
+	if(istype(H) && H.mind)
+		var/datum/antagonist/ring_artist/artist = H.mind.has_antag_datum(/datum/antagonist/ring_artist)
+		if(artist)
+			artist.grades_received += grade

--- a/ModularLobotomy/ring/ring_skills/artistic_exp.dm
+++ b/ModularLobotomy/ring/ring_skills/artistic_exp.dm
@@ -113,6 +113,10 @@
 			exp_gain = 5
 		if("add_body")
 			exp_gain = 3
+		if("arrange_part")
+			exp_gain = 2
+		if("submit_custom")
+			exp_gain = 5
 
 	if(exp_gain > 0)
 		modify_exp(exp_gain)

--- a/ModularLobotomy/ring/ring_skills/corporist_student.dm
+++ b/ModularLobotomy/ring/ring_skills/corporist_student.dm
@@ -24,6 +24,11 @@
 	if(H.mind)
 		H.mind.add_antag_datum(/datum/antagonist/ring_artist/student)
 
+	// Give toolkit if they don't already have one
+	if(!locate(/obj/item/storage/box/corporist_toolkit) in H.contents)
+		var/obj/item/storage/box/corporist_toolkit/toolkit = new(get_turf(H))
+		H.put_in_hands(toolkit)
+
 	to_chat(H, span_nicegreen("You are now a Student of The Ring's artistic schools."))
 
 /datum/component/corporist_student/RegisterWithParent()
@@ -136,7 +141,7 @@
 		to_chat(H, span_warning("You need to be next to a dead creature to sculpt it."))
 		return FALSE
 
-	var/choice = tgui_input_list(H, "What type of artwork will you create?", "Create Artwork", list("Basic Sculpture", "Custom Artwork"))
+	var/choice = tgui_input_list(H, "What type of artwork will you create?", "Create Artwork", list("Basic Sculpture", "Custom Artwork", "Carve Body"))
 	if(!choice)
 		return FALSE
 
@@ -145,6 +150,12 @@
 	if(!do_after(H, 7 SECONDS, corpse))
 		to_chat(H, span_warning("You were interrupted!"))
 		return FALSE
+
+	if(choice == "Carve Body")
+		var/datum/carve_body_editor/editor = new(corpse, H)
+		editor.ui_interact(H)
+		StartCooldown()
+		return TRUE
 
 	if(choice == "Custom Artwork")
 		new /obj/structure/custom_corporist_artwork(get_turf(corpse), H)

--- a/ModularLobotomy/ring/ring_skills/corporist_student.dm
+++ b/ModularLobotomy/ring/ring_skills/corporist_student.dm
@@ -1,1 +1,167 @@
-// Stub - populated by the Ring sub-PR
+// Corporist Student Component
+// Permanent status for players who have proven their artistic dedication
+
+/datum/component/corporist_student
+
+/datum/component/corporist_student/Initialize()
+	. = ..()
+	if(!ishuman(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	var/mob/living/carbon/human/H = parent
+
+	// Mark as Ring artist - incompatible with skill augments
+	ADD_TRAIT(H, TRAIT_RING_ARTIST, "corporist_student")
+
+	// Remove any existing skill augments
+	remove_existing_skill_augments(H)
+
+	// Ensure they have the artistic EXP component
+	if(!H.GetComponent(/datum/component/artistic_exp))
+		H.AddComponent(/datum/component/artistic_exp)
+
+	// Add student antagonist datum for rules/round end tracking
+	if(H.mind)
+		H.mind.add_antag_datum(/datum/antagonist/ring_artist/student)
+
+	to_chat(H, span_nicegreen("You are now a Student of The Ring's artistic schools."))
+
+/datum/component/corporist_student/RegisterWithParent()
+	. = ..()
+	var/mob/living/carbon/human/H = parent
+
+	RegisterSignal(parent, COMSIG_NURSEFATHER_RECRUITMENT_OVERRIDE, PROC_REF(on_nursefather_override))
+
+	// Register for organ insertions to block skill augment organs
+	RegisterSignal(parent, COMSIG_CARBON_GAIN_ORGAN, PROC_REF(on_organ_gained))
+
+	// Register for examine to show student status
+	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))
+
+	// Grant artwork creation action
+	var/datum/action/cooldown/create_artwork_student/create_action = new(H)
+	create_action.Grant(H)
+
+	// Grant describe artwork action
+	var/datum/action/cooldown/describe_artwork/describe_action = new(H)
+	describe_action.Grant(H)
+
+	// Grant skill tree action
+	var/datum/action/innate/ring_skill_tree/tree_action = new(H)
+	tree_action.Grant(H)
+
+/datum/component/corporist_student/UnregisterFromParent()
+	var/mob/living/carbon/human/H = parent
+
+	// Remove Ring artist trait
+	REMOVE_TRAIT(H, TRAIT_RING_ARTIST, "corporist_student")
+
+	// Unregister signals
+	UnregisterSignal(parent, COMSIG_NURSEFATHER_RECRUITMENT_OVERRIDE)
+	UnregisterSignal(parent, COMSIG_CARBON_GAIN_ORGAN)
+	UnregisterSignal(parent, COMSIG_PARENT_EXAMINE)
+
+	// Remove actions
+	for(var/datum/action/cooldown/create_artwork_student/action in H.actions)
+		action.Remove(H)
+	for(var/datum/action/cooldown/describe_artwork/action in H.actions)
+		action.Remove(H)
+	for(var/datum/action/innate/ring_skill_tree/action in H.actions)
+		action.Remove(H)
+
+	return ..()
+
+/// Show student status when examined
+/datum/component/corporist_student/proc/on_examine(datum/source, mob/examiner, list/examine_list)
+	SIGNAL_HANDLER
+
+	var/mob/living/carbon/human/H = parent
+	// Just show "Student of The Ring" - the school is shown by artistic_exp component
+	examine_list += span_notice("[H.p_they(TRUE)] [H.p_are()] a Student of The Ring.")
+
+/// Removes any existing skill augments from the target
+/datum/component/corporist_student/proc/remove_existing_skill_augments(mob/living/carbon/human/H)
+	// Remove implanted skill modification organ
+	var/obj/item/organ/cyberimp/chest/body_modification/organ = H.getorganslot(ORGAN_SLOT_HEART_AID)
+	if(organ && istype(organ))
+		organ.Remove(H)
+		qdel(organ)
+		to_chat(H, span_warning("Your skill modification is incompatible with Ring artistry and has been removed!"))
+
+	// Remove injectable skill modifications
+	for(var/obj/item/body_modification_injectable/inj in H.contents)
+		if(inj.used)
+			inj.forceMove(get_turf(H))
+			inj.used = FALSE
+			to_chat(H, span_warning("Your injectable skill modification is incompatible with Ring artistry and has been ejected!"))
+
+/// Signal handler for organ insertions - rejects skill augment organs
+/datum/component/corporist_student/proc/on_organ_gained(datum/source, obj/item/organ/O)
+	SIGNAL_HANDLER
+
+	if(istype(O, /obj/item/organ/cyberimp/chest/body_modification))
+		addtimer(CALLBACK(src, PROC_REF(reject_skill_organ), O, parent), 1)
+
+/// Removes a skill augment organ after insertion completes
+/datum/component/corporist_student/proc/reject_skill_organ(obj/item/organ/O, mob/living/carbon/human/H)
+	if(QDELETED(O) || QDELETED(H))
+		return
+	O.Remove(H)
+	O.forceMove(get_turf(H))
+	to_chat(H, span_warning("The skill modification is rejected by your body! Ring artists cannot use skill augments."))
+
+// Student's artwork creation action (faster than Inspired, no time limit)
+/datum/action/cooldown/create_artwork_student
+	name = "Create Artwork"
+	desc = "Sculpt a corpse into artwork using your artistic training."
+	icon_icon = 'icons/mob/actions/actions_spells.dmi'
+	button_icon_state = "statue"
+	cooldown_time = 15 SECONDS
+	check_flags = AB_CHECK_HANDS_BLOCKED | AB_CHECK_CONSCIOUS
+
+/datum/action/cooldown/create_artwork_student/Trigger(trigger_flags)
+	. = ..()
+	if(!.)
+		return FALSE
+	var/mob/living/carbon/human/H = owner
+
+	// Find a dead simple_animal nearby
+	var/mob/living/simple_animal/corpse = null
+	for(var/mob/living/simple_animal/SA in range(1, H))
+		if(SA.stat == DEAD)
+			corpse = SA
+			break
+
+	if(!corpse)
+		to_chat(H, span_warning("You need to be next to a dead creature to sculpt it."))
+		return FALSE
+
+	to_chat(H, span_notice("You begin sculpting [corpse] into artwork..."))
+
+	if(!do_after(H, 7 SECONDS, corpse)) // Faster than inspired
+		to_chat(H, span_warning("You were interrupted!"))
+		return FALSE
+
+	// Create the artwork
+	var/obj/structure/corporist_artwork/artwork = new(get_turf(corpse), H)
+
+	// Track the simple creature used (not as bodyparts)
+	artwork.simple_creatures_used[corpse.name] = 1
+
+	to_chat(H, span_nicegreen("You create a crude sculpture from [corpse]'s remains."))
+	playsound(H, 'sound/effects/splat.ogg', 50, TRUE)
+
+	// Gib the corpse
+	corpse.gib()
+
+	// Add EXP
+	var/datum/component/artistic_exp/exp_comp = H.GetComponent(/datum/component/artistic_exp)
+	if(exp_comp)
+		exp_comp.add_activity_exp("create_artwork")
+
+	StartCooldown()
+	return TRUE
+
+/datum/component/corporist_student/proc/on_nursefather_override(datum/source, mob/living/recruiter, obj/item/apprentice_recruitment/scroll)
+	SIGNAL_HANDLER
+	qdel(src)

--- a/ModularLobotomy/ring/ring_skills/corporist_student.dm
+++ b/ModularLobotomy/ring/ring_skills/corporist_student.dm
@@ -136,25 +136,27 @@
 		to_chat(H, span_warning("You need to be next to a dead creature to sculpt it."))
 		return FALSE
 
+	var/choice = tgui_input_list(H, "What type of artwork will you create?", "Create Artwork", list("Basic Sculpture", "Custom Artwork"))
+	if(!choice)
+		return FALSE
+
 	to_chat(H, span_notice("You begin sculpting [corpse] into artwork..."))
 
-	if(!do_after(H, 7 SECONDS, corpse)) // Faster than inspired
+	if(!do_after(H, 7 SECONDS, corpse))
 		to_chat(H, span_warning("You were interrupted!"))
 		return FALSE
 
-	// Create the artwork
-	var/obj/structure/corporist_artwork/artwork = new(get_turf(corpse), H)
+	if(choice == "Custom Artwork")
+		new /obj/structure/custom_corporist_artwork(get_turf(corpse), H)
+		to_chat(H, span_nicegreen("You create a custom artwork pedestal from [corpse]'s remains."))
+	else
+		var/obj/structure/corporist_artwork/artwork = new(get_turf(corpse), H)
+		artwork.simple_creatures_used[corpse.name] = 1
+		to_chat(H, span_nicegreen("You create a crude sculpture from [corpse]'s remains."))
 
-	// Track the simple creature used (not as bodyparts)
-	artwork.simple_creatures_used[corpse.name] = 1
-
-	to_chat(H, span_nicegreen("You create a crude sculpture from [corpse]'s remains."))
 	playsound(H, 'sound/effects/splat.ogg', 50, TRUE)
-
-	// Gib the corpse
 	corpse.gib()
 
-	// Add EXP
 	var/datum/component/artistic_exp/exp_comp = H.GetComponent(/datum/component/artistic_exp)
 	if(exp_comp)
 		exp_comp.add_activity_exp("create_artwork")

--- a/ModularLobotomy/ring/ring_skills/inspired_artist.dm
+++ b/ModularLobotomy/ring/ring_skills/inspired_artist.dm
@@ -1,1 +1,148 @@
-// Stub - populated by the Ring sub-PR
+// Inspired Artist Component
+// Temporary status granted by watching a Maestro's demonstration
+
+/datum/component/inspired_artist
+	/// How long the inspiration lasts (in deciseconds)
+	var/duration = 10 MINUTES
+	/// Timer ID for expiration
+	var/timerid
+	/// Artistic progress toward becoming a Student
+	var/artistic_progress = 0
+	/// Progress needed to become a Student
+	var/progress_threshold = 4
+
+/datum/component/inspired_artist/Initialize(duration_override)
+	. = ..()
+	if(!ishuman(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	if(duration_override)
+		duration = duration_override
+
+	// Start the expiration timer
+	timerid = addtimer(CALLBACK(src, PROC_REF(expire)), duration, TIMER_STOPPABLE)
+
+	to_chat(parent, span_nicegreen("You feel inspired by the artistic demonstration! You can now create basic artwork."))
+	to_chat(parent, span_notice("This inspiration will last for [duration / (1 MINUTES)] minutes. Create art to become a permanent Student!"))
+
+/datum/component/inspired_artist/Destroy()
+	if(timerid)
+		deltimer(timerid)
+	return ..()
+
+/datum/component/inspired_artist/RegisterWithParent()
+	. = ..()
+	var/mob/living/carbon/human/H = parent
+
+	RegisterSignal(parent, COMSIG_NURSEFATHER_RECRUITMENT_OVERRIDE, PROC_REF(on_nursefather_override))
+
+	// Grant the create artwork action
+	var/datum/action/cooldown/create_basic_artwork/action = new(H)
+	action.Grant(H)
+
+	// Grant describe artwork action
+	var/datum/action/cooldown/describe_artwork/describe_action = new(H)
+	describe_action.Grant(H)
+
+/datum/component/inspired_artist/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_NURSEFATHER_RECRUITMENT_OVERRIDE)
+	var/mob/living/carbon/human/H = parent
+
+	// Remove the create artwork action
+	for(var/datum/action/cooldown/create_basic_artwork/action in H.actions)
+		action.Remove(H)
+
+	// Remove describe artwork action
+	for(var/datum/action/cooldown/describe_artwork/action in H.actions)
+		action.Remove(H)
+
+	return ..()
+
+/// Called when inspiration expires
+/datum/component/inspired_artist/proc/expire()
+	to_chat(parent, span_warning("Your artistic inspiration fades..."))
+	qdel(src)
+
+/// Add artistic progress
+/datum/component/inspired_artist/proc/add_progress(amount = 1)
+	artistic_progress += amount
+	to_chat(parent, span_notice("Artistic progress: [artistic_progress]/[progress_threshold]"))
+
+	if(artistic_progress >= progress_threshold)
+		become_student()
+
+/// Convert to permanent Student status
+/datum/component/inspired_artist/proc/become_student()
+	var/mob/living/carbon/human/H = parent
+	to_chat(H, span_greentext("Your dedication to art has paid off! You are now a Student of The Ring!"))
+
+	// Remove inspiration and add student component
+	H.AddComponent(/datum/component/corporist_student)
+
+	// Transfer any EXP component or create one
+	var/datum/component/artistic_exp/exp_comp = H.GetComponent(/datum/component/artistic_exp)
+	if(!exp_comp)
+		exp_comp = H.AddComponent(/datum/component/artistic_exp)
+
+	qdel(src)
+
+// Action for inspired players to create basic artwork
+/datum/action/cooldown/create_basic_artwork
+	name = "Create Basic Artwork"
+	desc = "Use your inspiration to sculpt a corpse into basic artwork."
+	icon_icon = 'icons/mob/actions/actions_spells.dmi'
+	button_icon_state = "statue"
+	cooldown_time = 15 SECONDS
+	check_flags = AB_CHECK_HANDS_BLOCKED | AB_CHECK_CONSCIOUS
+
+/datum/action/cooldown/create_basic_artwork/Trigger(trigger_flags)
+	. = ..()
+	if(!.)
+		return FALSE
+	var/mob/living/carbon/human/H = owner
+
+	// Find a dead simple_animal nearby
+	var/mob/living/simple_animal/corpse = null
+	for(var/mob/living/simple_animal/SA in range(1, H))
+		if(SA.stat == DEAD)
+			corpse = SA
+			break
+
+	if(!corpse)
+		to_chat(H, span_warning("You need to be next to a dead creature to sculpt it."))
+		return FALSE
+
+	to_chat(H, span_notice("You begin sculpting [corpse] into artwork..."))
+
+	if(!do_after(H, 8 SECONDS, corpse))
+		to_chat(H, span_warning("You were interrupted!"))
+		return FALSE
+
+	// Create the artwork
+	var/obj/structure/corporist_artwork/artwork = new(get_turf(corpse), H)
+
+	// Track the simple creature used (not as bodyparts)
+	artwork.simple_creatures_used[corpse.name] = 1
+
+	to_chat(H, span_nicegreen("You create a crude sculpture from [corpse]'s remains."))
+	playsound(H, 'sound/effects/splat.ogg', 50, TRUE)
+
+	// Gib the corpse
+	corpse.gib()
+
+	// Add artistic progress
+	var/datum/component/inspired_artist/inspiration = H.GetComponent(/datum/component/inspired_artist)
+	if(inspiration)
+		inspiration.add_progress(1)
+
+	// Add EXP if they have the component
+	var/datum/component/artistic_exp/exp_comp = H.GetComponent(/datum/component/artistic_exp)
+	if(exp_comp)
+		exp_comp.add_activity_exp("create_artwork")
+
+	StartCooldown()
+	return TRUE
+
+/datum/component/inspired_artist/proc/on_nursefather_override(datum/source, mob/living/recruiter, obj/item/apprentice_recruitment/scroll)
+	SIGNAL_HANDLER
+	qdel(src)

--- a/ModularLobotomy/ring/ring_skills/inspired_artist.dm
+++ b/ModularLobotomy/ring/ring_skills/inspired_artist.dm
@@ -84,6 +84,10 @@
 	if(!exp_comp)
 		exp_comp = H.AddComponent(/datum/component/artistic_exp)
 
+	// Give toolkit
+	var/obj/item/storage/box/corporist_toolkit/toolkit = new(get_turf(H))
+	H.put_in_hands(toolkit)
+
 	qdel(src)
 
 // Action for inspired players to create basic artwork

--- a/ModularLobotomy/ring/ring_skills/inspired_artist.dm
+++ b/ModularLobotomy/ring/ring_skills/inspired_artist.dm
@@ -9,7 +9,7 @@
 	/// Artistic progress toward becoming a Student
 	var/artistic_progress = 0
 	/// Progress needed to become a Student
-	var/progress_threshold = 4
+	var/progress_threshold = 1
 
 /datum/component/inspired_artist/Initialize(duration_override)
 	. = ..()
@@ -101,7 +101,6 @@
 		return FALSE
 	var/mob/living/carbon/human/H = owner
 
-	// Find a dead simple_animal nearby
 	var/mob/living/simple_animal/corpse = null
 	for(var/mob/living/simple_animal/SA in range(1, H))
 		if(SA.stat == DEAD)
@@ -112,30 +111,31 @@
 		to_chat(H, span_warning("You need to be next to a dead creature to sculpt it."))
 		return FALSE
 
+	var/choice = tgui_input_list(H, "What type of artwork will you create?", "Create Artwork", list("Basic Sculpture", "Custom Artwork"))
+	if(!choice)
+		return FALSE
+
 	to_chat(H, span_notice("You begin sculpting [corpse] into artwork..."))
 
 	if(!do_after(H, 8 SECONDS, corpse))
 		to_chat(H, span_warning("You were interrupted!"))
 		return FALSE
 
-	// Create the artwork
-	var/obj/structure/corporist_artwork/artwork = new(get_turf(corpse), H)
+	if(choice == "Custom Artwork")
+		new /obj/structure/custom_corporist_artwork(get_turf(corpse), H)
+		to_chat(H, span_nicegreen("You create a custom artwork pedestal from [corpse]'s remains."))
+	else
+		var/obj/structure/corporist_artwork/artwork = new(get_turf(corpse), H)
+		artwork.simple_creatures_used[corpse.name] = 1
+		to_chat(H, span_nicegreen("You create a crude sculpture from [corpse]'s remains."))
 
-	// Track the simple creature used (not as bodyparts)
-	artwork.simple_creatures_used[corpse.name] = 1
-
-	to_chat(H, span_nicegreen("You create a crude sculpture from [corpse]'s remains."))
 	playsound(H, 'sound/effects/splat.ogg', 50, TRUE)
-
-	// Gib the corpse
 	corpse.gib()
 
-	// Add artistic progress
 	var/datum/component/inspired_artist/inspiration = H.GetComponent(/datum/component/inspired_artist)
 	if(inspiration)
 		inspiration.add_progress(1)
 
-	// Add EXP if they have the component
 	var/datum/component/artistic_exp/exp_comp = H.GetComponent(/datum/component/artistic_exp)
 	if(exp_comp)
 		exp_comp.add_activity_exp("create_artwork")

--- a/ModularLobotomy/ring/ring_skills/inspired_artist.dm
+++ b/ModularLobotomy/ring/ring_skills/inspired_artist.dm
@@ -52,9 +52,10 @@
 	for(var/datum/action/cooldown/create_basic_artwork/action in H.actions)
 		action.Remove(H)
 
-	// Remove describe artwork action
-	for(var/datum/action/cooldown/describe_artwork/action in H.actions)
-		action.Remove(H)
+	// Only remove describe artwork if they haven't become a Student (Student grants its own)
+	if(!H.GetComponent(/datum/component/corporist_student))
+		for(var/datum/action/cooldown/describe_artwork/action in H.actions)
+			action.Remove(H)
 
 	return ..()
 

--- a/ModularLobotomy/ring/ring_skills/ring_skill_tree.dm
+++ b/ModularLobotomy/ring/ring_skills/ring_skill_tree.dm
@@ -1,1 +1,391 @@
-// Stub - populated by the Ring sub-PR
+// Ring Skill Tree Datum
+// Handles the TGUI interface for the skill tree
+
+/datum/ring_skill_tree
+	/// The mob viewing the skill tree
+	var/mob/living/carbon/human/viewer
+
+/datum/ring_skill_tree/New(mob/living/carbon/human/user)
+	viewer = user
+
+/datum/ring_skill_tree/Destroy()
+	viewer = null
+	return ..()
+
+/datum/ring_skill_tree/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "RingSkillTree")
+		ui.open()
+
+/datum/ring_skill_tree/ui_state(mob/user)
+	return GLOB.conscious_state
+
+/datum/ring_skill_tree/ui_data(mob/user)
+	var/list/data = list()
+
+	var/datum/component/artistic_exp/exp_comp = viewer.GetComponent(/datum/component/artistic_exp)
+	if(!exp_comp)
+		return data
+
+	data["exp"] = exp_comp.exp
+	data["next_threshold"] = exp_comp.get_next_threshold()
+	data["skill_points"] = exp_comp.skill_points
+	data["skill_points_spent"] = exp_comp.skill_points_spent
+	data["schools_invested"] = exp_comp.schools_invested
+	data["main_school"] = exp_comp.main_school
+	data["max_schools"] = exp_comp.max_schools
+
+	// Build skill data for each school
+	data["schools"] = list()
+
+	// Fauvists
+	data["schools"] += list(list(
+		"name" = "Fauvists",
+		"id" = "fauvist",
+		"desc" = "Those who use primary colors and complex lines. Known to wear animal masks.",
+		"theme" = "Predatory aggression, WHITE/SP damage focus.",
+		"tiers" = get_school_tiers("fauvist", exp_comp)
+	))
+
+	// Pointillists
+	data["schools"] += list(list(
+		"name" = "Pointillists",
+		"id" = "pointillist",
+		"desc" = "Those who use small strokes and dots to depict light. Known to wield paintbrush weapons.",
+		"theme" = "Random status effect application, SP recovery, scaling power.",
+		"tiers" = get_school_tiers("pointillist", exp_comp)
+	))
+
+	// Cubists
+	data["schools"] += list(list(
+		"name" = "Cubists",
+		"id" = "cubist",
+		"desc" = "Those who incorporate abstract three-dimensionality and depth.",
+		"theme" = "Area control, spatial manipulation.",
+		"tiers" = get_school_tiers("cubist", exp_comp)
+	))
+
+	// Corporists
+	data["schools"] += list(list(
+		"name" = "Corporists",
+		"id" = "corporist",
+		"desc" = "Those who utilize human bones and muscles, contraction and elongation.",
+		"theme" = "Duality of pain and power. Inflict negative effects while gaining positive effects for Artistic Synergy bonuses.",
+		"tiers" = get_school_tiers("corporist", exp_comp)
+	))
+
+	return data
+
+/datum/ring_skill_tree/proc/get_school_tiers(school_id, datum/component/artistic_exp/exp_comp)
+	var/list/tiers = list()
+	var/list/skill_defs = GLOB.ring_skill_definitions[school_id]
+
+	if(!skill_defs)
+		return tiers
+
+	for(var/tier_num in 1 to 3)
+		var/list/tier_data = list(
+			"tier" = tier_num,
+			"cost" = tier_num,
+			"choices" = list()
+		)
+
+		// Check if previous tier is completed
+		var/previous_completed = (tier_num == 1) || has_tier_completed(school_id, tier_num - 1)
+		var/can_afford = exp_comp.skill_points >= tier_num
+		var/can_invest = exp_comp.can_invest_in_school(school_id)
+
+		// Get the two choices for this tier
+		var/list/tier_skills = skill_defs["tier[tier_num]"]
+		if(tier_skills)
+			for(var/choice in list("a", "b"))
+				var/list/skill_info = tier_skills[choice]
+				if(!skill_info)
+					continue
+
+				var/skill_type = skill_info["type"]
+				var/is_selected = has_skill(skill_type)
+				var/other_choice = (choice == "a") ? "b" : "a"
+				var/other_selected = has_skill(tier_skills[other_choice]["type"])
+
+				tier_data["choices"] += list(list(
+					"id" = choice,
+					"name" = skill_info["name"],
+					"desc" = skill_info["desc"],
+					"type" = "[skill_type]",
+					"selected" = is_selected,
+					"excluded" = other_selected,
+					"available" = (previous_completed && can_afford && can_invest && !is_selected && !other_selected),
+					"locked" = !previous_completed
+				))
+
+		tiers += list(tier_data)
+
+	return tiers
+
+/datum/ring_skill_tree/proc/has_tier_completed(school_id, tier_num)
+	var/list/skill_defs = GLOB.ring_skill_definitions[school_id]
+	if(!skill_defs)
+		return FALSE
+
+	var/list/tier_skills = skill_defs["tier[tier_num]"]
+	if(!tier_skills)
+		return FALSE
+
+	// Check if either choice is selected
+	for(var/choice in list("a", "b"))
+		var/list/skill_info = tier_skills[choice]
+		if(skill_info && has_skill(skill_info["type"]))
+			return TRUE
+
+	return FALSE
+
+/datum/ring_skill_tree/proc/has_skill(skill_type)
+	var/datum/component/ring_skill/skill = locate(skill_type) in viewer.GetComponents(/datum/component/ring_skill)
+	return !!skill
+
+/datum/ring_skill_tree/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	if(.)
+		return
+
+	switch(action)
+		if("select_skill")
+			var/skill_type = text2path(params["skill_type"])
+			var/school_id = params["school"]
+			var/tier = text2num(params["tier"])
+
+			if(!skill_type)
+				return FALSE
+
+			var/datum/component/artistic_exp/exp_comp = viewer.GetComponent(/datum/component/artistic_exp)
+			if(!exp_comp)
+				return FALSE
+
+			// Validate
+			if(exp_comp.skill_points < tier)
+				to_chat(viewer, span_warning("You don't have enough skill points!"))
+				return FALSE
+
+			if(!exp_comp.can_invest_in_school(school_id))
+				to_chat(viewer, span_warning("You can only invest in 2 schools maximum!"))
+				return FALSE
+
+			// Spend points and add skill
+			if(!exp_comp.spend_skill_point(tier))
+				return FALSE
+
+			exp_comp.invest_in_school(school_id)
+
+			// Add the skill component
+			viewer.AddComponent(skill_type)
+
+			to_chat(viewer, span_nicegreen("You have learned a new skill!"))
+			playsound(viewer, 'sound/machines/chime.ogg', 50, TRUE)
+
+			return TRUE
+
+		if("set_main_school")
+			var/school_id = params["school"]
+			if(!school_id)
+				return FALSE
+
+			var/datum/component/artistic_exp/exp_comp = viewer.GetComponent(/datum/component/artistic_exp)
+			if(!exp_comp)
+				return FALSE
+
+			// Must have invested in this school to set it as main
+			if(!(school_id in exp_comp.schools_invested))
+				to_chat(viewer, span_warning("You must invest in a school before you can claim it as your main school!"))
+				return FALSE
+
+			exp_comp.main_school = school_id
+
+			var/school_name = get_school_display_name(school_id)
+			to_chat(viewer, span_nicegreen("You now identify as a student of the [school_name] school."))
+
+			return TRUE
+
+	return FALSE
+
+/// Convert school ID to display name
+/datum/ring_skill_tree/proc/get_school_display_name(school_id)
+	switch(school_id)
+		if("fauvist")
+			return "Fauvist"
+		if("pointillist")
+			return "Pointillist"
+		if("cubist")
+			return "Cubist"
+		if("corporist")
+			return "Corporist"
+	return "Unknown"
+
+// Global skill definitions
+GLOBAL_LIST_INIT(ring_skill_definitions, init_ring_skill_definitions())
+
+/proc/init_ring_skill_definitions()
+	var/list/defs = list()
+
+	// ========== FAUVISTS ==========
+	defs["fauvist"] = list(
+		"tier1" = list(
+			"a" = list(
+				"name" = "Predator's Scent",
+				"desc" = "+15% damage vs bleeding targets",
+				"type" = /datum/component/ring_skill/fauvist/predators_scent
+			),
+			"b" = list(
+				"name" = "Maddening Maw",
+				"desc" = "Attacks on bleeding targets deal 15% of your melee damage as additional WHITE damage",
+				"type" = /datum/component/ring_skill/fauvist/maddening_maw
+			)
+		),
+		"tier2" = list(
+			"a" = list(
+				"name" = "Rending Claws",
+				"desc" = "Attacks apply 2 bleed stacks",
+				"type" = /datum/component/ring_skill/fauvist/rending_claws
+			),
+			"b" = list(
+				"name" = "Savage Instinct",
+				"desc" = "After hitting a bleeding target, gain +15% damage for 4 seconds (refreshes on hit)",
+				"type" = /datum/component/ring_skill/fauvist/savage_instinct
+			)
+		),
+		"tier3" = list(
+			"a" = list(
+				"name" = "Spreading Wounds",
+				"desc" = "When hitting bleeding target, adjacent enemies gain 3 bleed",
+				"type" = /datum/component/ring_skill/fauvist/spreading_wounds
+			),
+			"b" = list(
+				"name" = "Primal Terror",
+				"desc" = "Hitting targets with 10+ bleed deals 20 WHITE damage and removes 5 bleed stacks",
+				"type" = /datum/component/ring_skill/fauvist/primal_terror
+			)
+		)
+	)
+
+	// ========== POINTILLISTS ==========
+	defs["pointillist"] = list(
+		"tier1" = list(
+			"a" = list(
+				"name" = "Hematic Coloring",
+				"desc" = "Attacks apply 3 stacks of a random effect (Bleed, Overheat, Tremor, or Mental Decay). If target already has that effect, deal +10% damage instead.",
+				"type" = /datum/component/ring_skill/pointillist/hematic_coloring
+			),
+			"b" = list(
+				"name" = "Sanguine Pointillism",
+				"desc" = "Attacks apply 1 stack of TWO random effects. Heal 2 SP whenever you apply an effect the target didn't already have.",
+				"type" = /datum/component/ring_skill/pointillist/sanguine_pointillism
+			)
+		),
+		"tier2" = list(
+			"a" = list(
+				"name" = "Assignment Evaluation",
+				"desc" = "Heal 5 SP when hitting targets, +3 SP per status effect on them",
+				"type" = /datum/component/ring_skill/pointillist/assignment_evaluation
+			),
+			"b" = list(
+				"name" = "Beat the Brush",
+				"desc" = "+5% damage per status effect on target (max 20% at 4 effects)",
+				"type" = /datum/component/ring_skill/pointillist/beat_the_brush
+			)
+		),
+		"tier3" = list(
+			"a" = list(
+				"name" = "Paint Over",
+				"desc" = "Random effect application now applies 2x stacks; +10% chance to apply ALL four effects at once",
+				"type" = /datum/component/ring_skill/pointillist/paint_over
+			),
+			"b" = list(
+				"name" = "Practices on Aesthetics",
+				"desc" = "+10% damage and +2 bleed per status effect on target",
+				"type" = /datum/component/ring_skill/pointillist/practices_on_aesthetics
+			)
+		)
+	)
+
+	// ========== CUBISTS ==========
+	defs["cubist"] = list(
+		"tier1" = list(
+			"a" = list(
+				"name" = "Fractured Reflection",
+				"desc" = "Attackers gain 3 bleed when hitting you",
+				"type" = /datum/component/ring_skill/cubist/fractured_reflection
+			),
+			"b" = list(
+				"name" = "Geometric Reach",
+				"desc" = "Your attacks apply 2 bleed to enemies adjacent to your target",
+				"type" = /datum/component/ring_skill/cubist/geometric_reach
+			)
+		),
+		"tier2" = list(
+			"a" = list(
+				"name" = "Abstract Suffering",
+				"desc" = "When enemies within 5 tiles take bleed damage, they also take WHITE damage equal to half the bleed damage",
+				"type" = /datum/component/ring_skill/cubist/abstract_suffering
+			),
+			"b" = list(
+				"name" = "Warped Space",
+				"desc" = "Hitting targets with 8+ bleed stacks inflicts 20% slowdown for 3 seconds",
+				"type" = /datum/component/ring_skill/cubist/warped_space
+			)
+		),
+		"tier3" = list(
+			"a" = list(
+				"name" = "Spatial Anchor",
+				"desc" = "Enemies within 4 tiles of you cannot have their bleed reduced below 5 stacks",
+				"type" = /datum/component/ring_skill/cubist/spatial_anchor
+			),
+			"b" = list(
+				"name" = "Crimson Dimension",
+				"desc" = "Active (60s CD): Create 3x3 zone applying 2 bleed/sec for 10s; you take 20% less damage while inside",
+				"type" = /datum/component/ring_skill/cubist/crimson_dimension
+			)
+		)
+	)
+
+	// ========== CORPORISTS ==========
+	defs["corporist"] = list(
+		"tier1" = list(
+			"a" = list(
+				"name" = "Butcher - Ribs",
+				"desc" = "On Hit: Apply 2 bleed to target and gain 1 Protection. Heal 5% max SP. If at max SP, gain 1 Damage Up instead.",
+				"type" = /datum/component/ring_skill/corporist/butcher_ribs
+			),
+			"b" = list(
+				"name" = "Rotator Crush",
+				"desc" = "On Hit: Apply 2 bleed to target and gain 1 Damage Up. Heal 5% max SP. If at max SP, gain 1 Protection instead.",
+				"type" = /datum/component/ring_skill/corporist/rotator_crush
+			)
+		),
+		"tier2" = list(
+			"a" = list(
+				"name" = "Repressed Flesh",
+				"desc" = "On Hit: If target is bleeding and you have a positive effect, heal 5 HP and apply 2 extra bleed. If target has 10+ bleed, gain 1 extra Protection. (5s cooldown)",
+				"type" = /datum/component/ring_skill/corporist/repressed_flesh
+			),
+			"b" = list(
+				"name" = "Tendon Tear",
+				"desc" = "On Hit: If target is bleeding and you have a positive effect, deal 20 bonus RED damage. If you have 3+ Damage Up, deal additional 15 RED damage.",
+				"type" = /datum/component/ring_skill/corporist/tendon_tear
+			)
+		),
+		"tier3" = list(
+			"a" = list(
+				"name" = "Anatomize",
+				"desc" = "On Hit: If target is bleeding and below 25% HP, and you have both Protection and Damage Up, consume all bleed for 5 RED damage per stack and fully restore SP. (30s CD)",
+				"type" = /datum/component/ring_skill/corporist/anatomize
+			),
+			"b" = list(
+				"name" = "Exhibition Arrangements",
+				"desc" = "Active (30s CD): For 8s, attacks apply 3 bleed + 1 random negative effect AND grant 1 Protection + 1 Damage Up. Heal 5% max SP per hit. On expiry, consume all bleed on last target for 3 dmg/stack.",
+				"type" = /datum/component/ring_skill/corporist/exhibition_arrangements
+			)
+		)
+	)
+
+	return defs

--- a/ModularLobotomy/ring/ring_skills/ring_skill_tree.dm
+++ b/ModularLobotomy/ring/ring_skills/ring_skill_tree.dm
@@ -228,7 +228,7 @@ GLOBAL_LIST_INIT(ring_skill_definitions, init_ring_skill_definitions())
 /proc/init_ring_skill_definitions()
 	var/list/defs = list()
 
-	// ========== FAUVISTS ==========
+	// FAUVISTS
 	defs["fauvist"] = list(
 		"tier1" = list(
 			"a" = list(
@@ -268,7 +268,7 @@ GLOBAL_LIST_INIT(ring_skill_definitions, init_ring_skill_definitions())
 		)
 	)
 
-	// ========== POINTILLISTS ==========
+	// POINTILLISTS
 	defs["pointillist"] = list(
 		"tier1" = list(
 			"a" = list(
@@ -308,7 +308,7 @@ GLOBAL_LIST_INIT(ring_skill_definitions, init_ring_skill_definitions())
 		)
 	)
 
-	// ========== CUBISTS ==========
+	// CUBISTS
 	defs["cubist"] = list(
 		"tier1" = list(
 			"a" = list(
@@ -348,7 +348,7 @@ GLOBAL_LIST_INIT(ring_skill_definitions, init_ring_skill_definitions())
 		)
 	)
 
-	// ========== CORPORISTS ==========
+	// CORPORISTS
 	defs["corporist"] = list(
 		"tier1" = list(
 			"a" = list(

--- a/ModularLobotomy/ring/ring_skills/schools/_schools.dm
+++ b/ModularLobotomy/ring/ring_skills/schools/_schools.dm
@@ -1,1 +1,168 @@
-// Stub - populated by the Ring sub-PR
+// Base Ring Skill Component
+// All ring skills inherit from this
+
+/datum/component/ring_skill
+	/// Name of the skill
+	var/skill_name = "Base Skill"
+	/// Description of the skill
+	var/skill_desc = "A ring skill."
+	/// Which school this skill belongs to
+	var/school = "corporist"
+	/// Which tier (1-3)
+	var/tier = 1
+	/// Which choice (a or b)
+	var/choice = "a"
+
+	/// Reference to the human parent
+	var/mob/living/carbon/human/human_parent
+	/// Bleed stacks to apply to target after damage resolves (applied in on_post_attack)
+	var/pending_bleed = 0
+	/// Shared SP heal cooldown - keyed by mob ref, shared across all ring skills on the same mob
+	var/static/list/sp_heal_cooldowns = list()
+
+/datum/component/ring_skill/Initialize()
+	. = ..()
+	if(!ishuman(parent))
+		return COMPONENT_INCOMPATIBLE
+	human_parent = parent
+
+/datum/component/ring_skill/RegisterWithParent()
+	. = ..()
+	RegisterSignal(parent, COMSIG_NURSEFATHER_RECRUITMENT_OVERRIDE, PROC_REF(on_nursefather_override))
+	// Common signals that most skills will use
+	RegisterSignal(parent, COMSIG_MOB_ITEM_ATTACK, PROC_REF(on_attack))
+	RegisterSignal(parent, COMSIG_MOB_ITEM_AFTERATTACK, PROC_REF(on_post_attack))
+	RegisterSignal(parent, COMSIG_MOB_APPLY_DAMGE, PROC_REF(on_take_damage))
+	RegisterSignal(parent, COMSIG_MOB_AFTER_APPLY_DAMGE, PROC_REF(on_after_take_damage))
+
+/datum/component/ring_skill/UnregisterFromParent()
+	UnregisterSignal(parent, list(
+		COMSIG_NURSEFATHER_RECRUITMENT_OVERRIDE,
+		COMSIG_MOB_ITEM_ATTACK,
+		COMSIG_MOB_ITEM_AFTERATTACK,
+		COMSIG_MOB_APPLY_DAMGE,
+		COMSIG_MOB_AFTER_APPLY_DAMGE
+	))
+	human_parent = null
+	. = ..()
+
+/datum/component/ring_skill/proc/on_nursefather_override(datum/source, mob/living/recruiter, obj/item/apprentice_recruitment/scroll)
+	SIGNAL_HANDLER
+	qdel(src)
+
+/// Called when the parent attacks something with an item
+/datum/component/ring_skill/proc/on_attack(datum/source, mob/living/target, obj/item/weapon)
+	SIGNAL_HANDLER
+	return
+
+/// Called after the parent's attack resolves - applies deferred bleed
+/datum/component/ring_skill/proc/on_post_attack(datum/source, mob/living/target, obj/item/weapon)
+	SIGNAL_HANDLER
+	if(pending_bleed > 0 && isliving(target) && target.stat != DEAD)
+		target.apply_lc_bleed(pending_bleed)
+		pending_bleed = 0
+
+/// Called when the parent is about to take damage
+/datum/component/ring_skill/proc/on_take_damage(datum/source, damage, damagetype, def_zone)
+	SIGNAL_HANDLER
+	return
+
+/// Called after the parent takes damage
+/// Signal args: final_damage, damage_type, def_zone, wound_bonus, bare_wound_bonus, sharpness, attacker, flags, attack_type
+/datum/component/ring_skill/proc/on_after_take_damage(datum/source, damage, damagetype, def_zone, wound_bonus, bare_wound_bonus, sharpness, atom/attacker, flags, attack_type)
+	SIGNAL_HANDLER
+	return
+
+/// Helper to check if user has any positive stacking effect (Protection or Damage Up)
+/datum/component/ring_skill/proc/has_positive_effect(mob/living/user)
+	if(user.has_status_effect(/datum/status_effect/stacking/protection))
+		return TRUE
+	if(user.has_status_effect(/datum/status_effect/stacking/damage_up))
+		return TRUE
+	return FALSE
+
+/// Helper to check if target is bleeding
+/datum/component/ring_skill/proc/target_is_bleeding(mob/living/target)
+	return !!target.has_status_effect(/datum/status_effect/stacking/lc_bleed)
+
+/// Helper to get bleed stacks on target
+/datum/component/ring_skill/proc/get_bleed_stacks(mob/living/target)
+	var/datum/status_effect/stacking/lc_bleed/bleed = target.has_status_effect(/datum/status_effect/stacking/lc_bleed)
+	if(!bleed)
+		return 0
+	return bleed.stacks
+
+/// Helper to count status effects on target
+/datum/component/ring_skill/proc/count_status_effects(mob/living/target)
+	var/count = 0
+	if(target.has_status_effect(/datum/status_effect/stacking/lc_bleed))
+		count++
+	if(target.has_status_effect(/datum/status_effect/stacking/lc_overheat))
+		count++
+	if(target.has_status_effect(/datum/status_effect/stacking/lc_tremor))
+		count++
+	if(target.has_status_effect(/datum/status_effect/stacking/lc_mental_decay))
+		count++
+	return count
+
+/// Helper to apply random status effect (bleed is deferred to on_post_attack)
+/datum/component/ring_skill/proc/apply_random_effect(mob/living/target, stacks = 1)
+	var/effect_type = pick("bleed", "overheat", "tremor", "mental_decay")
+	switch(effect_type)
+		if("bleed")
+			pending_bleed += stacks
+		if("overheat")
+			target.apply_lc_overheat(stacks)
+		if("tremor")
+			target.apply_lc_tremor(stacks, 999)
+		if("mental_decay")
+			target.apply_lc_mental_decay(stacks)
+	return effect_type
+
+/// Ring-specific: Add protection stacks additively, capped at ring_max
+/// Unlike apply_lc_protection which only sets stacks, this actually adds to existing stacks
+/datum/component/ring_skill/proc/add_ring_protection(mob/living/user, stacks_to_add, ring_max = 5)
+	var/datum/status_effect/stacking/protection/P = user.has_status_effect(/datum/status_effect/stacking/protection)
+	if(!P)
+		user.apply_status_effect(/datum/status_effect/stacking/protection, min(stacks_to_add, ring_max))
+		return
+	if(P.stacks >= ring_max)
+		return
+	var/add_amount = min(stacks_to_add, ring_max - P.stacks)
+	P.add_stacks(add_amount)
+
+/// Ring-specific: Add damage up stacks additively, capped at ring_max
+/// Unlike apply_lc_strength which only sets stacks, this actually adds to existing stacks
+/datum/component/ring_skill/proc/add_ring_strength(mob/living/user, stacks_to_add, ring_max = 5)
+	var/datum/status_effect/stacking/damage_up/S = user.has_status_effect(/datum/status_effect/stacking/damage_up)
+	if(!S)
+		user.apply_status_effect(/datum/status_effect/stacking/damage_up, min(stacks_to_add, ring_max))
+		return
+	if(S.stacks >= ring_max)
+		return
+	var/add_amount = min(stacks_to_add, ring_max - S.stacks)
+	S.add_stacks(add_amount)
+
+/// Checks if SP healing is ready for this mob (shared across all ring skills)
+/datum/component/ring_skill/proc/sp_heal_ready()
+	var/ref = REF(human_parent)
+	if(sp_heal_cooldowns[ref] && world.time < sp_heal_cooldowns[ref])
+		return FALSE
+	return TRUE
+
+/// Sets the shared SP heal cooldown for this mob
+/datum/component/ring_skill/proc/set_sp_heal_cooldown(cooldown = 1 SECONDS)
+	sp_heal_cooldowns[REF(human_parent)] = world.time + cooldown
+
+/// Helper to check if target has a specific effect
+/datum/component/ring_skill/proc/has_effect(mob/living/target, effect_type)
+	switch(effect_type)
+		if("bleed")
+			return !!target.has_status_effect(/datum/status_effect/stacking/lc_bleed)
+		if("overheat")
+			return !!target.has_status_effect(/datum/status_effect/stacking/lc_overheat)
+		if("tremor")
+			return !!target.has_status_effect(/datum/status_effect/stacking/lc_tremor)
+		if("mental_decay")
+			return !!target.has_status_effect(/datum/status_effect/stacking/lc_mental_decay)
+	return FALSE

--- a/ModularLobotomy/ring/ring_skills/schools/corporist.dm
+++ b/ModularLobotomy/ring/ring_skills/schools/corporist.dm
@@ -1,1 +1,335 @@
-// Stub - populated by the Ring sub-PR
+// Corporist School Skills
+// Theme: Duality of pain and power. Inflict negative effects on targets while gaining positive effects.
+// When both occur simultaneously, trigger Artistic Synergy bonuses.
+// "Those who utilize the interaction between human bones and muscles, the contraction and elongation thereof."
+
+// ========== TIER 1 ==========
+
+// Butcher - Ribs: On hit, apply 2 bleed to target and gain 1 Protection.
+// Artistic Synergy: Heal 5% max SP. If at max SP, gain 1 Damage Up instead.
+/datum/component/ring_skill/corporist/butcher_ribs
+	skill_name = "Butcher - Ribs"
+	skill_desc = "On Hit: Apply 2 bleed to target and gain 1 Protection. Heal 5% max SP. If at max SP, gain 1 Damage Up instead."
+	school = "corporist"
+	tier = 1
+	choice = "a"
+
+	var/bleed_stacks = 2
+	var/protection_stacks = 1
+	var/sp_heal_percent = 0.05
+	var/next_use = 0
+
+/datum/component/ring_skill/corporist/butcher_ribs/on_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(!isliving(target) || target.stat == DEAD)
+		return
+	if(world.time < next_use)
+		return
+	next_use = world.time + 1 SECONDS
+
+	// Inflict negative effect (deferred to on_post_attack)
+	pending_bleed += bleed_stacks
+
+	// Gain positive effect
+	add_ring_protection(human_parent, protection_stacks)
+
+	// Artistic Synergy: both occurred simultaneously
+	if(!sp_heal_ready())
+		return
+	set_sp_heal_cooldown()
+	if(human_parent.sanityhealth >= human_parent.maxSanity)
+		// At max SP - gain Damage Up instead
+		add_ring_strength(human_parent, 1)
+		to_chat(human_parent, span_nicegreen("Butcher - Ribs: Your artistry empowers you! (+1 Damage Up)"))
+	else
+		var/sp_heal = round(human_parent.maxSanity * sp_heal_percent)
+		human_parent.adjustSanityLoss(-sp_heal)
+		to_chat(human_parent, span_nicegreen("Butcher - Ribs: Your creative vision soothes your mind. (+[sp_heal] SP)"))
+
+// Rotator Crush: On hit, apply 2 bleed to target and gain 1 Damage Up.
+// Artistic Synergy: Heal 5% max SP. If at max SP, gain 1 Protection instead.
+/datum/component/ring_skill/corporist/rotator_crush
+	skill_name = "Rotator Crush"
+	skill_desc = "On Hit: Apply 2 bleed to target and gain 1 Damage Up. Heal 5% max SP. If at max SP, gain 1 Protection instead."
+	school = "corporist"
+	tier = 1
+	choice = "b"
+
+	var/bleed_stacks = 2
+	var/damage_up_stacks = 1
+	var/sp_heal_percent = 0.05
+	var/next_use = 0
+
+/datum/component/ring_skill/corporist/rotator_crush/on_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(!isliving(target) || target.stat == DEAD)
+		return
+	if(world.time < next_use)
+		return
+	next_use = world.time + 1 SECONDS
+
+	// Inflict negative effect (deferred to on_post_attack)
+	pending_bleed += bleed_stacks
+
+	// Gain positive effect
+	add_ring_strength(human_parent, damage_up_stacks)
+
+	// Artistic Synergy: both occurred simultaneously
+	if(!sp_heal_ready())
+		return
+	set_sp_heal_cooldown()
+	if(human_parent.sanityhealth >= human_parent.maxSanity)
+		// At max SP - gain Protection instead
+		add_ring_protection(human_parent, 1)
+		to_chat(human_parent, span_nicegreen("Rotator Crush: Your artistry shields you! (+1 Protection)"))
+	else
+		var/sp_heal = round(human_parent.maxSanity * sp_heal_percent)
+		human_parent.adjustSanityLoss(-sp_heal)
+		to_chat(human_parent, span_nicegreen("Rotator Crush: Your creative tension soothes your mind. (+[sp_heal] SP)"))
+
+// ========== TIER 2 ==========
+
+// Repressed Flesh: When you have a positive effect and hit a bleeding target,
+// heal 5 HP and apply 2 extra bleed. If target has 10+ bleed, also gain 1 extra Protection. (5s CD)
+/datum/component/ring_skill/corporist/repressed_flesh
+	skill_name = "Repressed Flesh"
+	skill_desc = "On Hit: If target is bleeding and you have a positive effect, heal 5 HP and apply 2 extra bleed. If target has 10+ bleed, gain 1 extra Protection. (5s cooldown)"
+	school = "corporist"
+	tier = 2
+	choice = "a"
+
+	var/cooldown_time = 5 SECONDS
+	var/next_use = 0
+	var/heal_amount = 5
+	var/extra_bleed = 2
+	var/bleed_threshold = 10
+
+/datum/component/ring_skill/corporist/repressed_flesh/on_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(!isliving(target) || target.stat == DEAD)
+		return
+
+	if(world.time < next_use)
+		return
+
+	// Check conditions: target must be bleeding, user must have a positive effect
+	if(!target_is_bleeding(target))
+		return
+
+	if(!has_positive_effect(human_parent))
+		return
+
+	// Synergy triggered
+	human_parent.adjustBruteLoss(-heal_amount)
+	pending_bleed += extra_bleed
+	next_use = world.time + cooldown_time
+
+	// Bonus at high bleed
+	if(get_bleed_stacks(target) >= bleed_threshold)
+		add_ring_protection(human_parent, 1)
+		to_chat(human_parent, span_nicegreen("Repressed Flesh: The artwork deepens! (+[heal_amount] HP, +1 Protection)"))
+	else
+		to_chat(human_parent, span_nicegreen("Repressed Flesh: You absorb vitality from your work. (+[heal_amount] HP)"))
+
+// Tendon Tear: When you have a positive effect and hit a bleeding target,
+// deal 20 bonus RED damage. If you have 3+ Damage Up stacks, deal additional 15 RED damage.
+/datum/component/ring_skill/corporist/tendon_tear
+	skill_name = "Tendon Tear"
+	skill_desc = "On Hit: If target is bleeding and you have a positive effect, deal 10 bonus RED damage. If you have 3+ Damage Up, deal additional 15 RED damage."
+	school = "corporist"
+	tier = 2
+	choice = "b"
+
+	var/base_bonus_damage = 10
+	var/extra_bonus_damage = 15
+	var/damage_up_threshold = 3
+
+/datum/component/ring_skill/corporist/tendon_tear/on_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(!isliving(target) || target.stat == DEAD)
+		return
+
+	// Check conditions: target must be bleeding, user must have positive
+	if(!target_is_bleeding(target))
+		return
+
+	if(!has_positive_effect(human_parent))
+		return
+
+	// Base bonus damage
+	var/total_damage = base_bonus_damage
+
+	// Check for enhanced damage from Damage Up stacks
+	var/datum/status_effect/stacking/damage_up/dup = human_parent.has_status_effect(/datum/status_effect/stacking/damage_up)
+	if(dup && dup.stacks >= damage_up_threshold)
+		total_damage += extra_bonus_damage
+		to_chat(human_parent, span_boldwarning("Tendon Tear: Muscles tear apart! ([total_damage] bonus RED damage)"))
+	else
+		to_chat(human_parent, span_nicegreen("Tendon Tear: Bones crack! ([total_damage] bonus RED damage)"))
+
+	target.deal_damage(total_damage, RED_DAMAGE)
+	playsound(target, 'sound/effects/splat.ogg', 40, TRUE)
+
+// ========== TIER 3 ==========
+
+// Anatomize: When you have both Protection and Damage Up and hit a bleeding target
+// below 25% HP, consume all bleed stacks to deal 5 RED damage per stack. Also fully restore SP. (30s CD)
+/datum/component/ring_skill/corporist/anatomize
+	skill_name = "Anatomize"
+	skill_desc = "On Hit: If target is bleeding and below 25% HP, and you have both Protection and Damage Up, consume all bleed to deal 5 RED damage per stack and fully restore SP. (30s CD)"
+	school = "corporist"
+	tier = 3
+	choice = "a"
+
+	var/cooldown_time = 30 SECONDS
+	var/next_use = 0
+	var/damage_per_stack = 5
+	var/hp_threshold = 0.25
+
+/datum/component/ring_skill/corporist/anatomize/on_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(!isliving(target) || target.stat == DEAD)
+		return
+
+	if(world.time < next_use)
+		return
+
+	// Must have both Protection and Damage Up
+	if(!human_parent.has_status_effect(/datum/status_effect/stacking/protection))
+		return
+
+	if(!human_parent.has_status_effect(/datum/status_effect/stacking/damage_up))
+		return
+
+	// Target must be bleeding and below HP threshold
+	var/datum/status_effect/stacking/lc_bleed/bleed = target.has_status_effect(/datum/status_effect/stacking/lc_bleed)
+	if(!bleed || bleed.stacks <= 0)
+		return
+
+	var/hp_percent = target.health / target.maxHealth
+	if(hp_percent > hp_threshold)
+		return
+
+	// Execute!
+	var/stacks = bleed.stacks
+	var/total_damage = stacks * damage_per_stack
+	qdel(bleed)
+
+	target.deal_damage(total_damage, RED_DAMAGE)
+	human_parent.adjustSanityLoss(-human_parent.maxSanity) // Fully restore SP
+	next_use = world.time + cooldown_time
+
+	to_chat(human_parent, span_boldwarning("Anatomize: A transcendent dissection! ([total_damage] RED damage from [stacks] stacks, SP fully restored)"))
+	playsound(target, 'sound/effects/splat.ogg', 70, TRUE)
+
+// Exhibition Arrangements: Active (30s CD) - For 8 seconds, every attack applies 3 bleed + 1 random
+// negative effect AND grants 1 Protection + 1 Damage Up. Guaranteed synergy every hit.
+// Heal 5% max SP per hit (or +2 Damage Up if at max SP). When buff expires, consume all bleed
+// on most recent target for 3 RED damage per stack.
+/datum/component/ring_skill/corporist/exhibition_arrangements
+	skill_name = "Exhibition Arrangements"
+	skill_desc = "Active (30s CD): For 8s, attacks apply 3 bleed + 1 random negative effect AND grant 1 Protection + 1 Damage Up. Heal 5% max SP per hit (at max SP: +2 Damage Up). On expiry, consume all bleed on last target for 3 dmg/stack."
+	school = "corporist"
+	tier = 3
+	choice = "b"
+
+	var/buff_active = FALSE
+	var/buff_duration = 8 SECONDS
+	var/buff_timer_id
+	var/mob/living/last_target
+	var/next_use = 0
+
+/datum/component/ring_skill/corporist/exhibition_arrangements/RegisterWithParent()
+	. = ..()
+	// Grant the activation action
+	var/datum/action/cooldown/exhibition_arrangements_activate/action = new(human_parent)
+	action.skill_ref = WEAKREF(src)
+	action.Grant(human_parent)
+
+/datum/component/ring_skill/corporist/exhibition_arrangements/UnregisterFromParent()
+	for(var/datum/action/cooldown/exhibition_arrangements_activate/action in human_parent.actions)
+		action.Remove(human_parent)
+	if(buff_timer_id)
+		deltimer(buff_timer_id)
+	last_target = null
+	. = ..()
+
+/datum/component/ring_skill/corporist/exhibition_arrangements/proc/activate_buff()
+	buff_active = TRUE
+	last_target = null
+	to_chat(human_parent, span_nicegreen("Exhibition Arrangements: You begin arranging your masterpiece!"))
+	if(buff_timer_id)
+		deltimer(buff_timer_id)
+	buff_timer_id = addtimer(CALLBACK(src, PROC_REF(deactivate_buff)), buff_duration, TIMER_STOPPABLE)
+
+/datum/component/ring_skill/corporist/exhibition_arrangements/proc/deactivate_buff()
+	buff_timer_id = null
+	if(!buff_active)
+		return
+	buff_active = FALSE
+
+	// Consume all bleed on last target
+	if(last_target && !QDELETED(last_target) && last_target.stat != DEAD)
+		var/datum/status_effect/stacking/lc_bleed/bleed = last_target.has_status_effect(/datum/status_effect/stacking/lc_bleed)
+		if(bleed && bleed.stacks > 0)
+			var/stacks = bleed.stacks
+			var/total_damage = stacks * 3
+			qdel(bleed)
+			last_target.deal_damage(total_damage, RED_DAMAGE)
+			to_chat(human_parent, span_boldwarning("Exhibition Arrangements: The exhibition opens! ([total_damage] RED damage from [stacks] stacks)"))
+			playsound(last_target, 'sound/effects/splat.ogg', 60, TRUE)
+		else
+			to_chat(human_parent, span_warning("Exhibition Arrangements: The exhibition closes."))
+	else
+		to_chat(human_parent, span_warning("Exhibition Arrangements: The exhibition closes."))
+
+	last_target = null
+
+/datum/component/ring_skill/corporist/exhibition_arrangements/on_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(!buff_active || !isliving(target) || target.stat == DEAD)
+		return
+	if(world.time < next_use)
+		return
+	next_use = world.time + 1 SECONDS
+
+	last_target = target
+
+	// Apply negative effects (bleed deferred to on_post_attack)
+	pending_bleed += 3
+	var/effect_name = apply_random_effect(target, 1) // 1 stack of random negative effect
+
+	// Gain positive effects
+	add_ring_protection(human_parent, 1)
+	add_ring_strength(human_parent, 1)
+
+	// Synergy bonus
+	if(!sp_heal_ready())
+		return
+	set_sp_heal_cooldown()
+	if(human_parent.sanityhealth >= human_parent.maxSanity)
+		add_ring_strength(human_parent, 2)
+		to_chat(human_parent, span_nicegreen("Exhibition Arrangements: Perfect arrangement! (+3 bleed, +[effect_name], +1 Protection, +3 Damage Up)"))
+	else
+		var/sp_heal = round(human_parent.maxSanity * 0.05)
+		human_parent.adjustSanityLoss(-sp_heal)
+		to_chat(human_parent, span_nicegreen("Exhibition Arrangements: Artistic flow! (+3 bleed, +[effect_name], +1 Protection, +1 Damage Up, +[sp_heal] SP)"))
+
+// Action to activate Exhibition Arrangements
+/datum/action/cooldown/exhibition_arrangements_activate
+	name = "Exhibition Arrangements"
+	desc = "Begin arranging your exhibition - a masterpiece of destruction."
+	icon_icon = 'icons/obj/spider_house/ring/ring_icons.dmi'
+	button_icon_state = "exhibition_arrangements"
+	cooldown_time = 30 SECONDS
+	check_flags = AB_CHECK_CONSCIOUS
+
+	var/datum/weakref/skill_ref
+
+/datum/action/cooldown/exhibition_arrangements_activate/Trigger(trigger_flags)
+	. = ..()
+	if(!.)
+		return FALSE
+	if(owner.stat == DEAD)
+		return FALSE
+	var/datum/component/ring_skill/corporist/exhibition_arrangements/skill = skill_ref?.resolve()
+	if(!skill)
+		return FALSE
+
+	skill.activate_buff()
+	StartCooldown()
+	return TRUE

--- a/ModularLobotomy/ring/ring_skills/schools/corporist.dm
+++ b/ModularLobotomy/ring/ring_skills/schools/corporist.dm
@@ -3,7 +3,7 @@
 // When both occur simultaneously, trigger Artistic Synergy bonuses.
 // "Those who utilize the interaction between human bones and muscles, the contraction and elongation thereof."
 
-// ========== TIER 1 ==========
+// TIER 1
 
 // Butcher - Ribs: On hit, apply 2 bleed to target and gain 1 Protection.
 // Artistic Synergy: Heal 5% max SP. If at max SP, gain 1 Damage Up instead.
@@ -85,7 +85,7 @@
 		human_parent.adjustSanityLoss(-sp_heal)
 		to_chat(human_parent, span_nicegreen("Rotator Crush: Your creative tension soothes your mind. (+[sp_heal] SP)"))
 
-// ========== TIER 2 ==========
+// TIER 2
 
 // Repressed Flesh: When you have a positive effect and hit a bleeding target,
 // heal 5 HP and apply 2 extra bleed. If target has 10+ bleed, also gain 1 extra Protection. (5s CD)
@@ -166,7 +166,7 @@
 	target.deal_damage(total_damage, RED_DAMAGE)
 	playsound(target, 'sound/effects/splat.ogg', 40, TRUE)
 
-// ========== TIER 3 ==========
+// TIER 3
 
 // Anatomize: When you have both Protection and Damage Up and hit a bleeding target
 // below 25% HP, consume all bleed stacks to deal 5 RED damage per stack. Also fully restore SP. (30s CD)

--- a/ModularLobotomy/ring/ring_skills/schools/cubist.dm
+++ b/ModularLobotomy/ring/ring_skills/schools/cubist.dm
@@ -1,1 +1,252 @@
-// Stub - populated by the Ring sub-PR
+// Cubist School Skills
+// Theme: Area control, spatial manipulation. Command the battlefield through bleeding zones.
+
+// ========== TIER 1 ==========
+
+// Fractured Reflection: Attackers gain 3 bleed when hitting you
+/datum/component/ring_skill/cubist/fractured_reflection
+	skill_name = "Fractured Reflection"
+	skill_desc = "Attackers gain 3 bleed when hitting you"
+	school = "cubist"
+	tier = 1
+	choice = "a"
+
+	var/reflect_stacks = 3
+
+/datum/component/ring_skill/cubist/fractured_reflection/on_after_take_damage(datum/source, damage, damagetype, def_zone, wound_bonus, bare_wound_bonus, sharpness, atom/attacker, flags, attack_type)
+	// Apply bleed to the attacker
+	if(!attacker || !isliving(attacker))
+		return
+	if(attacker == human_parent)
+		return
+
+	var/mob/living/L = attacker
+	L.apply_lc_bleed(reflect_stacks)
+
+// Geometric Reach: Your attacks apply 2 bleed to enemies adjacent to your target
+/datum/component/ring_skill/cubist/geometric_reach
+	skill_name = "Geometric Reach"
+	skill_desc = "Your attacks apply 5 bleed to enemies adjacent to your target"
+	school = "cubist"
+	tier = 1
+	choice = "b"
+
+	var/splash_stacks = 5
+	var/next_use = 0
+	/// Whether to apply adjacent bleed in on_post_attack
+	var/do_adjacent_bleed = FALSE
+
+/datum/component/ring_skill/cubist/geometric_reach/on_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(!isliving(target))
+		return
+	if(world.time < next_use)
+		return
+	next_use = world.time + 1 SECONDS
+	do_adjacent_bleed = TRUE
+
+/datum/component/ring_skill/cubist/geometric_reach/on_post_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(do_adjacent_bleed)
+		do_adjacent_bleed = FALSE
+		// Apply bleed to adjacent enemies
+		for(var/mob/living/nearby in range(1, target))
+			if(nearby == target || nearby == human_parent)
+				continue
+			if(nearby.stat == DEAD)
+				continue
+			nearby.apply_lc_bleed(splash_stacks)
+	..()
+
+
+// ========== TIER 2 ==========
+
+// Abstract Suffering: Attacks against bleeding targets deal bonus WHITE damage
+/datum/component/ring_skill/cubist/abstract_suffering
+	skill_name = "Abstract Suffering"
+	skill_desc = "Your attacks against bleeding targets deal bonus WHITE damage equal to their bleed stacks * 2"
+	school = "cubist"
+	tier = 2
+	choice = "a"
+
+/datum/component/ring_skill/cubist/abstract_suffering/on_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(!isliving(target))
+		return
+
+	// Check if target is bleeding
+	var/bleed_stacks = get_bleed_stacks(target)
+	if(bleed_stacks <= 0)
+		return
+
+	// Deal bonus WHITE damage equal to bleed stacks *2
+	target.deal_damage(bleed_stacks * 2, WHITE_DAMAGE)
+
+// Warped Space: Hitting targets with 8+ bleed inflicts slowdown
+/datum/component/ring_skill/cubist/warped_space
+	skill_name = "Warped Space"
+	skill_desc = "Hitting targets with 8+ bleed stacks inflicts 20% slowdown for 3 seconds"
+	school = "cubist"
+	tier = 2
+	choice = "b"
+
+	var/stack_threshold = 8
+	var/slowdown_amount = 0.2
+	var/slowdown_duration = 3 SECONDS
+
+/datum/component/ring_skill/cubist/warped_space/on_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(!isliving(target))
+		return
+
+	var/stacks = get_bleed_stacks(target)
+	if(stacks < stack_threshold)
+		return
+
+	// Apply slowdown
+	target.add_movespeed_modifier(/datum/movespeed_modifier/warped_space)
+	addtimer(CALLBACK(src, PROC_REF(remove_slowdown), target), slowdown_duration)
+	to_chat(human_parent, span_nicegreen("Warped Space: Reality bends around your victim!"))
+
+/datum/component/ring_skill/cubist/warped_space/proc/remove_slowdown(mob/living/target)
+	if(target)
+		target.remove_movespeed_modifier(/datum/movespeed_modifier/warped_space)
+
+/datum/movespeed_modifier/warped_space
+	multiplicative_slowdown = 0.2
+
+// ========== TIER 3 ==========
+
+// Spatial Anchor: Enemies within 6 tiles can't have bleed reduced below 5
+/datum/component/ring_skill/cubist/spatial_anchor
+	skill_name = "Spatial Anchor"
+	skill_desc = "Enemies within 6 tiles of you cannot have their bleed reduced below 5 stacks"
+	school = "cubist"
+	tier = 3
+	choice = "a"
+
+	var/range = 6
+	var/min_stacks = 5
+
+/datum/component/ring_skill/cubist/spatial_anchor/RegisterWithParent()
+	. = ..()
+	// Register for bleed damage signal to enforce minimum when bleed ticks nearby
+	RegisterSignal(parent, COMSIG_STATUS_BLEED_DAMAGE, PROC_REF(on_bleed_damage))
+
+/datum/component/ring_skill/cubist/spatial_anchor/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_STATUS_BLEED_DAMAGE)
+	. = ..()
+
+/datum/component/ring_skill/cubist/spatial_anchor/proc/on_bleed_damage(datum/source, mob/living/bleeder, bleed_stacks)
+	SIGNAL_HANDLER
+
+	// Check if bleeder is within range
+	if(!bleeder || bleeder == human_parent)
+		return
+	if(get_dist(human_parent, bleeder) > range)
+		return
+
+	// Enforce minimum bleed stacks
+	var/datum/status_effect/stacking/lc_bleed/bleed = bleeder.has_status_effect(/datum/status_effect/stacking/lc_bleed)
+	if(bleed && bleed.stacks < min_stacks && bleed.stacks > 0)
+		bleed.stacks = min_stacks
+		to_chat(human_parent, span_notice("Spatial Anchor prevents [bleeder]'s bleed from falling below [min_stacks] stacks."))
+
+// Crimson Dimension: Create bleed zone, damage reduction while inside
+/datum/component/ring_skill/cubist/crimson_dimension
+	skill_name = "Crimson Dimension"
+	skill_desc = "Active (30 CD): Create 3x3 zone applying 2 bleed/sec for 10s; gain Protection while inside (max 5)"
+	school = "cubist"
+	tier = 3
+	choice = "b"
+
+/datum/component/ring_skill/cubist/crimson_dimension/RegisterWithParent()
+	. = ..()
+	// Grant the activation action
+	var/datum/action/cooldown/crimson_dimension_activate/action = new(human_parent)
+	action.skill_ref = WEAKREF(src)
+	action.Grant(human_parent)
+
+/datum/component/ring_skill/cubist/crimson_dimension/UnregisterFromParent()
+	for(var/datum/action/cooldown/crimson_dimension_activate/action in human_parent.actions)
+		action.Remove(human_parent)
+	. = ..()
+
+// Action to activate Crimson Dimension
+/datum/action/cooldown/crimson_dimension_activate
+	name = "Crimson Dimension"
+	desc = "Create a 3x3 bleed zone. Gain Protection while inside."
+	icon_icon = 'icons/obj/spider_house/ring/ring_icons.dmi'
+	button_icon_state = "crimson_dimension"
+	cooldown_time = 30 SECONDS
+	check_flags = AB_CHECK_CONSCIOUS
+
+	var/datum/weakref/skill_ref
+
+/datum/action/cooldown/crimson_dimension_activate/Trigger(trigger_flags)
+	. = ..()
+	if(!.)
+		return FALSE
+	if(owner.stat == DEAD)
+		return FALSE
+	var/mob/living/carbon/human/H = owner
+
+	// Create the zone at the user's location
+	var/turf/center = get_turf(H)
+	new /obj/effect/crimson_dimension_zone(center, H)
+
+	to_chat(H, span_nicegreen("Crimson Dimension: You warp space around you!"))
+	StartCooldown()
+	return TRUE
+
+// The crimson dimension zone effect
+/obj/effect/crimson_dimension_zone
+	name = "crimson dimension"
+	desc = "A warped area of crimson energy."
+	icon = 'icons/effects/cult_effects.dmi'
+	icon_state = "floorglow_looping"
+	anchored = TRUE
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	layer = BELOW_MOB_LAYER
+
+	var/duration = 10 SECONDS
+	var/bleed_per_tick = 2
+	var/protection_per_tick = 1
+	var/max_protection = 5
+	var/mob/living/carbon/human/creator
+	var/list/zone_turfs = list()
+	var/list/zone_effects = list()
+
+/obj/effect/crimson_dimension_zone/Initialize(mapload, mob/living/carbon/human/owner)
+	. = ..()
+	creator = owner
+
+	// Create 3x3 zone
+	var/turf/center = get_turf(src)
+	for(var/turf/T in range(1, center))
+		zone_turfs += T
+		if(T != center)
+			var/obj/effect/crimson_dimension_zone/tile = new(T)
+			zone_effects += tile
+
+	START_PROCESSING(SSobj, src)
+	addtimer(CALLBACK(src, PROC_REF(end_zone)), duration)
+
+/obj/effect/crimson_dimension_zone/process(delta_time)
+	// Apply bleed to enemies in zone
+	for(var/turf/T in zone_turfs)
+		for(var/mob/living/M in T)
+			if(M == creator)
+				continue
+			M.apply_lc_bleed(bleed_per_tick)
+
+	// Grant Protection to creator while inside the zone
+	if(creator && (get_turf(creator) in zone_turfs))
+		var/datum/status_effect/stacking/protection/P = creator.has_status_effect(/datum/status_effect/stacking/protection)
+		if(!P)
+			creator.apply_status_effect(/datum/status_effect/stacking/protection, min(protection_per_tick, max_protection))
+		else if(P.stacks < max_protection)
+			P.add_stacks(min(protection_per_tick, max_protection - P.stacks))
+
+/obj/effect/crimson_dimension_zone/proc/end_zone()
+	STOP_PROCESSING(SSobj, src)
+	for(var/obj/effect/crimson_dimension_zone/tile in zone_effects)
+		qdel(tile)
+	zone_effects = null
+	qdel(src)

--- a/ModularLobotomy/ring/ring_skills/schools/cubist.dm
+++ b/ModularLobotomy/ring/ring_skills/schools/cubist.dm
@@ -1,7 +1,7 @@
 // Cubist School Skills
 // Theme: Area control, spatial manipulation. Command the battlefield through bleeding zones.
 
-// ========== TIER 1 ==========
+// TIER 1
 
 // Fractured Reflection: Attackers gain 3 bleed when hitting you
 /datum/component/ring_skill/cubist/fractured_reflection
@@ -57,7 +57,7 @@
 	..()
 
 
-// ========== TIER 2 ==========
+// TIER 2
 
 // Abstract Suffering: Attacks against bleeding targets deal bonus WHITE damage
 /datum/component/ring_skill/cubist/abstract_suffering
@@ -111,7 +111,7 @@
 /datum/movespeed_modifier/warped_space
 	multiplicative_slowdown = 0.2
 
-// ========== TIER 3 ==========
+// TIER 3
 
 // Spatial Anchor: Enemies within 6 tiles can't have bleed reduced below 5
 /datum/component/ring_skill/cubist/spatial_anchor

--- a/ModularLobotomy/ring/ring_skills/schools/fauvist.dm
+++ b/ModularLobotomy/ring/ring_skills/schools/fauvist.dm
@@ -1,1 +1,182 @@
-// Stub - populated by the Ring sub-PR
+// Fauvist School Skills
+// Theme: Predatory aggression, WHITE/SP damage focus. The beast tears at both body and mind.
+
+// ========== TIER 1 ==========
+
+// Predator's Scent: +15% damage vs bleeding targets
+/datum/component/ring_skill/fauvist/predators_scent
+	skill_name = "Predator's Scent"
+	skill_desc = "+15% damage vs bleeding targets"
+	school = "fauvist"
+	tier = 1
+	choice = "a"
+
+	var/damage_bonus = 15
+	var/active_bonus = 0
+
+/datum/component/ring_skill/fauvist/predators_scent/on_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(!isliving(target))
+		return
+
+	if(target_is_bleeding(target))
+		active_bonus = damage_bonus
+		human_parent.extra_damage += active_bonus
+
+/datum/component/ring_skill/fauvist/predators_scent/on_post_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(active_bonus > 0)
+		human_parent.extra_damage -= active_bonus
+		active_bonus = 0
+	..()
+
+
+// Maddening Maw: Attacks on bleeding targets deal 15% of melee damage as additional WHITE damage
+/datum/component/ring_skill/fauvist/maddening_maw
+	skill_name = "Maddening Maw"
+	skill_desc = "Attacks on bleeding targets deal 15% of your melee damage as additional WHITE damage"
+	school = "fauvist"
+	tier = 1
+	choice = "b"
+
+	var/white_damage_percent = 0.15
+
+/datum/component/ring_skill/fauvist/maddening_maw/on_post_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(isliving(target) && target_is_bleeding(target))
+		// Calculate WHITE damage based on weapon force
+		var/white_damage = round(weapon.force * white_damage_percent)
+		if(white_damage > 0)
+			target.deal_damage(white_damage, WHITE_DAMAGE)
+	..()
+
+
+// ========== TIER 2 ==========
+
+// Rending Claws: Attacks apply 2 bleed stacks
+/datum/component/ring_skill/fauvist/rending_claws
+	skill_name = "Rending Claws"
+	skill_desc = "Attacks apply 2 bleed stacks"
+	school = "fauvist"
+	tier = 2
+	choice = "a"
+
+	var/bleed_stacks = 2
+	var/next_use = 0
+
+/datum/component/ring_skill/fauvist/rending_claws/on_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(!isliving(target))
+		return
+	if(world.time < next_use)
+		return
+	next_use = world.time + 1 SECONDS
+
+	pending_bleed += bleed_stacks
+
+// Savage Instinct: After hitting a bleeding target, gain +15% damage for 4 seconds
+/datum/component/ring_skill/fauvist/savage_instinct
+	skill_name = "Savage Instinct"
+	skill_desc = "After hitting a bleeding target, gain +15% damage for 4 seconds (refreshes on hit)"
+	school = "fauvist"
+	tier = 2
+	choice = "b"
+
+	var/damage_buff = 15
+	var/buff_duration = 4 SECONDS
+	var/buff_active = FALSE
+	var/buff_timer_id
+
+/datum/component/ring_skill/fauvist/savage_instinct/on_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(!isliving(target))
+		return
+
+	if(!target_is_bleeding(target))
+		return
+
+	// Refresh or apply buff
+	if(buff_active)
+		// Refresh timer
+		if(buff_timer_id)
+			deltimer(buff_timer_id)
+	else
+		// Apply buff
+		buff_active = TRUE
+		human_parent.extra_damage += damage_buff
+		to_chat(human_parent, span_nicegreen("Savage Instinct: Your predatory fury intensifies!"))
+
+	buff_timer_id = addtimer(CALLBACK(src, PROC_REF(remove_buff)), buff_duration, TIMER_STOPPABLE)
+
+/datum/component/ring_skill/fauvist/savage_instinct/proc/remove_buff()
+	if(buff_active)
+		buff_active = FALSE
+		human_parent.extra_damage -= damage_buff
+		to_chat(human_parent, span_warning("Savage Instinct fades..."))
+
+/datum/component/ring_skill/fauvist/savage_instinct/UnregisterFromParent()
+	if(buff_timer_id)
+		deltimer(buff_timer_id)
+	if(buff_active)
+		human_parent.extra_damage -= damage_buff
+	. = ..()
+
+// ========== TIER 3 ==========
+
+// Spreading Wounds: When hitting bleeding target, adjacent enemies gain 3 bleed
+/datum/component/ring_skill/fauvist/spreading_wounds
+	skill_name = "Spreading Wounds"
+	skill_desc = "When hitting bleeding target, adjacent enemies gain 3 bleed"
+	school = "fauvist"
+	tier = 3
+	choice = "a"
+
+	var/spread_stacks = 3
+	var/next_use = 0
+	/// Whether to apply spread bleed in on_post_attack
+	var/do_spread_bleed = FALSE
+
+/datum/component/ring_skill/fauvist/spreading_wounds/on_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(!isliving(target))
+		return
+	if(world.time < next_use)
+		return
+
+	if(!target_is_bleeding(target))
+		return
+	next_use = world.time + 1 SECONDS
+	do_spread_bleed = TRUE
+
+/datum/component/ring_skill/fauvist/spreading_wounds/on_post_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(do_spread_bleed)
+		do_spread_bleed = FALSE
+		// Apply bleed to adjacent enemies
+		for(var/mob/living/nearby in range(1, target))
+			if(nearby == target || nearby == human_parent)
+				continue
+			if(nearby.stat == DEAD)
+				continue
+			nearby.apply_lc_bleed(spread_stacks)
+	..()
+
+
+// Primal Terror: Hitting targets with 10+ bleed deals 20 WHITE damage and removes 5 bleed
+/datum/component/ring_skill/fauvist/primal_terror
+	skill_name = "Primal Terror"
+	skill_desc = "Hitting targets with 10+ bleed deals 20 WHITE damage and removes 5 bleed stacks"
+	school = "fauvist"
+	tier = 3
+	choice = "b"
+
+	var/stack_threshold = 10
+	var/white_damage = 20
+	var/stacks_removed = 5
+
+/datum/component/ring_skill/fauvist/primal_terror/on_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(!isliving(target))
+		return
+
+	var/datum/status_effect/stacking/lc_bleed/bleed = target.has_status_effect(/datum/status_effect/stacking/lc_bleed)
+	if(!bleed || bleed.stacks < stack_threshold)
+		return
+
+	// Deal WHITE damage and consume stacks
+	target.deal_damage(white_damage, WHITE_DAMAGE)
+	bleed.stacks -= stacks_removed
+
+	to_chat(human_parent, span_nicegreen("Primal Terror: Your victim's mind shatters! ([white_damage] WHITE damage)"))

--- a/ModularLobotomy/ring/ring_skills/schools/fauvist.dm
+++ b/ModularLobotomy/ring/ring_skills/schools/fauvist.dm
@@ -1,7 +1,7 @@
 // Fauvist School Skills
 // Theme: Predatory aggression, WHITE/SP damage focus. The beast tears at both body and mind.
 
-// ========== TIER 1 ==========
+// TIER 1
 
 // Predator's Scent: +15% damage vs bleeding targets
 /datum/component/ring_skill/fauvist/predators_scent
@@ -48,7 +48,7 @@
 	..()
 
 
-// ========== TIER 2 ==========
+// TIER 2
 
 // Rending Claws: Attacks apply 2 bleed stacks
 /datum/component/ring_skill/fauvist/rending_claws
@@ -116,7 +116,7 @@
 		human_parent.extra_damage -= damage_buff
 	. = ..()
 
-// ========== TIER 3 ==========
+// TIER 3
 
 // Spreading Wounds: When hitting bleeding target, adjacent enemies gain 3 bleed
 /datum/component/ring_skill/fauvist/spreading_wounds

--- a/ModularLobotomy/ring/ring_skills/schools/pointillist.dm
+++ b/ModularLobotomy/ring/ring_skills/schools/pointillist.dm
@@ -1,1 +1,226 @@
-// Stub - populated by the Ring sub-PR
+// Pointillist School Skills
+// Theme: Random status effect application, SP recovery, scaling power.
+
+// ========== TIER 1 ==========
+
+// Hematic Coloring: Apply 3 stacks of random effect. If target has it, +10% damage instead.
+/datum/component/ring_skill/pointillist/hematic_coloring
+	skill_name = "Hematic Coloring"
+	skill_desc = "Attacks apply 3 stacks of a random effect. If target already has that effect, deal +10% damage instead."
+	school = "pointillist"
+	tier = 1
+	choice = "a"
+
+	var/stacks_applied = 3
+	var/damage_bonus = 10
+	var/active_bonus = 0
+	var/next_use = 0
+
+/datum/component/ring_skill/pointillist/hematic_coloring/on_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(!isliving(target))
+		return
+	if(world.time < next_use)
+		return
+	next_use = world.time + 1 SECONDS
+
+	var/effect_type = pick("bleed", "overheat", "tremor", "mental_decay")
+
+	if(has_effect(target, effect_type))
+		// Target already has this effect - bonus damage instead
+		active_bonus = damage_bonus
+		human_parent.extra_damage += active_bonus
+	else
+		// Apply the effect (bleed deferred to on_post_attack)
+		switch(effect_type)
+			if("bleed")
+				pending_bleed += stacks_applied
+			if("overheat")
+				target.apply_lc_overheat(stacks_applied)
+			if("tremor")
+				target.apply_lc_tremor(stacks_applied, 999)
+			if("mental_decay")
+				target.apply_lc_mental_decay(stacks_applied)
+
+/datum/component/ring_skill/pointillist/hematic_coloring/on_post_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(active_bonus > 0)
+		human_parent.extra_damage -= active_bonus
+		active_bonus = 0
+	..()
+
+
+// Sanguine Pointillism: Apply 1 stack of TWO random effects. Heal 2 SP for new effects.
+/datum/component/ring_skill/pointillist/sanguine_pointillism
+	skill_name = "Sanguine Pointillism"
+	skill_desc = "Attacks apply 1 stack of TWO random effects. Heal 2 SP whenever you apply an effect the target didn't already have."
+	school = "pointillist"
+	tier = 1
+	choice = "b"
+
+	var/sp_heal = 2
+	var/next_use = 0
+
+/datum/component/ring_skill/pointillist/sanguine_pointillism/on_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(!isliving(target))
+		return
+	if(world.time < next_use)
+		return
+	next_use = world.time + 1 SECONDS
+
+	var/list/effect_types = list("bleed", "overheat", "tremor", "mental_decay")
+	var/sp_healed = 0
+
+	// Apply two random effects
+	for(var/i in 1 to 2)
+		if(!length(effect_types))
+			break
+
+		var/effect_type = pick_n_take(effect_types)
+		var/was_new = !has_effect(target, effect_type)
+
+		switch(effect_type)
+			if("bleed")
+				pending_bleed += 1
+			if("overheat")
+				target.apply_lc_overheat(1)
+			if("tremor")
+				target.apply_lc_tremor(1, 999)
+			if("mental_decay")
+				target.apply_lc_mental_decay(1)
+
+		if(was_new)
+			sp_healed += sp_heal
+
+	if(sp_healed > 0 && ishuman(human_parent) && sp_heal_ready())
+		set_sp_heal_cooldown()
+		human_parent.adjustSanityLoss(-sp_healed)
+		to_chat(human_parent, span_nicegreen("Sanguine Pointillism: New colors soothe your mind! (+[sp_healed] SP)"))
+
+// ========== TIER 2 ==========
+
+// Assignment Evaluation: Heal 5 SP when hitting targets, +3 SP per status effect on them
+/datum/component/ring_skill/pointillist/assignment_evaluation
+	skill_name = "Assignment Evaluation"
+	skill_desc = "Heal 5 SP when hitting targets, +3 SP per status effect on them"
+	school = "pointillist"
+	tier = 2
+	choice = "a"
+
+	var/base_heal = 5
+	var/bonus_per_effect = 3
+
+/datum/component/ring_skill/pointillist/assignment_evaluation/on_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(!isliving(target))
+		return
+	if(!sp_heal_ready())
+		return
+	set_sp_heal_cooldown()
+
+	var/effect_count = count_status_effects(target)
+	var/total_heal = base_heal + (effect_count * bonus_per_effect)
+
+	human_parent.adjustSanityLoss(-total_heal)
+	if(effect_count > 0)
+		to_chat(human_parent, span_nicegreen("Assignment Evaluation: [effect_count] effects evaluated! (+[total_heal] SP)"))
+
+// Beat the Brush: +5% damage per status effect on target (max 20%)
+/datum/component/ring_skill/pointillist/beat_the_brush
+	skill_name = "Beat the Brush"
+	skill_desc = "+5% damage per status effect on target (max 20% at 4 effects)"
+	school = "pointillist"
+	tier = 2
+	choice = "b"
+
+	var/damage_per_effect = 5
+	var/max_bonus = 20
+	var/active_bonus = 0
+
+/datum/component/ring_skill/pointillist/beat_the_brush/on_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(!isliving(target))
+		return
+
+	var/effect_count = count_status_effects(target)
+	if(effect_count > 0)
+		active_bonus = min(effect_count * damage_per_effect, max_bonus)
+		human_parent.extra_damage += active_bonus
+
+/datum/component/ring_skill/pointillist/beat_the_brush/on_post_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(active_bonus > 0)
+		human_parent.extra_damage -= active_bonus
+		active_bonus = 0
+	..()
+
+
+// ========== TIER 3 ==========
+
+// Paint Over: Random effects apply 2x stacks; 10% chance for all four
+/datum/component/ring_skill/pointillist/paint_over
+	skill_name = "Paint Over"
+	skill_desc = "Random effect application now applies 2x stacks; +10% chance to apply ALL four effects at once"
+	school = "pointillist"
+	tier = 3
+	choice = "a"
+
+	var/all_effects_chance = 10
+	var/next_use = 0
+
+/datum/component/ring_skill/pointillist/paint_over/on_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(!isliving(target))
+		return
+	if(world.time < next_use)
+		return
+	next_use = world.time + 1 SECONDS
+
+	if(prob(all_effects_chance))
+		// Apply all four effects! (bleed deferred to on_post_attack)
+		pending_bleed += 2
+		target.apply_lc_overheat(2)
+		target.apply_lc_tremor(2, 999)
+		target.apply_lc_mental_decay(2)
+		to_chat(human_parent, span_nicegreen("Paint Over: A masterful stroke! All colors applied!"))
+	else
+		// Apply one random effect with 2x stacks (bleed deferred to on_post_attack)
+		var/effect_type = pick("bleed", "overheat", "tremor", "mental_decay")
+		switch(effect_type)
+			if("bleed")
+				pending_bleed += 2
+			if("overheat")
+				target.apply_lc_overheat(2)
+			if("tremor")
+				target.apply_lc_tremor(2, 999)
+			if("mental_decay")
+				target.apply_lc_mental_decay(2)
+
+// Practices on Aesthetics: +10% damage and +2 bleed per status effect on target
+/datum/component/ring_skill/pointillist/practices_on_aesthetics
+	skill_name = "Practices on Aesthetics"
+	skill_desc = "+10% damage and +2 bleed per status effect on target"
+	school = "pointillist"
+	tier = 3
+	choice = "b"
+
+	var/damage_per_effect = 10
+	var/bleed_per_effect = 2
+	var/active_bonus = 0
+	var/next_use = 0
+
+/datum/component/ring_skill/pointillist/practices_on_aesthetics/on_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(!isliving(target))
+		return
+	if(world.time < next_use)
+		return
+	next_use = world.time + 1 SECONDS
+
+	var/effect_count = count_status_effects(target)
+	if(effect_count > 0)
+		active_bonus = effect_count * damage_per_effect
+		human_parent.extra_damage += active_bonus
+
+		// Apply bonus bleed (deferred to on_post_attack)
+		pending_bleed += effect_count * bleed_per_effect
+
+/datum/component/ring_skill/pointillist/practices_on_aesthetics/on_post_attack(datum/source, mob/living/target, obj/item/weapon)
+	if(active_bonus > 0)
+		human_parent.extra_damage -= active_bonus
+		active_bonus = 0
+	..()
+

--- a/ModularLobotomy/ring/ring_skills/schools/pointillist.dm
+++ b/ModularLobotomy/ring/ring_skills/schools/pointillist.dm
@@ -1,7 +1,7 @@
 // Pointillist School Skills
 // Theme: Random status effect application, SP recovery, scaling power.
 
-// ========== TIER 1 ==========
+// TIER 1
 
 // Hematic Coloring: Apply 3 stacks of random effect. If target has it, +10% damage instead.
 /datum/component/ring_skill/pointillist/hematic_coloring
@@ -95,7 +95,7 @@
 		human_parent.adjustSanityLoss(-sp_healed)
 		to_chat(human_parent, span_nicegreen("Sanguine Pointillism: New colors soothe your mind! (+[sp_healed] SP)"))
 
-// ========== TIER 2 ==========
+// TIER 2
 
 // Assignment Evaluation: Heal 5 SP when hitting targets, +3 SP per status effect on them
 /datum/component/ring_skill/pointillist/assignment_evaluation
@@ -150,7 +150,7 @@
 	..()
 
 
-// ========== TIER 3 ==========
+// TIER 3
 
 // Paint Over: Random effects apply 2x stacks; 10% chance for all four
 /datum/component/ring_skill/pointillist/paint_over

--- a/ModularLobotomy/ring/structures/corporist_artwork.dm
+++ b/ModularLobotomy/ring/structures/corporist_artwork.dm
@@ -1,7 +1,7 @@
 // Corporist Artwork System
 // Artworks created by The Ring's Corporist school from flesh and bone
 
-// ================== ARTIST'S TOOLKIT ==================
+// ARTIST'S TOOLKIT
 
 /obj/item/storage/box/corporist_toolkit
 	name = "artist's toolkit"
@@ -521,7 +521,7 @@
 
 	exp_comp.modify_exp(exp_change)
 
-// ================== CUSTOM ARTWORK ==================
+// CUSTOM ARTWORK
 // Player-composed artwork using a 48x48 grid editor
 // Standalone structure (not a subtype of corporist_artwork)
 
@@ -1187,7 +1187,7 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 		return TRUE
 	return FALSE
 
-// ================== CUSTOM ARTWORK EDITOR ==================
+// CUSTOM ARTWORK EDITOR
 
 /datum/custom_artwork_editor
 	/// The artwork being edited
@@ -1409,7 +1409,7 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 		if("clear_veins")
 			if(!length(artwork.vein_pixels))
 				return
-			artwork.vein_pixels = list()
+			artwork.vein_pixels.Cut()
 			. = TRUE
 
 		if("toggle_veins_layer")
@@ -1463,7 +1463,7 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 	if(exp_comp)
 		exp_comp.add_activity_exp("arrange_part")
 
-// ================== CARVED PIECE ITEM ==================
+// CARVED PIECE ITEM
 
 /obj/item/carved_piece
 	name = "carved flesh piece"
@@ -1538,7 +1538,7 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 	carved_base64 = icon2base64(carved_icon)
 	src.icon = carved_icon
 
-// ================== CARVE BODY EDITOR ==================
+// CARVE BODY EDITOR
 
 /datum/carve_body_editor
 	/// The target dead mob
@@ -1553,11 +1553,11 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 	/// Base64 of the source icon for TGUI
 	var/source_base64
 	/// List of opaque pixel coords (top-down, 0-indexed)
-	var/list/opaque_pixels
+	var/list/opaque_pixels = list()
 	/// Set of opaque pixel keys for fast lookup
-	var/list/opaque_set
+	var/list/opaque_set = list()
 	/// Selected pixels: "x,y" -> TRUE
-	var/list/selected_pixels
+	var/list/selected_pixels = list()
 	/// Whether using the living sprite (TRUE) or dead (FALSE)
 	var/using_living = FALSE
 	/// Living sprite icon
@@ -1574,7 +1574,6 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 /datum/carve_body_editor/New(mob/living/simple_animal/target, mob/living/carbon/human/user)
 	target_mob = target
 	artist = user
-	selected_pixels = list()
 
 	// Build both living and dead icons
 	var/dead_state = target.icon_dead || target.icon_state
@@ -1595,8 +1594,8 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 	source_height = I.Height()
 	source_base64 = base64
 
-	opaque_pixels = list()
-	opaque_set = list()
+	opaque_pixels.Cut()
+	opaque_set.Cut()
 	for(var/by in 1 to source_height)
 		for(var/bx in 1 to source_width)
 			if(I.GetPixel(bx, by))
@@ -1673,12 +1672,12 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 			. = TRUE
 
 		if("clear_selection")
-			selected_pixels = list()
+			selected_pixels.Cut()
 			. = TRUE
 
 		if("switch_sprite")
 			using_living = !using_living
-			selected_pixels = list()
+			selected_pixels.Cut()
 			if(using_living)
 				set_source_icon(living_icon, living_base64)
 			else

--- a/ModularLobotomy/ring/structures/corporist_artwork.dm
+++ b/ModularLobotomy/ring/structures/corporist_artwork.dm
@@ -498,3 +498,630 @@
 			to_chat(artist, span_greentext("Your work is a masterpiece! You gain a full skill point worth of experience!"))
 
 	exp_comp.modify_exp(exp_change)
+
+// ================== CUSTOM ARTWORK ==================
+// Player-composed artwork using a 48x48 grid editor
+// Standalone structure (not a subtype of corporist_artwork)
+
+GLOBAL_LIST_EMPTY(bodypart_icon_cache)
+
+/// Cache and return base64-encoded body part icon for TGUI
+/proc/get_bodypart_base64(icon_file, icon_state_name, dir = SOUTH, rotation = 0)
+	var/key = "[icon_file]:[icon_state_name]:[dir]:[rotation]"
+	if(GLOB.bodypart_icon_cache[key])
+		return GLOB.bodypart_icon_cache[key]
+	var/icon/I = icon(icon_file, icon_state_name, dir)
+	if(rotation)
+		I.Turn(rotation)
+	var/base64 = icon2base64(I)
+	GLOB.bodypart_icon_cache[key] = base64
+	return base64
+
+/// Helper: check if a mob can create/interact with corporist art
+/proc/is_corporist_artist(mob/user)
+	if(!ishuman(user))
+		return FALSE
+	var/mob/living/carbon/human/H = user
+	if(istype(H.dna?.species, /datum/species/corporist_maestro) || istype(H.dna?.species, /datum/species/corporist_apprentice))
+		return TRUE
+	if(H.GetComponent(/datum/component/corporist_student) || H.GetComponent(/datum/component/inspired_artist))
+		return TRUE
+	return FALSE
+
+/obj/structure/custom_corporist_artwork
+	name = "custom artwork"
+	desc = "An empty pedestal awaiting an artist's vision."
+	icon = 'icons/obj/statue.dmi'
+	icon_state = "base"
+	anchored = TRUE
+	density = TRUE
+	max_integrity = 200
+
+	/// Stored body parts: id -> list("body_zone", "icon_file", "icon_state")
+	var/list/stored_parts = list()
+	/// Placement data: id -> list("grid_x", "grid_y", "rotation", "tint")
+	var/list/placed_parts = list()
+	/// Vein pixels: keyed as "x,y" -> TRUE, representing painted cells
+	var/list/vein_pixels = list()
+	/// Next unique ID for stored parts
+	var/next_part_id = 1
+	/// Active TGUI editor datum
+	var/datum/custom_artwork_editor/editor
+	/// Whether veins render above body parts
+	var/veins_above = FALSE
+	/// Number of body parts added (for examine)
+	var/body_part_count = 0
+	/// Reference to the artist who created this artwork
+	var/datum/weakref/creator_ref
+	/// Custom description set by the artist (via Describe Artwork action)
+	var/custom_desc
+	/// Final grade from Maestro (F/C/B/A/S)
+	var/final_grade
+	/// Maestro's critique text
+	var/final_grade_critique
+	/// Reference to Maestro who graded it
+	var/datum/weakref/graded_by_ref
+	/// SP damage to non-artists on examine
+	var/examine_sp_damage = 15
+	/// SP heal to artists on examine
+	var/examine_sp_heal = 10
+
+/obj/structure/custom_corporist_artwork/Initialize(mapload, mob/creator)
+	. = ..()
+	if(creator)
+		creator_ref = WEAKREF(creator)
+
+/obj/structure/custom_corporist_artwork/Destroy()
+	if(editor)
+		QDEL_NULL(editor)
+	return ..()
+
+/obj/structure/custom_corporist_artwork/examine(mob/user)
+	. = ..()
+
+	if(custom_desc)
+		. += span_notice("\"[custom_desc]\"")
+
+	if(body_part_count)
+		. += span_notice("It incorporates [body_part_count] body part[body_part_count == 1 ? "" : "s"].")
+
+	if(final_grade)
+		var/grader_name = "Unknown"
+		var/mob/grader = graded_by_ref?.resolve()
+		if(grader)
+			grader_name = grader.name
+		. += span_purple("Final Grade: [final_grade][final_grade_critique ? " - '[final_grade_critique]'" : ""] - [grader_name]")
+	else
+		. += span_purple("Awaiting judgment.")
+
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(is_corporist_artist(H))
+			H.adjustSanityLoss(-examine_sp_heal)
+			to_chat(user, span_nicegreen("You appreciate the craftsmanship. The artistic vision soothes your mind."))
+		else
+			H.adjustSanityLoss(examine_sp_damage)
+			to_chat(user, span_warning("The artwork disturbs you deeply. You feel your sanity slipping..."))
+
+/obj/structure/custom_corporist_artwork/attack_hand(mob/living/user, list/modifiers)
+	if(!ishuman(user))
+		return ..()
+
+	var/mob/living/carbon/human/H = user
+	if(!is_corporist_artist(H))
+		to_chat(H, span_notice("You examine the disturbing artwork..."))
+		return
+
+	if(!length(stored_parts))
+		to_chat(H, span_warning("The artwork has no body parts to arrange. Hit it with body parts first."))
+		return
+
+	to_chat(H, span_notice("You begin arranging the artwork..."))
+	if(!editor)
+		editor = new(src)
+	editor.ui_interact(H)
+
+/obj/structure/custom_corporist_artwork/attackby(obj/item/I, mob/living/user, params)
+	if(istype(I, /obj/item/bodypart))
+		if(!is_corporist_artist(user))
+			to_chat(user, span_warning("You have no idea how to incorporate this into the artwork."))
+			return
+
+		var/obj/item/bodypart/BP = I
+		add_bodypart_custom(BP, user)
+		return
+
+	return ..()
+
+/// Add a bodypart to the custom artwork's storage
+/obj/structure/custom_corporist_artwork/proc/add_bodypart_custom(obj/item/bodypart/BP, mob/user)
+	var/part_id = "[next_part_id]"
+	next_part_id++
+
+	stored_parts[part_id] = list(
+		"body_zone" = BP.body_zone,
+		"icon_file" = "[BP.icon]",
+		"icon_state" = BP.icon_state
+	)
+
+	body_part_count++
+
+	to_chat(user, span_nicegreen("You incorporate the [BP.name] into the artwork's collection."))
+	playsound(src, 'sound/effects/splat.ogg', 50, TRUE)
+
+	if(user.transferItemToLoc(BP, src))
+		BP.forceMove(src)
+	else
+		BP.forceMove(src)
+
+	var/datum/component/artistic_exp/exp_comp = user.GetComponent(/datum/component/artistic_exp)
+	if(exp_comp)
+		exp_comp.add_activity_exp("add_body")
+
+	if(editor)
+		SStgui.update_static_data(user, editor)
+
+/// Assign a final grade (called by Maestro's judge_artwork action)
+/obj/structure/custom_corporist_artwork/proc/assign_final_grade(mob/grader, grade, critique)
+	final_grade = grade
+	final_grade_critique = critique
+	graded_by_ref = WEAKREF(grader)
+
+	var/mob/creator = creator_ref?.resolve()
+	if(creator && ishuman(creator))
+		apply_grade_exp(creator, grade)
+
+/// Apply EXP gain/loss based on grade
+/obj/structure/custom_corporist_artwork/proc/apply_grade_exp(mob/living/carbon/human/artist, grade)
+	var/datum/component/artistic_exp/exp_comp = artist.GetComponent(/datum/component/artistic_exp)
+	if(!exp_comp)
+		return
+
+	exp_comp.record_grade(grade)
+
+	var/next_threshold = exp_comp.get_next_threshold()
+	var/exp_change = 0
+
+	switch(grade)
+		if("F")
+			exp_change = -round(next_threshold * 0.5)
+			to_chat(artist, span_boldwarning("Your work has been judged harshly. You lose artistic experience."))
+		if("C")
+			exp_change = -round(next_threshold * 0.25)
+			to_chat(artist, span_warning("Your work was deemed mediocre. You lose some artistic experience."))
+		if("B")
+			exp_change = round(next_threshold * 0.25)
+			to_chat(artist, span_notice("Your work was judged favorably. You gain artistic experience."))
+		if("A")
+			exp_change = round(next_threshold * 0.5)
+			to_chat(artist, span_nicegreen("Your work was deemed excellent! You gain significant artistic experience."))
+		if("S")
+			exp_change = next_threshold
+			to_chat(artist, span_greentext("Your work is a masterpiece! You gain a full skill point worth of experience!"))
+
+	exp_comp.modify_exp(exp_change)
+
+/obj/structure/custom_corporist_artwork/update_overlays()
+	. = ..()
+
+	if(!veins_above)
+		. += generate_vein_overlay()
+
+	for(var/part_id in placed_parts)
+		var/list/placement = placed_parts[part_id]
+		var/list/part_data = stored_parts[part_id]
+		if(!part_data || !placement)
+			continue
+
+		var/icon/part_icon = icon(file(part_data["icon_file"]), part_data["icon_state"], SOUTH)
+		var/rotation = placement["rotation"]
+		if(rotation)
+			part_icon.Turn(rotation)
+		var/tint = placement["tint"]
+		if(tint && tint != "#ffffff")
+			part_icon.Blend(tint, ICON_MULTIPLY)
+
+		var/mutable_appearance/MA = mutable_appearance(part_icon)
+		MA.pixel_x = placement["grid_x"] - 24
+		MA.pixel_y = 23 - placement["grid_y"]
+		. += MA
+
+	if(veins_above)
+		. += generate_vein_overlay()
+
+/// Generate the vein overlay icon from vein_pixels
+/obj/structure/custom_corporist_artwork/proc/generate_vein_overlay()
+	if(!length(vein_pixels))
+		return list()
+
+	// Build 48x48 color grid: transparent by default, dark red where veins painted
+	var/list/data = list()
+	for(var/y in 1 to 48)
+		for(var/x in 1 to 48)
+			if(vein_pixels["[x],[y]"])
+				data += "#8b0000ff"
+			else
+				data += "#00000000"
+
+	var/data_string = data.Join("")
+	var/png_path = "data/tmp/custom_artwork_[REF(src)].png"
+	var/result = rustg_dmi_create_png(png_path, "48", "48", data_string)
+	if(result)
+		return list()
+
+	var/icon/vein_icon = new(png_path)
+	var/mutable_appearance/MA = mutable_appearance(vein_icon)
+	MA.pixel_x = -8
+	MA.pixel_y = -8
+	return list(MA)
+
+/// Check if all placed parts form a connected, grounded structure
+/obj/structure/custom_corporist_artwork/proc/validate_placement()
+	if(!length(placed_parts))
+		return TRUE
+
+	var/has_grounded = FALSE
+	for(var/part_id in placed_parts)
+		var/list/placement = placed_parts[part_id]
+		if(placement["grid_y"] + 32 >= 48)
+			has_grounded = TRUE
+			break
+
+	if(!has_grounded)
+		return FALSE
+
+	return check_connectivity()
+
+/// BFS connectivity check - all placed parts must be reachable from a grounded part
+/obj/structure/custom_corporist_artwork/proc/check_connectivity()
+	if(length(placed_parts) <= 1)
+		return TRUE
+
+	var/list/nodes = list()
+	for(var/part_id in placed_parts)
+		nodes += part_id
+
+	var/list/visited = list()
+	var/list/queue = list(nodes[1])
+	visited[nodes[1]] = TRUE
+
+	while(length(queue))
+		var/current = queue[1]
+		queue.Cut(1, 2)
+
+		for(var/other_id in nodes)
+			if(visited[other_id])
+				continue
+			if(parts_adjacent(current, other_id))
+				visited[other_id] = TRUE
+				queue += other_id
+
+	return length(visited) == length(nodes)
+
+/// Check if two placed parts are adjacent (bounding boxes overlap or touch within 1px)
+/obj/structure/custom_corporist_artwork/proc/parts_adjacent(part_id_a, part_id_b)
+	var/list/a = placed_parts[part_id_a]
+	var/list/b = placed_parts[part_id_b]
+	if(!a || !b)
+		return FALSE
+
+	var/ax1 = a["grid_x"]
+	var/ay1 = a["grid_y"]
+	var/ax2 = ax1 + 31
+	var/ay2 = ay1 + 31
+
+	var/bx1 = b["grid_x"]
+	var/by1 = b["grid_y"]
+	var/bx2 = bx1 + 31
+	var/by2 = by1 + 31
+
+	// Check if bounding boxes overlap or are within 1px
+	if(ax1 > bx2 + 1 || bx1 > ax2 + 1)
+		return FALSE
+	if(ay1 > by2 + 1 || by1 > ay2 + 1)
+		return FALSE
+
+	return TRUE
+
+/// Check if a part is adjacent to any vein pixel
+/obj/structure/custom_corporist_artwork/proc/part_touches_vein(part_id)
+	var/list/placement = placed_parts[part_id]
+	if(!placement)
+		return FALSE
+
+	var/px1 = placement["grid_x"]
+	var/py1 = placement["grid_y"]
+	var/px2 = px1 + 31
+	var/py2 = py1 + 31
+
+	// Expand by 1 for adjacency
+	for(var/key in vein_pixels)
+		var/list/coords = splittext(key, ",")
+		var/vx = text2num(coords[1])
+		var/vy = text2num(coords[2])
+		if(vx >= px1 - 1 && vx <= px2 + 1 && vy >= py1 - 1 && vy <= py2 + 1)
+			return TRUE
+	return FALSE
+
+/// Full connectivity check including veins as connectors
+/obj/structure/custom_corporist_artwork/proc/check_full_connectivity()
+	if(length(placed_parts) <= 1)
+		return TRUE
+
+	var/list/nodes = list()
+	for(var/part_id in placed_parts)
+		nodes += part_id
+
+	var/list/visited = list()
+	var/list/queue = list(nodes[1])
+	visited[nodes[1]] = TRUE
+
+	while(length(queue))
+		var/current = queue[1]
+		queue.Cut(1, 2)
+
+		for(var/other_id in nodes)
+			if(visited[other_id])
+				continue
+			if(parts_adjacent(current, other_id))
+				visited[other_id] = TRUE
+				queue += other_id
+			else if(parts_connected_via_veins(current, other_id))
+				visited[other_id] = TRUE
+				queue += other_id
+
+	return length(visited) == length(nodes)
+
+/// Check if two parts are connected through vein segments
+/obj/structure/custom_corporist_artwork/proc/parts_connected_via_veins(part_id_a, part_id_b)
+	if(part_touches_vein(part_id_a) && part_touches_vein(part_id_b))
+		return TRUE
+	return FALSE
+
+// ================== CUSTOM ARTWORK EDITOR ==================
+
+/datum/custom_artwork_editor
+	/// The artwork being edited
+	var/obj/structure/custom_corporist_artwork/artwork
+	/// Last time arrangement EXP was granted
+	var/last_arrange_exp = 0
+
+/datum/custom_artwork_editor/New(obj/structure/custom_corporist_artwork/parent)
+	artwork = parent
+
+/datum/custom_artwork_editor/Destroy()
+	if(artwork?.editor == src)
+		artwork.editor = null
+	artwork = null
+	return ..()
+
+/datum/custom_artwork_editor/ui_state(mob/user)
+	return GLOB.conscious_state
+
+/datum/custom_artwork_editor/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "CustomArtworkEditor")
+		ui.open()
+
+/datum/custom_artwork_editor/ui_static_data(mob/user)
+	var/list/data = list()
+	data["gridSize"] = 48
+
+	var/list/part_icons = list()
+	for(var/part_id in artwork.stored_parts)
+		var/list/part_data = artwork.stored_parts[part_id]
+		var/list/rotations = list()
+		for(var/rot in list(0, 90, 180, 270))
+			rotations["[rot]"] = get_bodypart_base64(
+				file(part_data["icon_file"]),
+				part_data["icon_state"],
+				SOUTH,
+				rot
+			)
+		part_icons[part_id] = rotations
+	data["partIcons"] = part_icons
+
+	return data
+
+/datum/custom_artwork_editor/ui_data(mob/user)
+	var/list/data = list()
+
+	var/list/stored = list()
+	for(var/part_id in artwork.stored_parts)
+		var/list/part_data = artwork.stored_parts[part_id]
+		stored += list(list(
+			"id" = part_id,
+			"bodyZone" = part_data["body_zone"],
+			"placed" = !!artwork.placed_parts[part_id]
+		))
+	data["storedParts"] = stored
+
+	var/list/placed = list()
+	for(var/part_id in artwork.placed_parts)
+		var/list/placement = artwork.placed_parts[part_id]
+		placed += list(list(
+			"id" = part_id,
+			"gridX" = placement["grid_x"],
+			"gridY" = placement["grid_y"],
+			"rotation" = placement["rotation"],
+			"tint" = placement["tint"]
+		))
+	data["placedParts"] = placed
+
+	// Send vein pixels as flat list of {x, y}
+	var/list/vein_list = list()
+	for(var/key in artwork.vein_pixels)
+		var/list/coords = splittext(key, ",")
+		vein_list += list(list(
+			"x" = text2num(coords[1]),
+			"y" = text2num(coords[2])
+		))
+	data["veinPixels"] = vein_list
+	data["veinsAbove"] = artwork.veins_above
+
+	return data
+
+/datum/custom_artwork_editor/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	if(.)
+		return
+
+	var/mob/living/carbon/human/user = usr
+	if(!istype(user))
+		return
+
+	switch(action)
+		if("place_part")
+			var/part_id = params["id"]
+			var/grid_x = clamp(text2num(params["x"]), 0, 16)
+			var/grid_y = clamp(text2num(params["y"]), 0, 16)
+			if(!artwork.stored_parts[part_id])
+				return
+			if(artwork.placed_parts[part_id])
+				return
+
+			artwork.placed_parts[part_id] = list(
+				"grid_x" = grid_x,
+				"grid_y" = grid_y,
+				"rotation" = 0,
+				"tint" = "#ffffff"
+			)
+
+			if(!artwork.validate_placement())
+				artwork.placed_parts -= part_id
+				return
+
+			grant_arrange_exp(user)
+			. = TRUE
+
+		if("move_part")
+			var/part_id = params["id"]
+			var/grid_x = clamp(text2num(params["x"]), 0, 16)
+			var/grid_y = clamp(text2num(params["y"]), 0, 16)
+			if(!artwork.placed_parts[part_id])
+				return
+
+			var/list/current = artwork.placed_parts[part_id]
+			var/list/old_placement = current.Copy()
+			artwork.placed_parts[part_id]["grid_x"] = grid_x
+			artwork.placed_parts[part_id]["grid_y"] = grid_y
+
+			if(!artwork.validate_placement())
+				artwork.placed_parts[part_id] = old_placement
+				return
+
+			grant_arrange_exp(user)
+			. = TRUE
+
+		if("rotate_part")
+			var/part_id = params["id"]
+			if(!artwork.placed_parts[part_id])
+				return
+
+			var/old_rotation = artwork.placed_parts[part_id]["rotation"]
+			artwork.placed_parts[part_id]["rotation"] = (old_rotation + 90) % 360
+
+			if(!artwork.validate_placement())
+				artwork.placed_parts[part_id]["rotation"] = old_rotation
+				return
+
+			grant_arrange_exp(user)
+			. = TRUE
+
+		if("set_tint")
+			var/part_id = params["id"]
+			var/tint = params["tint"]
+			if(!artwork.placed_parts[part_id])
+				return
+
+			var/list/valid_tints = list("#ffffff", "#ff4444", "#888888", "#ddcccc", "#445544")
+			if(!(tint in valid_tints))
+				return
+
+			artwork.placed_parts[part_id]["tint"] = tint
+			. = TRUE
+
+		if("remove_part")
+			var/part_id = params["id"]
+			if(!artwork.placed_parts[part_id])
+				return
+
+			var/list/current_place = artwork.placed_parts[part_id]
+			var/list/old_placement = current_place.Copy()
+			artwork.placed_parts -= part_id
+
+			if(length(artwork.placed_parts) && !artwork.validate_placement())
+				artwork.placed_parts[part_id] = old_placement
+				return
+
+			. = TRUE
+
+		if("paint_veins")
+			// Params: list of cells to paint
+			var/list/cells = params["cells"]
+			if(!islist(cells))
+				return
+			for(var/list/cell in cells)
+				var/cx = clamp(text2num(cell["x"]), 1, 48)
+				var/cy = clamp(text2num(cell["y"]), 1, 48)
+				artwork.vein_pixels["[cx],[cy]"] = TRUE
+			. = TRUE
+
+		if("erase_veins")
+			var/list/cells = params["cells"]
+			if(!islist(cells))
+				return
+			var/list/old_pixels = artwork.vein_pixels.Copy()
+			for(var/list/cell in cells)
+				var/cx = clamp(text2num(cell["x"]), 1, 48)
+				var/cy = clamp(text2num(cell["y"]), 1, 48)
+				artwork.vein_pixels -= "[cx],[cy]"
+
+			if(length(artwork.placed_parts) > 1 && !artwork.check_full_connectivity())
+				artwork.vein_pixels = old_pixels
+				return
+
+			. = TRUE
+
+		if("clear_veins")
+			if(!length(artwork.vein_pixels))
+				return
+
+			var/list/old_pixels = artwork.vein_pixels.Copy()
+			artwork.vein_pixels = list()
+
+			if(length(artwork.placed_parts) > 1 && !artwork.check_full_connectivity())
+				artwork.vein_pixels = old_pixels
+				return
+
+			. = TRUE
+
+		if("toggle_veins_layer")
+			artwork.veins_above = !artwork.veins_above
+			. = TRUE
+
+		if("submit")
+			if(!artwork.validate_placement())
+				to_chat(user, span_warning("The artwork's structure is invalid. Ensure parts are connected and grounded."))
+				return
+
+			artwork.update_icon()
+
+			var/datum/component/artistic_exp/exp_comp = user.GetComponent(/datum/component/artistic_exp)
+			if(exp_comp)
+				exp_comp.add_activity_exp("submit_custom")
+
+			to_chat(user, span_nicegreen("You finalize the arrangement of your custom artwork."))
+			playsound(artwork, 'sound/effects/splat.ogg', 50, TRUE)
+			. = TRUE
+
+/// Grant arrangement EXP with 5-second throttle
+/datum/custom_artwork_editor/proc/grant_arrange_exp(mob/living/carbon/human/user)
+	if(world.time < last_arrange_exp + 5 SECONDS)
+		return
+	last_arrange_exp = world.time
+	var/datum/component/artistic_exp/exp_comp = user.GetComponent(/datum/component/artistic_exp)
+	if(exp_comp)
+		exp_comp.add_activity_exp("arrange_part")
+

--- a/ModularLobotomy/ring/structures/corporist_artwork.dm
+++ b/ModularLobotomy/ring/structures/corporist_artwork.dm
@@ -517,6 +517,38 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 	GLOB.bodypart_icon_cache[key] = base64
 	return base64
 
+/// Calculate non-transparent bounding box of an icon (returns list("ox", "oy", "w", "h"))
+/proc/get_icon_crop_bounds(icon_file, icon_state_name, dir = SOUTH, rotation = 0)
+	var/icon/I = icon(icon_file, icon_state_name, dir)
+	if(rotation)
+		I.Turn(rotation)
+	return get_icon_crop_bounds_from_icon(I)
+
+/// Calculate non-transparent bounding box from a pre-built icon object
+/proc/get_icon_crop_bounds_from_icon(icon/I)
+	var/iw = I.Width()
+	var/ih = I.Height()
+	var/min_x = iw
+	var/min_y = ih
+	var/max_x = -1
+	var/max_y = -1
+	for(var/y in 1 to ih)
+		for(var/x in 1 to iw)
+			var/pixel = I.GetPixel(x, y)
+			if(pixel)
+				if(x - 1 < min_x)
+					min_x = x - 1
+				if(x - 1 > max_x)
+					max_x = x - 1
+				var/ty = ih - y
+				if(ty < min_y)
+					min_y = ty
+				if(ty > max_y)
+					max_y = ty
+	if(max_x == -1)
+		return list("ox" = 0, "oy" = 0, "w" = iw, "h" = ih)
+	return list("ox" = min_x, "oy" = min_y, "w" = max_x - min_x + 1, "h" = max_y - min_y + 1)
+
 /// Helper: check if a mob can create/interact with corporist art
 /proc/is_corporist_artist(mob/user)
 	if(!ishuman(user))
@@ -536,6 +568,8 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 	anchored = TRUE
 	density = TRUE
 	max_integrity = 200
+	/// Whether the artwork has been vandalized with spray paint
+	var/vandalized = FALSE
 
 	/// Stored body parts: id -> list("body_zone", "icon_file", "icon_state")
 	var/list/stored_parts = list()
@@ -543,6 +577,10 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 	var/list/placed_parts = list()
 	/// Vein pixels: keyed as "x,y" -> TRUE, representing painted cells
 	var/list/vein_pixels = list()
+	/// Number of vein pixels that have been paid for (from last submit)
+	var/submitted_vein_count = 0
+	/// Blood cost per vein pixel
+	var/blood_per_vein = 1
 	/// Next unique ID for stored parts
 	var/next_part_id = 1
 	/// Active TGUI editor datum
@@ -568,6 +606,7 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 
 /obj/structure/custom_corporist_artwork/Initialize(mapload, mob/creator)
 	. = ..()
+	create_reagents(500)
 	if(creator)
 		creator_ref = WEAKREF(creator)
 
@@ -594,6 +633,13 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 	else
 		. += span_purple("Awaiting judgment.")
 
+	var/stored_blood = reagents?.get_reagent_amount(/datum/reagent/blood) || 0
+	if(stored_blood > 0)
+		. += span_notice("It has [stored_blood]u of blood stored.")
+
+	if(vandalized)
+		. += span_boldwarning("This artwork has been vandalized! It has been ruined.")
+
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(is_corporist_artist(H))
@@ -612,6 +658,19 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 		to_chat(H, span_notice("You examine the disturbing artwork..."))
 		return
 
+	var/list/choices = list("Arrange Parts", "Rename Artwork")
+	var/choice = tgui_input_list(H, "What would you like to do?", "Custom Artwork", choices)
+	if(!choice)
+		return
+
+	if(choice == "Rename Artwork")
+		var/new_name = stripped_input(H, "Name your artwork (max 60 characters):", "Rename Artwork", name, 60)
+		if(!new_name)
+			return
+		name = new_name
+		to_chat(H, span_nicegreen("You rename the artwork to '[new_name]'."))
+		return
+
 	if(!length(stored_parts))
 		to_chat(H, span_warning("The artwork has no body parts to arrange. Hit it with body parts first."))
 		return
@@ -621,7 +680,61 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 		editor = new(src)
 	editor.ui_interact(H)
 
+/obj/structure/custom_corporist_artwork/wrench_act(mob/living/user, obj/item/I)
+	. = ..()
+	if(anchored)
+		to_chat(user, span_notice("You begin loosening the bolts on [src]..."))
+	else
+		to_chat(user, span_notice("You begin securing [src] to the floor..."))
+
+	if(!do_after(user, 2 SECONDS, src))
+		to_chat(user, span_warning("You were interrupted!"))
+		return TRUE
+
+	anchored = !anchored
+	if(anchored)
+		to_chat(user, span_notice("You secure [src] to the floor."))
+	else
+		to_chat(user, span_notice("You unanchor [src] from the floor."))
+	playsound(src, 'sound/items/ratchet.ogg', 50, TRUE)
+	return TRUE
+
 /obj/structure/custom_corporist_artwork/attackby(obj/item/I, mob/living/user, params)
+	if(istype(I, /obj/item/reagent_containers/spray))
+		if(vandalized)
+			to_chat(user, span_warning("This artwork has already been vandalized."))
+			return
+
+		to_chat(user, span_warning("You begin spraying black paint over the artwork..."))
+
+		if(!do_after(user, 3 SECONDS, src))
+			to_chat(user, span_warning("You were interrupted!"))
+			return
+
+		vandalized = TRUE
+		add_atom_colour("#1a1a1a", FIXED_COLOUR_PRIORITY)
+		desc = "This artwork has been defaced with black spray paint."
+		playsound(src, 'sound/effects/spray.ogg', 50, TRUE)
+		to_chat(user, span_boldwarning("You vandalize the artwork!"))
+		visible_message(span_warning("[user] sprays black paint all over [src]!"), ignored_mobs = list(user))
+		return
+
+	if(istype(I, /obj/item/reagent_containers))
+		if(!is_corporist_artist(user))
+			to_chat(user, span_warning("You have no idea how to use this on the artwork."))
+			return
+		var/obj/item/reagent_containers/RC = I
+		if(!RC.reagents?.has_reagent(/datum/reagent/blood))
+			to_chat(user, span_warning("The container has no blood in it."))
+			return
+		var/transferred = RC.reagents.trans_id_to(src, /datum/reagent/blood, RC.amount_per_transfer_from_this)
+		if(transferred > 0)
+			to_chat(user, span_nicegreen("You add [transferred]u of blood to [src]. ([reagents.get_reagent_amount(/datum/reagent/blood)]u stored)"))
+			playsound(src, 'sound/effects/splat.ogg', 30, TRUE)
+		else
+			to_chat(user, span_warning("You couldn't transfer any blood."))
+		return
+
 	if(istype(I, /obj/item/bodypart))
 		if(!is_corporist_artist(user))
 			to_chat(user, span_warning("You have no idea how to incorporate this into the artwork."))
@@ -631,6 +744,15 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 		add_bodypart_custom(BP, user)
 		return
 
+	if(istype(I, /obj/item/carved_piece))
+		if(!is_corporist_artist(user))
+			to_chat(user, span_warning("You have no idea how to incorporate this into the artwork."))
+			return
+
+		var/obj/item/carved_piece/CP = I
+		add_carved_piece(CP, user)
+		return
+
 	return ..()
 
 /// Add a bodypart to the custom artwork's storage
@@ -638,10 +760,18 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 	var/part_id = "[next_part_id]"
 	next_part_id++
 
+	// BP.icon_state is "" after dismemberment (get_limb_icon clears it), use initial values
+	var/use_icon = "[initial(BP.icon)]"
+	var/use_state = initial(BP.icon_state)
+	var/list/crop = get_icon_crop_bounds(file(use_icon), use_state)
 	stored_parts[part_id] = list(
 		"body_zone" = BP.body_zone,
-		"icon_file" = "[BP.icon]",
-		"icon_state" = BP.icon_state
+		"icon_file" = use_icon,
+		"icon_state" = use_state,
+		"crop_ox" = crop["ox"],
+		"crop_oy" = crop["oy"],
+		"crop_w" = crop["w"],
+		"crop_h" = crop["h"]
 	)
 
 	body_part_count++
@@ -653,6 +783,40 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 		BP.forceMove(src)
 	else
 		BP.forceMove(src)
+
+	var/datum/component/artistic_exp/exp_comp = user.GetComponent(/datum/component/artistic_exp)
+	if(exp_comp)
+		exp_comp.add_activity_exp("add_body")
+
+	if(editor)
+		SStgui.update_static_data(user, editor)
+
+/// Add a carved piece to the custom artwork's storage
+/obj/structure/custom_corporist_artwork/proc/add_carved_piece(obj/item/carved_piece/CP, mob/user)
+	var/part_id = "[next_part_id]"
+	next_part_id++
+
+	stored_parts[part_id] = list(
+		"body_zone" = "carved_[CP.source_mob_name]",
+		"icon_file" = null,
+		"icon_state" = null,
+		"is_carved" = TRUE,
+		"carved_base64" = CP.carved_base64,
+		"carved_icon" = CP.carved_icon,
+		"crop_ox" = CP.crop_ox,
+		"crop_oy" = CP.crop_oy,
+		"crop_w" = CP.crop_w,
+		"crop_h" = CP.crop_h
+	)
+
+	body_part_count++
+	to_chat(user, span_nicegreen("You incorporate the [CP.name] into the artwork's collection."))
+	playsound(src, 'sound/effects/splat.ogg', 50, TRUE)
+
+	if(user.transferItemToLoc(CP, src))
+		CP.forceMove(src)
+	else
+		CP.forceMove(src)
 
 	var/datum/component/artistic_exp/exp_comp = user.GetComponent(/datum/component/artistic_exp)
 	if(exp_comp)
@@ -713,7 +877,14 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 		if(!part_data || !placement)
 			continue
 
-		var/icon/part_icon = icon(file(part_data["icon_file"]), part_data["icon_state"], SOUTH)
+		var/icon/part_icon
+		if(part_data["is_carved"])
+			part_icon = icon(part_data["carved_icon"])
+		else
+			var/icon_state_name = part_data["icon_state"]
+			if(!icon_state_name || icon_state_name == "")
+				icon_state_name = "default_human_[part_data["body_zone"]]"
+			part_icon = icon(file(part_data["icon_file"]), icon_state_name, SOUTH)
 		var/rotation = placement["rotation"]
 		if(rotation)
 			part_icon.Turn(rotation)
@@ -722,8 +893,8 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 			part_icon.Blend(tint, ICON_MULTIPLY)
 
 		var/mutable_appearance/MA = mutable_appearance(part_icon)
-		MA.pixel_x = placement["grid_x"] - 24
-		MA.pixel_y = 23 - placement["grid_y"]
+		MA.pixel_x = placement["grid_x"] - 8
+		MA.pixel_y = 8 - placement["grid_y"]
 		. += MA
 
 	if(veins_above)
@@ -734,43 +905,85 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 	if(!length(vein_pixels))
 		return list()
 
-	// Build 48x48 color grid: transparent by default, dark red where veins painted
-	var/list/data = list()
-	for(var/y in 1 to 48)
-		for(var/x in 1 to 48)
-			if(vein_pixels["[x],[y]"])
-				data += "#8b0000ff"
-			else
-				data += "#00000000"
+	var/icon/vein_icon = icon('icons/effects/effects.dmi', "nothing")
+	vein_icon.Scale(48, 48)
 
-	var/data_string = data.Join("")
-	var/png_path = "data/tmp/custom_artwork_[REF(src)].png"
-	var/result = rustg_dmi_create_png(png_path, "48", "48", data_string)
-	if(result)
-		return list()
+	for(var/key in vein_pixels)
+		var/list/coords = splittext(key, ",")
+		var/vx = text2num(coords[1])
+		var/vy = text2num(coords[2])
+		// Vein y=1 is top-down, BYOND y=1 is bottom
+		vein_icon.DrawBox("#8b0000", vx, 49 - vy)
 
-	var/icon/vein_icon = new(png_path)
 	var/mutable_appearance/MA = mutable_appearance(vein_icon)
 	MA.pixel_x = -8
 	MA.pixel_y = -8
 	return list(MA)
 
-/// Check if all placed parts form a connected, grounded structure
-/obj/structure/custom_corporist_artwork/proc/validate_placement()
-	if(!length(placed_parts))
-		return TRUE
+/// Count cardinal (4-dir) vein neighbors at a position
+/obj/structure/custom_corporist_artwork/proc/count_vein_neighbors(cx, cy)
+	var/n = 0
+	if(vein_pixels["[cx-1],[cy]"])
+		n++
+	if(vein_pixels["[cx+1],[cy]"])
+		n++
+	if(vein_pixels["[cx],[cy-1]"])
+		n++
+	if(vein_pixels["[cx],[cy+1]"])
+		n++
+	return n
 
-	var/has_grounded = FALSE
+/// Check if a vein cell can be placed without making any cell exceed 2 cardinal neighbors
+/obj/structure/custom_corporist_artwork/proc/can_place_vein(cx, cy)
+	if(vein_pixels["[cx],[cy]"])
+		return FALSE
+	var/my_neighbors = 0
+	var/list/dirs = list(list(-1, 0), list(1, 0), list(0, -1), list(0, 1))
+	for(var/list/d in dirs)
+		var/nx = cx + d[1]
+		var/ny = cy + d[2]
+		if(vein_pixels["[nx],[ny]"])
+			my_neighbors++
+			if(count_vein_neighbors(nx, ny) >= 2)
+				return FALSE
+	if(my_neighbors > 2)
+		return FALSE
+	return TRUE
+
+/// Check if any bodypart or vein touches the pedestal area (grid x:14-33, y:36-39)
+/obj/structure/custom_corporist_artwork/proc/touches_pedestal()
+	// Pedestal bounds (matching statue.dmi "base" in the 48-cell grid)
+	var/ped_x1 = 14
+	var/ped_y1 = 36
+	var/ped_x2 = 33
+	var/ped_y2 = 39
+
+	// Check body parts (using crop bounds, adjacent = touching within 1px)
 	for(var/part_id in placed_parts)
 		var/list/placement = placed_parts[part_id]
-		if(placement["grid_y"] + 32 >= 48)
-			has_grounded = TRUE
-			break
+		var/list/part_data = stored_parts[part_id]
+		var/c_ox = part_data ? part_data["crop_ox"] : 0
+		var/c_oy = part_data ? part_data["crop_oy"] : 0
+		var/c_w = part_data ? part_data["crop_w"] : 32
+		var/c_h = part_data ? part_data["crop_h"] : 32
 
-	if(!has_grounded)
-		return FALSE
+		var/px1 = placement["grid_x"] + c_ox
+		var/py1 = placement["grid_y"] + c_oy
+		var/px2 = px1 + c_w - 1
+		var/py2 = py1 + c_h - 1
 
-	return check_connectivity()
+		if(px1 <= ped_x2 + 1 && px2 >= ped_x1 - 1 && py1 <= ped_y2 + 1 && py2 >= ped_y1 - 1)
+			return TRUE
+
+	// Check veins
+	for(var/key in vein_pixels)
+		var/list/coords = splittext(key, ",")
+		var/vx = text2num(coords[1])
+		var/vy = text2num(coords[2])
+		if(vx >= ped_x1 - 1 && vx <= ped_x2 + 1 && vy >= ped_y1 - 1 && vy <= ped_y2 + 1)
+			return TRUE
+
+	return FALSE
 
 /// BFS connectivity check - all placed parts must be reachable from a grounded part
 /obj/structure/custom_corporist_artwork/proc/check_connectivity()
@@ -798,24 +1011,36 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 
 	return length(visited) == length(nodes)
 
-/// Check if two placed parts are adjacent (bounding boxes overlap or touch within 1px)
+/// Check if two placed parts are adjacent (content bounding boxes overlap or touch within 1px)
 /obj/structure/custom_corporist_artwork/proc/parts_adjacent(part_id_a, part_id_b)
 	var/list/a = placed_parts[part_id_a]
 	var/list/b = placed_parts[part_id_b]
 	if(!a || !b)
 		return FALSE
 
-	var/ax1 = a["grid_x"]
-	var/ay1 = a["grid_y"]
-	var/ax2 = ax1 + 31
-	var/ay2 = ay1 + 31
+	var/list/da = stored_parts[part_id_a]
+	var/list/db = stored_parts[part_id_b]
 
-	var/bx1 = b["grid_x"]
-	var/by1 = b["grid_y"]
-	var/bx2 = bx1 + 31
-	var/by2 = by1 + 31
+	var/a_ox = da ? da["crop_ox"] : 0
+	var/a_oy = da ? da["crop_oy"] : 0
+	var/a_w = da ? da["crop_w"] : 32
+	var/a_h = da ? da["crop_h"] : 32
 
-	// Check if bounding boxes overlap or are within 1px
+	var/b_ox = db ? db["crop_ox"] : 0
+	var/b_oy = db ? db["crop_oy"] : 0
+	var/b_w = db ? db["crop_w"] : 32
+	var/b_h = db ? db["crop_h"] : 32
+
+	var/ax1 = a["grid_x"] + a_ox
+	var/ay1 = a["grid_y"] + a_oy
+	var/ax2 = ax1 + a_w - 1
+	var/ay2 = ay1 + a_h - 1
+
+	var/bx1 = b["grid_x"] + b_ox
+	var/by1 = b["grid_y"] + b_oy
+	var/bx2 = bx1 + b_w - 1
+	var/by2 = by1 + b_h - 1
+
 	if(ax1 > bx2 + 1 || bx1 > ax2 + 1)
 		return FALSE
 	if(ay1 > by2 + 1 || by1 > ay2 + 1)
@@ -829,12 +1054,17 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 	if(!placement)
 		return FALSE
 
-	var/px1 = placement["grid_x"]
-	var/py1 = placement["grid_y"]
-	var/px2 = px1 + 31
-	var/py2 = py1 + 31
+	var/list/part_data = stored_parts[part_id]
+	var/c_ox = part_data ? part_data["crop_ox"] : 0
+	var/c_oy = part_data ? part_data["crop_oy"] : 0
+	var/c_w = part_data ? part_data["crop_w"] : 32
+	var/c_h = part_data ? part_data["crop_h"] : 32
 
-	// Expand by 1 for adjacency
+	var/px1 = placement["grid_x"] + c_ox
+	var/py1 = placement["grid_y"] + c_oy
+	var/px2 = px1 + c_w - 1
+	var/py2 = py1 + c_h - 1
+
 	for(var/key in vein_pixels)
 		var/list/coords = splittext(key, ",")
 		var/vx = text2num(coords[1])
@@ -912,15 +1142,51 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 	for(var/part_id in artwork.stored_parts)
 		var/list/part_data = artwork.stored_parts[part_id]
 		var/list/rotations = list()
-		for(var/rot in list(0, 90, 180, 270))
-			rotations["[rot]"] = get_bodypart_base64(
-				file(part_data["icon_file"]),
-				part_data["icon_state"],
-				SOUTH,
-				rot
-			)
+		if(part_data["is_carved"])
+			var/icon/carved = part_data["carved_icon"]
+			rotations["0"] = part_data["carved_base64"]
+			for(var/rot in list(90, 180, 270))
+				var/icon/rotated = icon(carved)
+				rotated.Turn(rot)
+				rotations["[rot]"] = icon2base64(rotated)
+		else
+			var/icon_state_name = part_data["icon_state"]
+			if(!icon_state_name || icon_state_name == "")
+				icon_state_name = "default_human_[part_data["body_zone"]]"
+			for(var/rot in list(0, 90, 180, 270))
+				rotations["[rot]"] = get_bodypart_base64(
+					file(part_data["icon_file"]),
+					icon_state_name,
+					SOUTH,
+					rot
+				)
 		part_icons[part_id] = rotations
 	data["partIcons"] = part_icons
+
+	var/list/crop_data = list()
+	for(var/part_id in artwork.stored_parts)
+		var/list/part_data = artwork.stored_parts[part_id]
+		var/list/rot_crops = list()
+		if(part_data["is_carved"])
+			var/icon/carved = part_data["carved_icon"]
+			rot_crops["0"] = list("ox" = part_data["crop_ox"], "oy" = part_data["crop_oy"], "w" = part_data["crop_w"], "h" = part_data["crop_h"])
+			for(var/rot in list(90, 180, 270))
+				var/icon/rotated = icon(carved)
+				rotated.Turn(rot)
+				rot_crops["[rot]"] = get_icon_crop_bounds_from_icon(rotated)
+		else
+			var/use_state = part_data["icon_state"]
+			if(!use_state || use_state == "")
+				use_state = "default_human_[part_data["body_zone"]]"
+			for(var/rot in list(0, 90, 180, 270))
+				rot_crops["[rot]"] = get_icon_crop_bounds(
+					file(part_data["icon_file"]),
+					use_state,
+					SOUTH,
+					rot
+				)
+		crop_data[part_id] = rot_crops
+	data["cropData"] = crop_data
 
 	return data
 
@@ -960,6 +1226,13 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 	data["veinPixels"] = vein_list
 	data["veinsAbove"] = artwork.veins_above
 
+	var/current_veins = length(artwork.vein_pixels)
+	var/vein_diff = current_veins - artwork.submitted_vein_count
+	var/stored_blood = artwork.reagents?.get_reagent_amount(/datum/reagent/blood) || 0
+	data["storedBlood"] = stored_blood
+	data["bloodCost"] = max(0, vein_diff) * artwork.blood_per_vein
+	data["bloodRefund"] = max(0, -vein_diff) * artwork.blood_per_vein
+
 	return data
 
 /datum/custom_artwork_editor/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
@@ -974,8 +1247,8 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 	switch(action)
 		if("place_part")
 			var/part_id = params["id"]
-			var/grid_x = clamp(text2num(params["x"]), 0, 16)
-			var/grid_y = clamp(text2num(params["y"]), 0, 16)
+			var/grid_x = clamp(text2num(params["x"]), -32, 47)
+			var/grid_y = clamp(text2num(params["y"]), -32, 47)
 			if(!artwork.stored_parts[part_id])
 				return
 			if(artwork.placed_parts[part_id])
@@ -988,30 +1261,17 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 				"tint" = "#ffffff"
 			)
 
-			if(!artwork.validate_placement())
-				artwork.placed_parts -= part_id
-				return
-
-			grant_arrange_exp(user)
 			. = TRUE
 
 		if("move_part")
 			var/part_id = params["id"]
-			var/grid_x = clamp(text2num(params["x"]), 0, 16)
-			var/grid_y = clamp(text2num(params["y"]), 0, 16)
+			var/grid_x = clamp(text2num(params["x"]), -32, 47)
+			var/grid_y = clamp(text2num(params["y"]), -32, 47)
 			if(!artwork.placed_parts[part_id])
 				return
 
-			var/list/current = artwork.placed_parts[part_id]
-			var/list/old_placement = current.Copy()
 			artwork.placed_parts[part_id]["grid_x"] = grid_x
 			artwork.placed_parts[part_id]["grid_y"] = grid_y
-
-			if(!artwork.validate_placement())
-				artwork.placed_parts[part_id] = old_placement
-				return
-
-			grant_arrange_exp(user)
 			. = TRUE
 
 		if("rotate_part")
@@ -1019,14 +1279,7 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 			if(!artwork.placed_parts[part_id])
 				return
 
-			var/old_rotation = artwork.placed_parts[part_id]["rotation"]
-			artwork.placed_parts[part_id]["rotation"] = (old_rotation + 90) % 360
-
-			if(!artwork.validate_placement())
-				artwork.placed_parts[part_id]["rotation"] = old_rotation
-				return
-
-			grant_arrange_exp(user)
+			artwork.placed_parts[part_id]["rotation"] = (artwork.placed_parts[part_id]["rotation"] + 90) % 360
 			. = TRUE
 
 		if("set_tint")
@@ -1047,24 +1300,20 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 			if(!artwork.placed_parts[part_id])
 				return
 
-			var/list/current_place = artwork.placed_parts[part_id]
-			var/list/old_placement = current_place.Copy()
 			artwork.placed_parts -= part_id
-
-			if(length(artwork.placed_parts) && !artwork.validate_placement())
-				artwork.placed_parts[part_id] = old_placement
-				return
-
 			. = TRUE
 
 		if("paint_veins")
-			// Params: list of cells to paint
 			var/list/cells = params["cells"]
 			if(!islist(cells))
 				return
 			for(var/list/cell in cells)
 				var/cx = clamp(text2num(cell["x"]), 1, 48)
 				var/cy = clamp(text2num(cell["y"]), 1, 48)
+				if(artwork.vein_pixels["[cx],[cy]"])
+					continue
+				if(!artwork.can_place_vein(cx, cy))
+					continue
 				artwork.vein_pixels["[cx],[cy]"] = TRUE
 			. = TRUE
 
@@ -1072,29 +1321,16 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 			var/list/cells = params["cells"]
 			if(!islist(cells))
 				return
-			var/list/old_pixels = artwork.vein_pixels.Copy()
 			for(var/list/cell in cells)
 				var/cx = clamp(text2num(cell["x"]), 1, 48)
 				var/cy = clamp(text2num(cell["y"]), 1, 48)
 				artwork.vein_pixels -= "[cx],[cy]"
-
-			if(length(artwork.placed_parts) > 1 && !artwork.check_full_connectivity())
-				artwork.vein_pixels = old_pixels
-				return
-
 			. = TRUE
 
 		if("clear_veins")
 			if(!length(artwork.vein_pixels))
 				return
-
-			var/list/old_pixels = artwork.vein_pixels.Copy()
 			artwork.vein_pixels = list()
-
-			if(length(artwork.placed_parts) > 1 && !artwork.check_full_connectivity())
-				artwork.vein_pixels = old_pixels
-				return
-
 			. = TRUE
 
 		if("toggle_veins_layer")
@@ -1102,15 +1338,38 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 			. = TRUE
 
 		if("submit")
-			if(!artwork.validate_placement())
-				to_chat(user, span_warning("The artwork's structure is invalid. Ensure parts are connected and grounded."))
+			if(!length(artwork.placed_parts))
+				to_chat(user, span_warning("Place at least one body part before submitting."))
 				return
 
-			artwork.update_icon()
+			if(length(artwork.placed_parts) > 1 && !artwork.check_full_connectivity())
+				to_chat(user, span_warning("All body parts must be connected to each other, either directly or through veins."))
+				return
 
-			var/datum/component/artistic_exp/exp_comp = user.GetComponent(/datum/component/artistic_exp)
-			if(exp_comp)
-				exp_comp.add_activity_exp("submit_custom")
+			if(!artwork.touches_pedestal())
+				to_chat(user, span_warning("At least one body part or vein must touch the pedestal."))
+				return
+
+			// Calculate blood cost for vein changes
+			var/current_veins = length(artwork.vein_pixels)
+			var/vein_diff = current_veins - artwork.submitted_vein_count
+			if(vein_diff > 0)
+				// Need to pay for new veins
+				var/blood_cost = vein_diff * artwork.blood_per_vein
+				var/stored_blood = artwork.reagents?.get_reagent_amount(/datum/reagent/blood) || 0
+				if(stored_blood < blood_cost)
+					to_chat(user, span_warning("Not enough blood stored! Need [blood_cost]u but only [stored_blood]u available. ([vein_diff] new vein pixels)"))
+					return
+				artwork.reagents.remove_reagent(/datum/reagent/blood, blood_cost)
+				to_chat(user, span_notice("Used [blood_cost]u of blood for [vein_diff] new vein pixels."))
+			else if(vein_diff < 0)
+				// Refund blood for removed veins
+				var/refund = -vein_diff * artwork.blood_per_vein
+				artwork.reagents.add_reagent(/datum/reagent/blood, refund)
+				to_chat(user, span_notice("Recovered [refund]u of blood from [abs(vein_diff)] removed vein pixels."))
+
+			artwork.submitted_vein_count = current_veins
+			artwork.update_icon()
 
 			to_chat(user, span_nicegreen("You finalize the arrangement of your custom artwork."))
 			playsound(artwork, 'sound/effects/splat.ogg', 50, TRUE)
@@ -1124,4 +1383,308 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 	var/datum/component/artistic_exp/exp_comp = user.GetComponent(/datum/component/artistic_exp)
 	if(exp_comp)
 		exp_comp.add_activity_exp("arrange_part")
+
+// ================== CARVED PIECE ITEM ==================
+
+/obj/item/carved_piece
+	name = "carved flesh piece"
+	desc = "A piece of flesh carefully carved from a creature's body."
+	icon = 'icons/obj/surgery.dmi'
+	icon_state = "yourorgans"
+	w_class = WEIGHT_CLASS_SMALL
+	/// The dynamically generated icon of the carved pixels
+	var/icon/carved_icon
+	/// Pre-computed base64 of the carved icon
+	var/carved_base64
+	/// Width of the source mob sprite
+	var/source_width = 32
+	/// Height of the source mob sprite
+	var/source_height = 32
+	/// Name of the source mob
+	var/source_mob_name
+	/// Crop bounds (top-down coordinates)
+	var/crop_ox = 0
+	var/crop_oy = 0
+	var/crop_w = 32
+	var/crop_h = 32
+
+/// Build the carved icon from selected pixel coordinates
+/obj/item/carved_piece/proc/setup_from_pixels(icon/source_icon, list/pixels, mob_name)
+	source_mob_name = mob_name
+	source_width = source_icon.Width()
+	source_height = source_icon.Height()
+	name = "carved [mob_name] piece"
+
+	// Copy source icon and blank it, preserving icon metadata
+	carved_icon = icon(source_icon)
+	carved_icon.DrawBox(null, 1, 1, source_width, source_height)
+
+	// Build a set of selected pixel keys for fast lookup
+	var/list/selected_set = list()
+	var/min_x = source_width
+	var/min_y = source_height
+	var/max_x = -1
+	var/max_y = -1
+
+	for(var/list/px in pixels)
+		var/tx = px["x"]
+		var/ty = px["y"]
+		var/bx = tx + 1
+		var/by = source_height - ty
+		selected_set["[bx],[by]"] = TRUE
+		if(tx < min_x)
+			min_x = tx
+		if(tx > max_x)
+			max_x = tx
+		if(ty < min_y)
+			min_y = ty
+		if(ty > max_y)
+			max_y = ty
+
+	// Draw only selected pixels from the source
+	for(var/key in selected_set)
+		var/list/coords = splittext(key, ",")
+		var/bx = text2num(coords[1])
+		var/by = text2num(coords[2])
+		var/color = source_icon.GetPixel(bx, by)
+		if(color)
+			carved_icon.DrawBox(color, bx, by)
+
+	if(max_x >= 0)
+		crop_ox = min_x
+		crop_oy = min_y
+		crop_w = max_x - min_x + 1
+		crop_h = max_y - min_y + 1
+
+	carved_base64 = icon2base64(carved_icon)
+	src.icon = carved_icon
+
+// ================== CARVE BODY EDITOR ==================
+
+/datum/carve_body_editor
+	/// The target dead mob
+	var/mob/living/simple_animal/target_mob
+	/// The artist using the editor
+	var/mob/living/carbon/human/artist
+	/// South-facing source icon (current selection)
+	var/icon/source_icon
+	/// Icon dimensions
+	var/source_width = 32
+	var/source_height = 32
+	/// Base64 of the source icon for TGUI
+	var/source_base64
+	/// List of opaque pixel coords (top-down, 0-indexed)
+	var/list/opaque_pixels
+	/// Set of opaque pixel keys for fast lookup
+	var/list/opaque_set
+	/// Selected pixels: "x,y" -> TRUE
+	var/list/selected_pixels
+	/// Whether using the living sprite (TRUE) or dead (FALSE)
+	var/using_living = FALSE
+	/// Living sprite icon
+	var/icon/living_icon
+	/// Dead sprite icon
+	var/icon/dead_icon
+	/// Living sprite base64
+	var/living_base64
+	/// Dead sprite base64
+	var/dead_base64
+	/// Whether the mob has distinct living/dead sprites
+	var/has_both_sprites = FALSE
+
+/datum/carve_body_editor/New(mob/living/simple_animal/target, mob/living/carbon/human/user)
+	target_mob = target
+	artist = user
+	selected_pixels = list()
+
+	// Build both living and dead icons
+	var/dead_state = target.icon_dead || target.icon_state
+	var/living_state = target.icon_living || target.icon_state
+	dead_icon = icon(target.icon, dead_state, SOUTH)
+	living_icon = icon(target.icon, living_state, SOUTH)
+	dead_base64 = icon2base64(dead_icon)
+	living_base64 = icon2base64(living_icon)
+	has_both_sprites = (dead_state != living_state)
+
+	// Default to dead sprite
+	set_source_icon(dead_icon, dead_base64)
+
+/// Rebuild opaque pixel data from the given icon
+/datum/carve_body_editor/proc/set_source_icon(icon/I, base64)
+	source_icon = I
+	source_width = I.Width()
+	source_height = I.Height()
+	source_base64 = base64
+
+	opaque_pixels = list()
+	opaque_set = list()
+	for(var/by in 1 to source_height)
+		for(var/bx in 1 to source_width)
+			if(I.GetPixel(bx, by))
+				var/tx = bx - 1
+				var/ty = source_height - by
+				opaque_pixels += list(list("x" = tx, "y" = ty))
+				opaque_set["[tx],[ty]"] = TRUE
+
+/datum/carve_body_editor/Destroy()
+	target_mob = null
+	artist = null
+	source_icon = null
+	living_icon = null
+	dead_icon = null
+	return ..()
+
+/datum/carve_body_editor/ui_state(mob/user)
+	return GLOB.conscious_state
+
+/datum/carve_body_editor/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "CarveBodyEditor")
+		ui.open()
+
+/datum/carve_body_editor/ui_static_data(mob/user)
+	var/list/data = list()
+	data["mobName"] = target_mob.name
+	data["hasBothSprites"] = has_both_sprites
+	return data
+
+/datum/carve_body_editor/ui_data(mob/user)
+	var/list/data = list()
+	data["sourceBase64"] = source_base64
+	data["sourceWidth"] = source_width
+	data["sourceHeight"] = source_height
+	data["opaquePixels"] = opaque_pixels
+	data["usingLiving"] = using_living
+
+	var/list/sel_list = list()
+	for(var/key in selected_pixels)
+		var/list/coords = splittext(key, ",")
+		sel_list += list(list(
+			"x" = text2num(coords[1]),
+			"y" = text2num(coords[2])
+		))
+	data["selectedPixels"] = sel_list
+	data["sections"] = get_sections()
+	return data
+
+/datum/carve_body_editor/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	if(.)
+		return
+
+	switch(action)
+		if("toggle_pixels")
+			var/list/pixels = params["pixels"]
+			var/mode = params["mode"]
+			if(!islist(pixels))
+				return
+			for(var/list/px in pixels)
+				var/x = text2num(px["x"])
+				var/y = text2num(px["y"])
+				if(!isnum(x) || !isnum(y))
+					continue
+				var/key = "[x],[y]"
+				if(!opaque_set[key])
+					continue
+				if(mode == "select")
+					selected_pixels[key] = TRUE
+				else
+					selected_pixels -= key
+			. = TRUE
+
+		if("clear_selection")
+			selected_pixels = list()
+			. = TRUE
+
+		if("switch_sprite")
+			using_living = !using_living
+			selected_pixels = list()
+			if(using_living)
+				set_source_icon(living_icon, living_base64)
+			else
+				set_source_icon(dead_icon, dead_base64)
+			. = TRUE
+
+		if("carve_out")
+			do_carve()
+			. = TRUE
+
+/// BFS flood fill to find contiguous groups of selected pixels
+/datum/carve_body_editor/proc/get_sections()
+	var/list/sections = list()
+	var/list/visited = list()
+	var/list/dirs = list(list(1, 0), list(-1, 0), list(0, 1), list(0, -1))
+
+	for(var/key in selected_pixels)
+		if(visited[key])
+			continue
+
+		var/list/section_pixels = list()
+		var/list/queue = list(key)
+		visited[key] = TRUE
+
+		while(length(queue))
+			var/current = queue[1]
+			queue.Cut(1, 2)
+			var/list/coords = splittext(current, ",")
+			var/cx = text2num(coords[1])
+			var/cy = text2num(coords[2])
+			section_pixels += list(list("x" = cx, "y" = cy))
+
+			for(var/list/d in dirs)
+				var/nkey = "[cx + d[1]],[cy + d[2]]"
+				if(selected_pixels[nkey] && !visited[nkey])
+					visited[nkey] = TRUE
+					queue += nkey
+
+		sections += list(list(
+			"pixels" = section_pixels,
+			"size" = length(section_pixels),
+			"valid" = length(section_pixels) >= 8
+		))
+
+	return sections
+
+/// Create carved pieces from valid sections and gib the mob
+/datum/carve_body_editor/proc/do_carve()
+	var/list/sections = get_sections()
+	var/has_valid = FALSE
+	for(var/list/section in sections)
+		if(section["valid"])
+			has_valid = TRUE
+			break
+
+	if(!has_valid)
+		to_chat(artist, span_warning("You need at least one group of 8 or more connected pixels to carve."))
+		return
+
+	if(!target_mob || target_mob.stat != DEAD)
+		to_chat(artist, span_warning("The creature is no longer available."))
+		return
+
+	if(!do_after(artist, 3 SECONDS, target_mob))
+		to_chat(artist, span_warning("You were interrupted!"))
+		return
+
+	var/target_turf = get_turf(target_mob)
+	var/carved_count = 0
+
+	for(var/list/section in sections)
+		if(!section["valid"])
+			continue
+		var/obj/item/carved_piece/piece = new(target_turf)
+		piece.setup_from_pixels(source_icon, section["pixels"], target_mob.name)
+		carved_count++
+
+	to_chat(artist, span_nicegreen("You carefully carve [carved_count] piece\s from [target_mob]."))
+	playsound(target_mob, 'sound/effects/splat.ogg', 50, TRUE)
+
+	var/datum/component/artistic_exp/exp_comp = artist.GetComponent(/datum/component/artistic_exp)
+	if(exp_comp)
+		exp_comp.add_activity_exp("create_artwork")
+
+	target_mob.gib()
+	SStgui.close_uis(src)
+	qdel(src)
 

--- a/ModularLobotomy/ring/structures/corporist_artwork.dm
+++ b/ModularLobotomy/ring/structures/corporist_artwork.dm
@@ -1,6 +1,21 @@
 // Corporist Artwork System
 // Artworks created by The Ring's Corporist school from flesh and bone
 
+// ================== ARTIST'S TOOLKIT ==================
+
+/obj/item/storage/box/corporist_toolkit
+	name = "artist's toolkit"
+	desc = "A box containing the essential tools of the Corporist trade."
+	icon_state = "secbox"
+	illustration = null
+
+/obj/item/storage/box/corporist_toolkit/PopulateContents()
+	new /obj/item/shears(src)
+	new /obj/item/reagent_containers/syringe(src)
+	new /obj/item/reagent_containers/blood(src)
+	new /obj/item/reagent_containers/blood(src)
+	new /obj/item/wrench(src)
+
 /obj/structure/corporist_artwork
 	name = "crude sculpture"
 	desc = "A basic arrangement of flesh and bone. The artist's vision is barely visible."
@@ -198,18 +213,23 @@
 /// Adding bodyparts by hitting the artwork
 /obj/structure/corporist_artwork/attackby(obj/item/I, mob/living/user, params)
 	// Check if it's a spray bottle - vandalism!
-	if(istype(I, /obj/item/reagent_containers/spray))
+	if(istype(I, /obj/item/reagent_containers/spray) || istype(I, /obj/item/toy/crayon))
 		if(vandalized)
 			to_chat(user, span_warning("This artwork has already been vandalized."))
 			return
 
-		to_chat(user, span_warning("You begin spraying black paint over the artwork..."))
+		if(istype(I, /obj/item/toy/crayon/spraycan))
+			to_chat(user, span_warning("You begin spraying graffiti over the artwork..."))
+		else if(istype(I, /obj/item/reagent_containers/spray))
+			to_chat(user, span_warning("You begin spraying paint over the artwork..."))
+		else
+			to_chat(user, span_warning("You begin scrawling over the artwork..."))
 
 		if(!do_after(user, 3 SECONDS, src))
 			to_chat(user, span_warning("You were interrupted!"))
 			return
 
-		vandalize_artwork(user)
+		vandalize_artwork(user, I)
 		return
 
 	// Check if it's a bodypart
@@ -229,25 +249,27 @@
 	return ..()
 
 /// Vandalize the artwork with spray paint - ruins technique and turns it black
-/obj/structure/corporist_artwork/proc/vandalize_artwork(mob/user)
+/obj/structure/corporist_artwork/proc/vandalize_artwork(mob/user, obj/item/tool)
 	vandalized = TRUE
 
-	// Ruin the technique grade
 	technique_grade = "F"
-	technique_scores = list(1) // Reset to just an F score
+	technique_scores = list(1)
 
-	// Turn the artwork black
 	add_atom_colour("#1a1a1a", FIXED_COLOUR_PRIORITY)
-
-	// Update description to reflect vandalism
-	desc = "This artwork has been defaced with black spray paint. The original craftsmanship is ruined."
-
 	playsound(src, 'sound/effects/spray.ogg', 50, TRUE)
-	to_chat(user, span_boldwarning("You vandalize the artwork, ruining its technique!"))
 
-	// Visible message for others
-	if(user)
-		visible_message(span_warning("[user] sprays black paint all over [src]!"), ignored_mobs = list(user))
+	if(istype(tool, /obj/item/toy/crayon/spraycan))
+		desc = "This artwork has been covered in spray-painted graffiti. The original craftsmanship is ruined."
+		to_chat(user, span_boldwarning("You tag the artwork with graffiti, ruining its technique!"))
+		visible_message(span_warning("[user] sprays graffiti all over [src]!"), ignored_mobs = list(user))
+	else if(istype(tool, /obj/item/toy/crayon))
+		desc = "This artwork has been scrawled over with crayon. The original craftsmanship is ruined."
+		to_chat(user, span_boldwarning("You deface the artwork with crayon, ruining its technique!"))
+		visible_message(span_warning("[user] scrawls all over [src] with a crayon!"), ignored_mobs = list(user))
+	else
+		desc = "This artwork has been defaced with spray paint. The original craftsmanship is ruined."
+		to_chat(user, span_boldwarning("You vandalize the artwork, ruining its technique!"))
+		visible_message(span_warning("[user] sprays paint all over [src]!"), ignored_mobs = list(user))
 
 /// Wrench to anchor/unanchor the artwork
 /obj/structure/corporist_artwork/wrench_act(mob/living/user, obj/item/I)
@@ -700,12 +722,17 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 	return TRUE
 
 /obj/structure/custom_corporist_artwork/attackby(obj/item/I, mob/living/user, params)
-	if(istype(I, /obj/item/reagent_containers/spray))
+	if(istype(I, /obj/item/reagent_containers/spray) || istype(I, /obj/item/toy/crayon))
 		if(vandalized)
 			to_chat(user, span_warning("This artwork has already been vandalized."))
 			return
 
-		to_chat(user, span_warning("You begin spraying black paint over the artwork..."))
+		if(istype(I, /obj/item/toy/crayon/spraycan))
+			to_chat(user, span_warning("You begin spraying graffiti over the artwork..."))
+		else if(istype(I, /obj/item/reagent_containers/spray))
+			to_chat(user, span_warning("You begin spraying paint over the artwork..."))
+		else
+			to_chat(user, span_warning("You begin scrawling over the artwork..."))
 
 		if(!do_after(user, 3 SECONDS, src))
 			to_chat(user, span_warning("You were interrupted!"))
@@ -713,10 +740,19 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 
 		vandalized = TRUE
 		add_atom_colour("#1a1a1a", FIXED_COLOUR_PRIORITY)
-		desc = "This artwork has been defaced with black spray paint."
+		if(istype(I, /obj/item/toy/crayon/spraycan))
+			desc = "This artwork has been covered in spray-painted graffiti."
+			to_chat(user, span_boldwarning("You tag the artwork with graffiti!"))
+			visible_message(span_warning("[user] sprays graffiti all over [src]!"), ignored_mobs = list(user))
+		else if(istype(I, /obj/item/reagent_containers/spray))
+			desc = "This artwork has been defaced with spray paint."
+			to_chat(user, span_boldwarning("You vandalize the artwork!"))
+			visible_message(span_warning("[user] sprays paint all over [src]!"), ignored_mobs = list(user))
+		else
+			desc = "This artwork has been scrawled over with crayon."
+			to_chat(user, span_boldwarning("You deface the artwork with crayon!"))
+			visible_message(span_warning("[user] scrawls all over [src] with a crayon!"), ignored_mobs = list(user))
 		playsound(src, 'sound/effects/spray.ogg', 50, TRUE)
-		to_chat(user, span_boldwarning("You vandalize the artwork!"))
-		visible_message(span_warning("[user] sprays black paint all over [src]!"), ignored_mobs = list(user))
 		return
 
 	if(istype(I, /obj/item/reagent_containers))
@@ -751,6 +787,15 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 
 		var/obj/item/carved_piece/CP = I
 		add_carved_piece(CP, user)
+		return
+
+	if(istype(I, /obj/item/organ))
+		if(!is_corporist_artist(user))
+			to_chat(user, span_warning("You have no idea how to incorporate this into the artwork."))
+			return
+
+		var/obj/item/organ/O = I
+		add_organ_custom(O, user)
 		return
 
 	return ..()
@@ -817,6 +862,40 @@ GLOBAL_LIST_EMPTY(bodypart_icon_cache)
 		CP.forceMove(src)
 	else
 		CP.forceMove(src)
+
+	var/datum/component/artistic_exp/exp_comp = user.GetComponent(/datum/component/artistic_exp)
+	if(exp_comp)
+		exp_comp.add_activity_exp("add_body")
+
+	if(editor)
+		SStgui.update_static_data(user, editor)
+
+/// Add an organ to the custom artwork's storage
+/obj/structure/custom_corporist_artwork/proc/add_organ_custom(obj/item/organ/O, mob/user)
+	var/part_id = "[next_part_id]"
+	next_part_id++
+
+	var/use_icon = "[initial(O.icon)]"
+	var/use_state = O.icon_state || initial(O.icon_state)
+	var/list/crop = get_icon_crop_bounds(file(use_icon), use_state)
+	stored_parts[part_id] = list(
+		"body_zone" = "organ_[O.name]",
+		"icon_file" = use_icon,
+		"icon_state" = use_state,
+		"crop_ox" = crop["ox"],
+		"crop_oy" = crop["oy"],
+		"crop_w" = crop["w"],
+		"crop_h" = crop["h"]
+	)
+
+	body_part_count++
+	to_chat(user, span_nicegreen("You incorporate the [O.name] into the artwork's collection."))
+	playsound(src, 'sound/effects/splat.ogg', 50, TRUE)
+
+	if(user.transferItemToLoc(O, src))
+		O.forceMove(src)
+	else
+		O.forceMove(src)
 
 	var/datum/component/artistic_exp/exp_comp = user.GetComponent(/datum/component/artistic_exp)
 	if(exp_comp)

--- a/ModularLobotomy/ring/structures/corporist_artwork.dm
+++ b/ModularLobotomy/ring/structures/corporist_artwork.dm
@@ -1,1 +1,500 @@
-// Stub - populated by the Ring sub-PR
+// Corporist Artwork System
+// Artworks created by The Ring's Corporist school from flesh and bone
+
+/obj/structure/corporist_artwork
+	name = "crude sculpture"
+	desc = "A basic arrangement of flesh and bone. The artist's vision is barely visible."
+	icon = 'icons/mob/blob.dmi'
+	icon_state = "still_blobpod"
+	anchored = TRUE
+	density = FALSE
+	can_buckle = TRUE
+	buckle_lying = 0
+	max_integrity = 200
+
+	/// Icon files for each tier
+	var/static/list/tier_icons = list(
+		'icons/mob/blob.dmi',                              // Tier 1
+		'icons/mob/cult.dmi',                              // Tier 2
+		'ModularLobotomy/_Lobotomyicons/32x32.dmi',        // Tier 3
+		'ModularLobotomy/_Lobotomyicons/32x48.dmi',        // Tier 4
+		'ModularLobotomy/_Lobotomyicons/48x48.dmi',        // Tier 5
+		'ModularLobotomy/_Lobotomyicons/64x96.dmi'         // Tier 6 (hidden)
+	)
+	/// Icon states for each tier
+	var/static/list/tier_icon_states = list(
+		"still_blobpod",    // Tier 1
+		"meat_bomb",        // Tier 2
+		"meatboi",          // Tier 3
+		"meatboi_rifle",    // Tier 4
+		"last_shot",        // Tier 5
+		"flesh_idol"        // Tier 6 (hidden)
+	)
+	/// Pixel X offset for each tier (for larger sprites)
+	var/static/list/tier_pixel_x = list(0, 0, 0, 0, -8, -16)
+
+	/// Current tier of the artwork (1-6)
+	var/tier = 1
+	/// Number of materials used for tier calculation (bodyparts + simple creatures)
+	var/materials_count = 0
+	/// List tracking bodypart types used - e.g., list("head" = 2, "chest" = 1, "l_arm" = 3)
+	var/list/bodyparts_used = list()
+	/// List tracking simple creatures incorporated - e.g., list("mouse" = 2, "chicken" = 1)
+	var/list/simple_creatures_used = list()
+	/// Reference to the mob who created this artwork
+	var/datum/weakref/creator_ref
+	/// Whether the artwork needs refinement before more bodies can be added
+	var/needs_refinement = FALSE
+	/// Custom description set by the artist
+	var/custom_desc
+	/// Technique grade from refinement minigame (F/C/B/A/S) - calculated as average of all minigames
+	var/technique_grade
+	/// List of all technique scores from minigames (stored as numbers for averaging)
+	var/list/technique_scores = list()
+	/// Final grade from Maestro (F/C/B/A/S)
+	var/final_grade
+	/// Maestro's critique text
+	var/final_grade_critique
+	/// Reference to Maestro who graded it
+	var/datum/weakref/graded_by_ref
+
+	/// SP damage dealt to non-artists on examine (scales with tier)
+	var/list/examine_sp_damage = list(5, 10, 15, 25, 40, 60)
+	/// SP healed for artists on examine (scales with tier)
+	var/list/examine_sp_heal = list(3, 6, 10, 15, 25, 40)
+	/// Whether the artwork has been vandalized with spray paint
+	var/vandalized = FALSE
+
+/obj/structure/corporist_artwork/Initialize(mapload, mob/creator)
+	. = ..()
+	if(creator)
+		creator_ref = WEAKREF(creator)
+	update_icon()
+
+/obj/structure/corporist_artwork/examine(mob/user)
+	. = ..()
+
+	// Show custom description or default
+	if(custom_desc)
+		. += span_notice("\"[custom_desc]\"")
+
+	// Show bodyparts used
+	if(length(bodyparts_used))
+		var/parts_text = ""
+		for(var/part_type in bodyparts_used)
+			if(parts_text != "")
+				parts_text += ", "
+			parts_text += "[bodyparts_used[part_type]]x [part_type]"
+		. += span_notice("Incorporated remains: [parts_text]")
+
+	// Show simple creatures used
+	if(length(simple_creatures_used))
+		var/creatures_text = ""
+		for(var/creature_name in simple_creatures_used)
+			if(creatures_text != "")
+				creatures_text += ", "
+			creatures_text += "[simple_creatures_used[creature_name]]x [creature_name]"
+		. += span_notice("Simple-minded creatures: [creatures_text]")
+
+	// Show final grade (visible to everyone)
+	if(final_grade)
+		var/grader_name = "Unknown"
+		var/mob/grader = graded_by_ref?.resolve()
+		if(grader)
+			grader_name = grader.name
+		. += span_purple("Final Grade: [final_grade][final_grade_critique ? " - '[final_grade_critique]'" : ""] - [grader_name]")
+	else
+		. += span_purple("Awaiting judgment.")
+
+	// Check if examiner can create art
+	var/is_artist = can_create_art(user)
+
+	// Show tier and technique grade (only to artists)
+	if(is_artist)
+		. += span_notice("Tier: [tier]/6 ([materials_count] materials)")
+		if(technique_grade)
+			var/technique_desc = get_technique_description(technique_grade)
+			. += span_notice("Technique: [technique_grade] - [technique_desc]")
+
+	// Show vandalism status
+	if(vandalized)
+		. += span_boldwarning("This artwork has been vandalized! Its technique has been ruined.")
+
+	// Show refinement status
+	if(needs_refinement)
+		. += span_warning("This artwork needs refinement before more can be added.")
+
+	// Apply SP effects based on viewer type
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(is_artist)
+			// Artists heal SP
+			var/heal_amount = examine_sp_heal[tier]
+			H.adjustSanityLoss(-heal_amount)
+			to_chat(user, span_nicegreen("You appreciate the craftsmanship. The artistic vision soothes your mind."))
+		else
+			// Non-artists take SP damage
+			var/damage_amount = examine_sp_damage[tier]
+			H.adjustSanityLoss(damage_amount)
+			to_chat(user, span_warning("The artwork disturbs you deeply. You feel your sanity slipping..."))
+
+/// Returns the technique grade description
+/obj/structure/corporist_artwork/proc/get_technique_description(grade)
+	switch(grade)
+		if("F")
+			return "The craftsmanship is crude and amateurish."
+		if("C")
+			return "Basic competence, but lacking refinement."
+		if("B")
+			return "Solid technique with clear artistic intent."
+		if("A")
+			return "Masterful technique, every cut deliberate."
+		if("S")
+			return "Transcendent skill that defies comprehension."
+	return "Unknown"
+
+/// Check if a mob can create/interact with art
+/obj/structure/corporist_artwork/proc/can_create_art(mob/user)
+	if(!ishuman(user))
+		return FALSE
+	var/mob/living/carbon/human/H = user
+
+	// Check for Maestro/Apprentice species
+	if(istype(H.dna?.species, /datum/species/corporist_maestro) || istype(H.dna?.species, /datum/species/corporist_apprentice))
+		return TRUE
+
+	// Check for Student or Inspired component
+	if(H.GetComponent(/datum/component/corporist_student) || H.GetComponent(/datum/component/inspired_artist))
+		return TRUE
+
+	return FALSE
+
+/// Clicking with empty hand to refine
+/obj/structure/corporist_artwork/attack_hand(mob/living/user, list/modifiers)
+	. = ..()
+	if(.)
+		return
+
+	if(!ishuman(user))
+		return
+
+	var/mob/living/carbon/human/H = user
+
+	// Check if they can create art
+	if(!can_create_art(H))
+		to_chat(H, span_notice("You examine the disturbing artwork..."))
+		return
+
+	// If it needs refinement, start the minigame
+	if(needs_refinement)
+		to_chat(H, span_notice("You begin refining the artwork..."))
+		var/datum/sculpting_minigame/minigame = new(H, src)
+		minigame.ui_interact(H)
+		return
+
+	// Otherwise just examine
+	to_chat(H, span_notice("The artwork is refined and ready for more materials or judgment."))
+
+/// Adding bodyparts by hitting the artwork
+/obj/structure/corporist_artwork/attackby(obj/item/I, mob/living/user, params)
+	// Check if it's a spray bottle - vandalism!
+	if(istype(I, /obj/item/reagent_containers/spray))
+		if(vandalized)
+			to_chat(user, span_warning("This artwork has already been vandalized."))
+			return
+
+		to_chat(user, span_warning("You begin spraying black paint over the artwork..."))
+
+		if(!do_after(user, 3 SECONDS, src))
+			to_chat(user, span_warning("You were interrupted!"))
+			return
+
+		vandalize_artwork(user)
+		return
+
+	// Check if it's a bodypart
+	if(istype(I, /obj/item/bodypart))
+		if(!can_create_art(user))
+			to_chat(user, span_warning("You have no idea how to incorporate this into the artwork."))
+			return
+
+		if(needs_refinement)
+			to_chat(user, span_warning("The artwork needs refinement before more can be added."))
+			return
+
+		var/obj/item/bodypart/BP = I
+		add_bodypart(BP, user)
+		return
+
+	return ..()
+
+/// Vandalize the artwork with spray paint - ruins technique and turns it black
+/obj/structure/corporist_artwork/proc/vandalize_artwork(mob/user)
+	vandalized = TRUE
+
+	// Ruin the technique grade
+	technique_grade = "F"
+	technique_scores = list(1) // Reset to just an F score
+
+	// Turn the artwork black
+	add_atom_colour("#1a1a1a", FIXED_COLOUR_PRIORITY)
+
+	// Update description to reflect vandalism
+	desc = "This artwork has been defaced with black spray paint. The original craftsmanship is ruined."
+
+	playsound(src, 'sound/effects/spray.ogg', 50, TRUE)
+	to_chat(user, span_boldwarning("You vandalize the artwork, ruining its technique!"))
+
+	// Visible message for others
+	if(user)
+		visible_message(span_warning("[user] sprays black paint all over [src]!"), ignored_mobs = list(user))
+
+/// Wrench to anchor/unanchor the artwork
+/obj/structure/corporist_artwork/wrench_act(mob/living/user, obj/item/I)
+	. = ..()
+	if(anchored)
+		to_chat(user, span_notice("You begin loosening the bolts on [src]..."))
+	else
+		to_chat(user, span_notice("You begin securing [src] to the floor..."))
+
+	if(!do_after(user, 2 SECONDS, src))
+		to_chat(user, span_warning("You were interrupted!"))
+		return TRUE
+
+	anchored = !anchored
+	if(anchored)
+		to_chat(user, span_notice("You secure [src] to the floor."))
+	else
+		to_chat(user, span_notice("You unanchor [src] from the floor."))
+	playsound(src, 'sound/items/ratchet.ogg', 50, TRUE)
+	return TRUE
+
+/// Add a bodypart to the artwork
+/obj/structure/corporist_artwork/proc/add_bodypart(obj/item/bodypart/BP, mob/user)
+	to_chat(user, span_notice("You begin incorporating the [BP.name] into your work..."))
+
+	if(!do_after(user, 3 SECONDS, src))
+		to_chat(user, span_warning("You were interrupted!"))
+		return
+
+	// Track the bodypart type
+	var/part_type = BP.body_zone
+	if(!bodyparts_used[part_type])
+		bodyparts_used[part_type] = 0
+	bodyparts_used[part_type]++
+
+	materials_count++
+	needs_refinement = TRUE
+
+	to_chat(user, span_nicegreen("You carefully incorporate the [BP.name] into the artwork."))
+	playsound(src, 'sound/effects/splat.ogg', 50, TRUE)
+
+	// Store the bodypart inside the artwork
+	if(user.transferItemToLoc(BP, src))
+		BP.forceMove(src)
+	else
+		BP.forceMove(src)
+
+	// Add EXP for adding a body part
+	var/datum/component/artistic_exp/exp_comp = user.GetComponent(/datum/component/artistic_exp)
+	if(exp_comp)
+		exp_comp.add_activity_exp("add_body")
+
+	check_tier_upgrade()
+	update_icon()
+
+/// Buckle a dead mob to add its corpse
+/obj/structure/corporist_artwork/user_buckle_mob(mob/living/M, mob/user, check_loc = TRUE)
+	if(!can_create_art(user))
+		to_chat(user, span_warning("You have no idea how to incorporate this into the artwork."))
+		return FALSE
+
+	if(M.stat != DEAD)
+		to_chat(user, span_warning("The subject must be dead first."))
+		return FALSE
+
+	if(!istype(M, /mob/living/simple_animal))
+		to_chat(user, span_warning("Only simple creatures can be incorporated into artwork."))
+		return FALSE
+
+	if(needs_refinement)
+		to_chat(user, span_warning("The artwork needs refinement before more can be added."))
+		return FALSE
+
+	to_chat(user, span_notice("You begin incorporating [M]'s remains into the artwork..."))
+
+	if(!do_after(user, 5 SECONDS, src))
+		to_chat(user, span_warning("You were interrupted!"))
+		return FALSE
+
+	add_corpse(M, user)
+	return TRUE
+
+/// Calculate material contribution based on mob's max health
+/obj/structure/corporist_artwork/proc/get_health_contribution(mob/living/M)
+	var/mob_health = M.maxHealth
+	if(mob_health >= 4000)
+		return 6
+	if(mob_health >= 2000)
+		return 5
+	if(mob_health >= 1500)
+		return 4
+	if(mob_health >= 1000)
+		return 3
+	if(mob_health >= 500)
+		return 2
+	if(mob_health >= 100)
+		return 1
+	return 1 // Minimum contribution
+
+/// Add a full corpse to the artwork
+/obj/structure/corporist_artwork/proc/add_corpse(mob/living/simple_animal/M, mob/user)
+	// Track the creature by name
+	var/creature_name = M.name
+	if(!simple_creatures_used[creature_name])
+		simple_creatures_used[creature_name] = 0
+	simple_creatures_used[creature_name]++
+
+	// Creatures contribute based on their max health
+	var/contribution = get_health_contribution(M)
+	materials_count += contribution
+	needs_refinement = TRUE
+
+	to_chat(user, span_nicegreen("You incorporate [M]'s remains into the artwork."))
+	playsound(src, 'sound/effects/splat.ogg', 50, TRUE)
+
+	// Gib the corpse dramatically
+	M.gib()
+
+	check_tier_upgrade()
+	update_icon()
+
+/// Check if the artwork should upgrade to a higher tier
+/obj/structure/corporist_artwork/proc/check_tier_upgrade()
+	var/new_tier = 1
+	if(materials_count >= 60)
+		new_tier = 6
+	else if(materials_count >= 27)
+		new_tier = 5
+	else if(materials_count >= 19)
+		new_tier = 4
+	else if(materials_count >= 12)
+		new_tier = 3
+	else if(materials_count >= 5)
+		new_tier = 2
+
+	if(new_tier > tier)
+		tier = new_tier
+		update_tier_appearance()
+
+/// Update appearance based on tier
+/obj/structure/corporist_artwork/proc/update_tier_appearance()
+	icon = tier_icons[tier]
+	icon_state = tier_icon_states[tier]
+	pixel_x = tier_pixel_x[tier]
+	switch(tier)
+		if(1)
+			name = "crude sculpture"
+			desc = "A basic arrangement of flesh and bone. The artist's vision is barely visible."
+		if(2)
+			name = "developing piece"
+			desc = "Multiple forms intertwined. The artwork begins to take shape."
+		if(3)
+			name = "refined work"
+			desc = "A disturbing yet captivating arrangement. Clear artistic intent."
+			density = TRUE
+		if(4)
+			name = "masterpiece"
+			desc = "A horrifying opus of flesh and bone. Those who gaze upon it feel... something."
+			density = TRUE
+		if(5)
+			name = "opus"
+			desc = "A transcendent work of corporeal art. It seems almost alive."
+			density = TRUE
+		if(6)
+			name = "magnum opus"
+			desc = "A towering monument of flesh and bone that seems to pulse with unnatural life. Those who behold it are forever changed."
+			density = TRUE
+
+/// Convert letter grade to numeric value for averaging
+/obj/structure/corporist_artwork/proc/grade_to_number(grade)
+	switch(grade)
+		if("F")
+			return 1
+		if("C")
+			return 2
+		if("B")
+			return 3
+		if("A")
+			return 4
+		if("S")
+			return 5
+	return 1
+
+/// Convert numeric average to letter grade
+/obj/structure/corporist_artwork/proc/number_to_grade(value)
+	if(value >= 4.5)
+		return "S"
+	if(value >= 3.5)
+		return "A"
+	if(value >= 2.5)
+		return "B"
+	if(value >= 1.5)
+		return "C"
+	return "F"
+
+/// Called when refinement is completed
+/obj/structure/corporist_artwork/proc/complete_refinement(grade)
+	// Add this grade to the list and calculate the average
+	technique_scores += grade_to_number(grade)
+
+	var/total = 0
+	for(var/score in technique_scores)
+		total += score
+	var/average = total / length(technique_scores)
+	technique_grade = number_to_grade(average)
+
+	needs_refinement = FALSE
+	to_chat(get_turf(src), span_notice("The artwork has been refined. This session: [grade] | Overall: [technique_grade]"))
+
+/// Called when Maestro assigns a final grade
+/obj/structure/corporist_artwork/proc/assign_final_grade(mob/grader, grade, critique)
+	final_grade = grade
+	final_grade_critique = critique
+	graded_by_ref = WEAKREF(grader)
+
+	// Find the creator and apply EXP effects
+	var/mob/creator = creator_ref?.resolve()
+	if(creator && ishuman(creator))
+		apply_grade_exp(creator, grade)
+
+/// Apply EXP gain/loss based on grade
+/obj/structure/corporist_artwork/proc/apply_grade_exp(mob/living/carbon/human/artist, grade)
+	var/datum/component/artistic_exp/exp_comp = artist.GetComponent(/datum/component/artistic_exp)
+	if(!exp_comp)
+		return
+
+	// Record the grade for round end tracking
+	exp_comp.record_grade(grade)
+
+	var/next_threshold = exp_comp.get_next_threshold()
+	var/exp_change = 0
+
+	switch(grade)
+		if("F")
+			exp_change = -round(next_threshold * 0.5)
+			to_chat(artist, span_boldwarning("Your work has been judged harshly. You lose artistic experience."))
+		if("C")
+			exp_change = -round(next_threshold * 0.25)
+			to_chat(artist, span_warning("Your work was deemed mediocre. You lose some artistic experience."))
+		if("B")
+			exp_change = round(next_threshold * 0.25)
+			to_chat(artist, span_notice("Your work was judged favorably. You gain artistic experience."))
+		if("A")
+			exp_change = round(next_threshold * 0.5)
+			to_chat(artist, span_nicegreen("Your work was deemed excellent! You gain significant artistic experience."))
+		if("S")
+			exp_change = next_threshold
+			to_chat(artist, span_greentext("Your work is a masterpiece! You gain a full skill point worth of experience!"))
+
+	exp_comp.modify_exp(exp_change)

--- a/code/modules/clothing/suits/ego_gear/non_abnormality/ring.dm
+++ b/code/modules/clothing/suits/ego_gear/non_abnormality/ring.dm
@@ -74,12 +74,34 @@
 	var/datum/action/spell_action/ability/item/A = AS.action
 	A.SetItem(src)
 
+/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/Destroy()
+	remove_phase1_weapon()
+	remove_phase2_weapon()
+	remove_reforge_action()
+	if(iron_curtain)
+		deactivate_iron_curtain()
+	bound_spirit = null
+	ClearWearer()
+	return ..()
+
 /obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/equipped(mob/user, slot)
 	. = ..()
 	if(slot == ITEM_SLOT_OCLOTHING && ishuman(user))
 		armor_wearer = user
 		RegisterSignal(user, COMSIG_MOB_APPLY_DAMGE, PROC_REF(on_damage_reflect))
 		RegisterSignal(user, COMSIG_MOB_AFTER_APPLY_DAMGE, PROC_REF(on_wearer_damaged))
+		RegisterSignal(user, COMSIG_PARENT_QDELETING, PROC_REF(on_wearer_deleted))
+
+/// Drops the wearer reference along with the signals that depend on it
+/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/proc/ClearWearer()
+	if(!armor_wearer)
+		return
+	UnregisterSignal(armor_wearer, list(COMSIG_MOB_APPLY_DAMGE, COMSIG_MOB_AFTER_APPLY_DAMGE, COMSIG_PARENT_QDELETING))
+	armor_wearer = null
+
+/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/proc/on_wearer_deleted(datum/source)
+	SIGNAL_HANDLER
+	ClearWearer()
 
 /obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/relaymove(mob/living/user, direction)
 	return //stops buckled message spam for the spirit
@@ -87,7 +109,6 @@
 /obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/dropped(mob/user)
 	. = ..()
 	if(armor_wearer)
-		UnregisterSignal(armor_wearer, list(COMSIG_MOB_APPLY_DAMGE, COMSIG_MOB_AFTER_APPLY_DAMGE))
 		remove_phase1_weapon()
 		remove_phase2_weapon()
 		if(iron_curtain)
@@ -95,10 +116,10 @@
 		if(phase == 2)
 			armor_wearer.remove_movespeed_modifier(/datum/movespeed_modifier/iron_maiden_fractured)
 		remove_reforge_action()
-		// Spirit is already sheltered by remove_phase1/2_weapon — keep it safe in the armor
+		// Spirit is already sheltered by remove_phase1/2_weapon - keep it safe in the armor
 		if(bound_spirit)
 			to_chat(bound_spirit, span_notice("The armor is removed. You remain sheltered within, waiting..."))
-		armor_wearer = null
+		ClearWearer()
 		// Reset to phase 1
 		phase = 1
 		icon_state = "ring_apprentice"
@@ -168,7 +189,7 @@
 	remove_phase1_weapon()
 	if(armor_wearer && !phase2_weapon)
 		phase2_weapon = new /obj/item/ego_weapon/city/ring/fascia_unleashed
-		phase2_weapon.linked_armor = src
+		phase2_weapon.LinkArmor(src)
 		if(!armor_wearer.put_in_hands(phase2_weapon))
 			QDEL_NULL(phase2_weapon)
 			to_chat(armor_wearer, span_warning("You need a free hand for the transformation!"))
@@ -195,7 +216,7 @@
 
 	if(phase == 2)
 		phase2_weapon = new /obj/item/ego_weapon/city/ring/fascia_unleashed
-		phase2_weapon.linked_armor = src
+		phase2_weapon.LinkArmor(src)
 		if(!user.put_in_hands(phase2_weapon))
 			QDEL_NULL(phase2_weapon)
 			to_chat(user, span_warning("You need a free hand to summon the weapon!"))
@@ -205,7 +226,7 @@
 			grant_spirit_to_weapon(phase2_weapon)
 	else
 		phase1_weapon = new /obj/item/ego_weapon/city/ring/fascia
-		phase1_weapon.linked_armor = src
+		phase1_weapon.LinkArmor(src)
 		if(!user.put_in_hands(phase1_weapon))
 			QDEL_NULL(phase1_weapon)
 			to_chat(user, span_warning("You need a free hand to summon the weapon!"))
@@ -371,7 +392,7 @@
 	remove_phase2_weapon()
 	if(armor_wearer && !phase1_weapon)
 		phase1_weapon = new /obj/item/ego_weapon/city/ring/fascia
-		phase1_weapon.linked_armor = src
+		phase1_weapon.LinkArmor(src)
 		if(!armor_wearer.put_in_hands(phase1_weapon))
 			QDEL_NULL(phase1_weapon)
 			to_chat(armor_wearer, span_warning("You need a free hand to reform the weapon!"))

--- a/code/modules/clothing/suits/ego_gear/non_abnormality/ring.dm
+++ b/code/modules/clothing/suits/ego_gear/non_abnormality/ring.dm
@@ -1,1 +1,497 @@
-// Stub - populated by the Ring sub-PR
+// The Ring - Syndicate of Artists
+// Corporist School - Utilizes interaction between human bones and muscles
+// "Those who utilize the interaction between human bones and muscles, and the contraction and elongation thereof."
+
+/obj/item/clothing/suit/armor/ego_gear/city/ring_maestro
+	name = "corporist maestro garb"
+	desc = "Draped white robes with a gilded trim worn by a Maestro of the Corporist school."
+	icon = 'icons/obj/spider_house/ring/ring_icons.dmi'
+	worn_icon = 'icons/obj/spider_house/ring/ring_maestro_worn.dmi'
+	icon_state = "ring_maestro"
+	worn_x_dimension = 48
+	worn_y_dimension = 48
+	clothing_flags = LARGE_WORN_ICON
+	hat = /obj/item/clothing/head/ego_hat/ring_maestro
+	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 50, BLACK_DAMAGE = 60, PALE_DAMAGE = 40)
+	attribute_requirements = list(
+		FORTITUDE_ATTRIBUTE = 100,
+		PRUDENCE_ATTRIBUTE = 100,
+		TEMPERANCE_ATTRIBUTE = 100,
+		JUSTICE_ATTRIBUTE = 100
+	)
+
+/obj/item/clothing/head/ego_hat/ring_maestro
+	name = "corporist maestro hat"
+	desc = "A large-brimmed hat featuring a litany of holes through its brim. A signature piece of a Corporist Maestro's attire."
+	icon = 'icons/obj/spider_house/ring/ring_icons.dmi'
+	worn_icon = 'icons/obj/spider_house/ring/ring_maestro_worn.dmi'
+	icon_state = "ring_maestro_hat"
+	worn_x_dimension = 48
+	worn_y_dimension = 48
+	clothing_flags = LARGE_WORN_ICON
+
+// Iron Maiden Armor - Two-phase armor that summons the Fascia weapon
+// Phase 1 (Defensive): Reflects damage back on attackers and inflicts bleed. Weapon has Iron Curtain ability.
+// Phase 2 (Offensive, <50% HP): Armor becomes invisible, weapon transforms into a leap-based attacker.
+/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice
+	name = "iron maiden armor"
+	desc = "Heavy white armor with bright yellow and golden highlights, featuring a faint iridescence. Spikes protrude from the lower dress-like half, and chains hang from thick bands at the elbows. Somewhat knightly in appearance. Grants the ability to summon the Fascia weapon."
+	icon_state = "ring_apprentice"
+	hat = /obj/item/clothing/head/ego_hat/helmet/ring_apprentice
+	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 40, BLACK_DAMAGE = 50, PALE_DAMAGE = 20)
+	slowdown = 0.75
+	attribute_requirements = list(
+		FORTITUDE_ATTRIBUTE = 80,
+		PRUDENCE_ATTRIBUTE = 80,
+		TEMPERANCE_ATTRIBUTE = 80,
+		JUSTICE_ATTRIBUTE = 80
+	)
+
+	/// Current armor phase (1 = defensive, 2 = offensive)
+	var/phase = 1
+	/// Phase 1 weapon reference
+	var/obj/item/ego_weapon/city/ring/fascia/phase1_weapon
+	/// Phase 2 weapon reference
+	var/obj/item/ego_weapon/city/ring/fascia_unleashed/phase2_weapon
+	/// Current wearer
+	var/mob/living/carbon/human/armor_wearer
+	/// Whether Iron Curtain mode is active (multiplies reflect damage)
+	var/iron_curtain = FALSE
+	/// Timer ID for Iron Curtain deactivation
+	var/iron_curtain_timer_id
+	/// Cooldown before phase 2 can trigger again after returning to phase 1 (world.time)
+	var/phase2_cooldown
+	/// Reference to the Reforge Iron Maiden action granted during phase 2
+	var/datum/action/cooldown/reforge_iron_maiden/reforge_action
+	/// Whether a ghost spirit inhabits the armor/weapon
+	var/possessed = FALSE
+	/// The spirit mob sheltered in the armor when no weapon is active
+	var/mob/living/simple_animal/fascia_spirit/bound_spirit
+
+/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/Initialize()
+	. = ..()
+	var/obj/effect/proc_holder/ability/AS = new /obj/effect/proc_holder/ability/ring_summon_fascia
+	var/datum/action/spell_action/ability/item/A = AS.action
+	A.SetItem(src)
+
+/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/equipped(mob/user, slot)
+	. = ..()
+	if(slot == ITEM_SLOT_OCLOTHING && ishuman(user))
+		armor_wearer = user
+		RegisterSignal(user, COMSIG_MOB_APPLY_DAMGE, PROC_REF(on_damage_reflect))
+		RegisterSignal(user, COMSIG_MOB_AFTER_APPLY_DAMGE, PROC_REF(on_wearer_damaged))
+
+/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/relaymove(mob/living/user, direction)
+	return //stops buckled message spam for the spirit
+
+/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/dropped(mob/user)
+	. = ..()
+	if(armor_wearer)
+		UnregisterSignal(armor_wearer, list(COMSIG_MOB_APPLY_DAMGE, COMSIG_MOB_AFTER_APPLY_DAMGE))
+		remove_phase1_weapon()
+		remove_phase2_weapon()
+		if(iron_curtain)
+			deactivate_iron_curtain()
+		if(phase == 2)
+			armor_wearer.remove_movespeed_modifier(/datum/movespeed_modifier/iron_maiden_fractured)
+		remove_reforge_action()
+		// Clean up spirit when armor is removed
+		if(bound_spirit)
+			to_chat(bound_spirit, span_userdanger("The armor is removed! You are cast out!"))
+			QDEL_NULL(bound_spirit)
+			possessed = FALSE
+		armor_wearer = null
+		// Reset to phase 1
+		phase = 1
+		icon_state = "ring_apprentice"
+		update_icon()
+
+/// Signal handler for COMSIG_MOB_APPLY_DAMGE - reflects damage back to attacker during phase 1
+/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/proc/on_damage_reflect(datum/source, damage, damagetype, def_zone, attack_source, flags, attack_type)
+	SIGNAL_HANDLER
+	if(phase != 1 || !armor_wearer)
+		return
+	if(!(attack_type & ATTACK_TYPE_MELEE))
+		return
+	if(!isliving(attack_source) || attack_source == armor_wearer)
+		return
+	INVOKE_ASYNC(src, PROC_REF(do_reflect_damage), attack_source, damage)
+
+/// Applies reflect damage and bleed to the attacker (called async from signal handler)
+/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/proc/do_reflect_damage(mob/living/attacker, damage)
+	if(QDELETED(attacker) || QDELETED(armor_wearer) || attacker.stat == DEAD)
+		return
+	var/reflect_damage = damage * 0.1
+	var/bleed_stacks = 2
+	if(iron_curtain)
+		reflect_damage *= 20
+		bleed_stacks = 4
+	attacker.deal_damage(reflect_damage, RED_DAMAGE, armor_wearer, attack_type = (ATTACK_TYPE_MELEE | ATTACK_TYPE_SPECIAL | ATTACK_TYPE_COUNTER))
+	attacker.apply_lc_bleed(bleed_stacks)
+
+/// Signal handler for COMSIG_MOB_AFTER_APPLY_DAMGE - checks if wearer drops below 50% HP for phase transition
+/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/proc/on_wearer_damaged(datum/source)
+	SIGNAL_HANDLER
+	if(phase != 1 || !armor_wearer)
+		return
+	if(phase2_cooldown > world.time)
+		return
+	if(armor_wearer.health <= (armor_wearer.maxHealth * 0.5))
+		INVOKE_ASYNC(src, PROC_REF(enter_phase2))
+
+/// Transitions the armor to phase 2 - armor becomes invisible, weapon transforms
+/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/proc/enter_phase2()
+	if(phase == 2)
+		return
+	phase = 2
+
+	// Deactivate Iron Curtain if active
+	if(iron_curtain)
+		deactivate_iron_curtain()
+
+	// Remove helmet if worn
+	if(armor_wearer)
+		var/obj/item/clothing/head/ego_hat/helmet/ring_apprentice/worn_helmet = armor_wearer.get_item_by_slot(ITEM_SLOT_HEAD)
+		if(istype(worn_helmet))
+			armor_wearer.dropItemToGround(worn_helmet, force = TRUE)
+			qdel(worn_helmet)
+			to_chat(armor_wearer, span_warning("The helmet shatters as the Iron Maiden fractures!"))
+
+	// Make armor invisible, reduce resistances, and apply speed boost
+	icon_state = null
+	src.armor = getArmor(red = 30, white = 40, black = 30, pale = 20)
+	update_icon()
+	if(armor_wearer)
+		armor_wearer.update_inv_wear_suit()
+		armor_wearer.add_movespeed_modifier(/datum/movespeed_modifier/iron_maiden_fractured)
+
+	// Transform weapon from phase 1 to phase 2
+	// remove_phase1_weapon() shelters any spirit into armor automatically
+	remove_phase1_weapon()
+	if(armor_wearer && !phase2_weapon)
+		phase2_weapon = new /obj/item/ego_weapon/city/ring/fascia_unleashed
+		phase2_weapon.linked_armor = src
+		if(!armor_wearer.put_in_hands(phase2_weapon))
+			QDEL_NULL(phase2_weapon)
+			to_chat(armor_wearer, span_warning("You need a free hand for the transformation!"))
+			return
+		// grant_spirit_to_weapon transfers spirit from armor to new weapon
+		if(bound_spirit)
+			grant_spirit_to_weapon(phase2_weapon)
+
+	// Grant the Reforge action
+	if(armor_wearer)
+		grant_reforge_action()
+
+	// Heal 15% max HP on fracture
+	if(armor_wearer)
+		var/heal_amount = round(armor_wearer.maxHealth * 0.15)
+		armor_wearer.adjustBruteLoss(-heal_amount)
+		to_chat(armor_wearer, span_userdanger("The Iron Maiden fractures! The Fascia transforms, revealing its true form! (+[heal_amount] HP)"))
+		playsound(get_turf(armor_wearer), 'sound/weapons/fixer/generic/finisher1.ogg', 50, 0, 4)
+
+/// Grants the appropriate weapon based on current phase
+/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/proc/grant_weapon(mob/living/carbon/human/user)
+	if(phase1_weapon || phase2_weapon)
+		return FALSE
+
+	if(phase == 2)
+		phase2_weapon = new /obj/item/ego_weapon/city/ring/fascia_unleashed
+		phase2_weapon.linked_armor = src
+		if(!user.put_in_hands(phase2_weapon))
+			QDEL_NULL(phase2_weapon)
+			to_chat(user, span_warning("You need a free hand to summon the weapon!"))
+			return FALSE
+		// Transfer sheltered spirit to new weapon
+		if(bound_spirit)
+			grant_spirit_to_weapon(phase2_weapon)
+	else
+		phase1_weapon = new /obj/item/ego_weapon/city/ring/fascia
+		phase1_weapon.linked_armor = src
+		if(!user.put_in_hands(phase1_weapon))
+			QDEL_NULL(phase1_weapon)
+			to_chat(user, span_warning("You need a free hand to summon the weapon!"))
+			return FALSE
+		// Transfer sheltered spirit to new weapon
+		if(bound_spirit)
+			grant_spirit_to_weapon(phase1_weapon)
+
+	to_chat(user, span_userdanger("The Fascia manifests in your hands!"))
+	playsound(get_turf(user), 'sound/abnormalities/onesin/bless.ogg', 50, 0, 4)
+	return TRUE
+
+/// Removes the phase 1 weapon
+/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/proc/remove_phase1_weapon()
+	if(phase1_weapon)
+		// Shelter spirit in armor before destroying weapon
+		shelter_spirit_from_weapon(phase1_weapon)
+		REMOVE_TRAIT(phase1_weapon, TRAIT_NODROP, "ring_fascia")
+		var/mob/living/holder = phase1_weapon.loc
+		if(istype(holder))
+			holder.dropItemToGround(phase1_weapon, force = TRUE, silent = TRUE)
+		QDEL_NULL(phase1_weapon)
+
+/// Removes the phase 2 weapon
+/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/proc/remove_phase2_weapon()
+	if(phase2_weapon)
+		// Shelter spirit in armor before destroying weapon
+		shelter_spirit_from_weapon(phase2_weapon)
+		REMOVE_TRAIT(phase2_weapon, TRAIT_NODROP, "ring_fascia")
+		var/mob/living/holder = phase2_weapon.loc
+		if(istype(holder))
+			holder.dropItemToGround(phase2_weapon, force = TRUE, silent = TRUE)
+		QDEL_NULL(phase2_weapon)
+
+/// Moves a spirit from a weapon into the armor for safekeeping
+/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/proc/shelter_spirit_from_weapon(obj/item/weapon)
+	var/mob/living/simple_animal/fascia_spirit/spirit
+	var/obj/item/ego_weapon/city/ring/fascia/F1 = weapon
+	var/obj/item/ego_weapon/city/ring/fascia_unleashed/F2 = weapon
+	if(istype(F1) && F1.bound_spirit)
+		spirit = F1.bound_spirit
+		F1.bound_spirit = null
+		F1.possessed = FALSE
+		F1.empowered = FALSE
+		if(F1.empower_timer_id)
+			deltimer(F1.empower_timer_id)
+			F1.empower_timer_id = null
+	else if(istype(F2) && F2.bound_spirit)
+		spirit = F2.bound_spirit
+		F2.bound_spirit = null
+		F2.possessed = FALSE
+		F2.empowered = FALSE
+		if(F2.empower_timer_id)
+			deltimer(F2.empower_timer_id)
+			F2.empower_timer_id = null
+
+	if(!spirit)
+		return
+
+	// Move spirit into armor
+	spirit.forceMove(src)
+	spirit.bound_weapon = null
+	bound_spirit = spirit
+	possessed = TRUE
+
+	// Remove weapon-dependent actions while in armor
+	for(var/datum/action/cooldown/fascia_empower_strike/action in spirit.actions)
+		action.Remove(spirit)
+		qdel(action)
+	for(var/datum/action/cooldown/fascia_compel_dash/action in spirit.actions)
+		action.Remove(spirit)
+		qdel(action)
+
+	to_chat(spirit, span_notice("The weapon dissipates. You retreat into the armor, waiting..."))
+
+/// Transfers the sheltered spirit from armor into a newly created weapon
+/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/proc/grant_spirit_to_weapon(obj/item/weapon)
+	if(!bound_spirit)
+		return
+
+	var/mob/living/simple_animal/fascia_spirit/spirit = bound_spirit
+
+	// Move spirit into weapon
+	spirit.forceMove(weapon)
+	spirit.bound_weapon = weapon
+
+	// Set refs on weapon
+	var/obj/item/ego_weapon/city/ring/fascia/F1 = weapon
+	var/obj/item/ego_weapon/city/ring/fascia_unleashed/F2 = weapon
+	if(istype(F1))
+		F1.bound_spirit = spirit
+		F1.possessed = TRUE
+	else if(istype(F2))
+		F2.bound_spirit = spirit
+		F2.possessed = TRUE
+
+	// Clear armor refs
+	bound_spirit = null
+
+	// Grant actions pointing to new weapon
+	var/datum/action/cooldown/fascia_empower_strike/empower_action = new(spirit)
+	empower_action.weapon_ref = WEAKREF(weapon)
+	empower_action.Grant(spirit)
+
+	var/datum/action/cooldown/fascia_compel_dash/dash_action = new(spirit)
+	dash_action.weapon_ref = WEAKREF(weapon)
+	dash_action.Grant(spirit)
+
+	to_chat(spirit, span_nicegreen("A new weapon manifests! You flow into the blade."))
+
+/// Activates Iron Curtain mode - massively boosts reflect damage, slows the user
+/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/proc/activate_iron_curtain()
+	if(!armor_wearer || phase != 1)
+		return
+	iron_curtain = TRUE
+	armor_wearer.add_atom_colour("#FFD700", TEMPORARY_COLOUR_PRIORITY)
+	armor_wearer.add_movespeed_modifier(/datum/movespeed_modifier/iron_curtain)
+	to_chat(armor_wearer, span_userdanger("Iron Curtain! Your body becomes an immovable fortress of spikes!"))
+	playsound(get_turf(armor_wearer), 'sound/weapons/fixer/generic/finisher1.ogg', 50, 0, 4)
+	iron_curtain_timer_id = addtimer(CALLBACK(src, PROC_REF(deactivate_iron_curtain)), 5 SECONDS, TIMER_STOPPABLE)
+
+/// Deactivates Iron Curtain mode - restores normal movement and color
+/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/proc/deactivate_iron_curtain()
+	if(iron_curtain_timer_id)
+		deltimer(iron_curtain_timer_id)
+		iron_curtain_timer_id = null
+	iron_curtain = FALSE
+	if(armor_wearer && !QDELETED(armor_wearer))
+		armor_wearer.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, "#FFD700")
+		armor_wearer.remove_movespeed_modifier(/datum/movespeed_modifier/iron_curtain)
+		to_chat(armor_wearer, span_notice("Iron Curtain fades. Your movement returns to normal."))
+
+/// Grants the Reforge Iron Maiden action to the wearer
+/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/proc/grant_reforge_action()
+	if(reforge_action || !armor_wearer)
+		return
+	reforge_action = new(src)
+	reforge_action.linked_armor = src
+	reforge_action.Grant(armor_wearer)
+
+/// Removes the Reforge Iron Maiden action from the wearer
+/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/proc/remove_reforge_action()
+	if(reforge_action)
+		reforge_action.Remove(reforge_action.owner)
+		QDEL_NULL(reforge_action)
+
+/// Returns the armor to phase 1 from phase 2 (called by the Reforge action)
+/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/proc/return_to_phase1()
+	if(phase != 2)
+		return
+	phase = 1
+
+	// Restore armor appearance, resistances, and remove speed boost
+	icon_state = "ring_apprentice"
+	src.armor = getArmor(red = 50, white = 40, black = 50, pale = 20)
+	update_icon()
+	if(armor_wearer)
+		armor_wearer.remove_movespeed_modifier(/datum/movespeed_modifier/iron_maiden_fractured)
+		armor_wearer.update_inv_wear_suit()
+
+	// Transform weapon back to phase 1
+	// remove_phase2_weapon() shelters any spirit into armor automatically
+	remove_phase2_weapon()
+	if(armor_wearer && !phase1_weapon)
+		phase1_weapon = new /obj/item/ego_weapon/city/ring/fascia
+		phase1_weapon.linked_armor = src
+		if(!armor_wearer.put_in_hands(phase1_weapon))
+			QDEL_NULL(phase1_weapon)
+			to_chat(armor_wearer, span_warning("You need a free hand to reform the weapon!"))
+		else if(bound_spirit)
+			grant_spirit_to_weapon(phase1_weapon)
+
+	// Remove the reforge action
+	remove_reforge_action()
+
+	// Set 30 second cooldown before phase 2 can trigger again
+	phase2_cooldown = world.time + 30 SECONDS
+
+	if(armor_wearer)
+		to_chat(armor_wearer, span_userdanger("The Iron Maiden reforges itself around you!"))
+		playsound(get_turf(armor_wearer), 'sound/abnormalities/onesin/bless.ogg', 50, 0, 4)
+
+/obj/item/clothing/head/ego_hat/helmet/ring_apprentice
+	name = "iron maiden helmet"
+	desc = "A helmet with sharp golden eyes painted on and two white spikes on each side. Part of the Corporist apprentice's ensemble."
+	icon = 'icons/obj/spider_house/ring/ring_mask.dmi'
+	worn_icon = 'icons/obj/spider_house/ring/ring_mask_worn.dmi'
+	icon_state = "ring_apprentice_mask"
+
+/// Prevents equipping the helmet while the linked armor is in phase 2
+/obj/item/clothing/head/ego_hat/helmet/ring_apprentice/mob_can_equip(mob/living/M, mob/living/equipper, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		var/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/armor = H.get_item_by_slot(ITEM_SLOT_OCLOTHING)
+		if(istype(armor) && armor.phase == 2)
+			to_chat(M, span_warning("The helmet refuses to attach while the Iron Maiden is fractured!"))
+			return FALSE
+	return ..()
+
+// Ability for summoning the Fascia weapon from Iron Maiden armor
+/obj/effect/proc_holder/ability/ring_summon_fascia
+	name = "Summon Fascia"
+	desc = "Summon or dismiss the Fascia weapon from the Iron Maiden armor."
+	action_icon = 'icons/mob/actions/actions_ecult.dmi'
+	action_icon_state = "mansus_link"
+	base_icon_state = "mansus_link"
+	cooldown_time = 5 SECONDS
+
+/obj/effect/proc_holder/ability/ring_summon_fascia/Perform(target, mob/user)
+	if(!ishuman(user))
+		return ..()
+
+	var/mob/living/carbon/human/H = user
+	var/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/armor = H.get_item_by_slot(ITEM_SLOT_OCLOTHING)
+
+	if(!istype(armor))
+		to_chat(user, span_warning("You must be wearing the Iron Maiden armor!"))
+		return ..()
+
+	// Toggle weapon - dismiss if exists, summon if not
+	if(armor.phase1_weapon)
+		armor.remove_phase1_weapon()
+		to_chat(user, span_notice("The Fascia dissipates."))
+		playsound(get_turf(user), 'sound/abnormalities/onesin/bless.ogg', 50, 0, 4)
+	else if(armor.phase2_weapon)
+		armor.remove_phase2_weapon()
+		to_chat(user, span_notice("The Fascia dissipates."))
+		playsound(get_turf(user), 'sound/abnormalities/onesin/bless.ogg', 50, 0, 4)
+	else
+		armor.grant_weapon(H)
+
+	return ..()
+
+// Action to return from phase 2 to phase 1 via a long channel
+/datum/action/cooldown/reforge_iron_maiden
+	name = "Reforge Iron Maiden"
+	desc = "Channel your will to reforge the fractured Iron Maiden armor, returning to the defensive phase."
+	icon_icon = 'icons/obj/spider_house/ring/ring_icons.dmi'
+	button_icon_state = "reforge_maiden"
+	cooldown_time = 0
+	check_flags = AB_CHECK_HANDS_BLOCKED | AB_CHECK_CONSCIOUS
+
+	/// Linked armor reference
+	var/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/linked_armor
+
+/datum/action/cooldown/reforge_iron_maiden/Trigger(trigger_flags)
+	. = ..(trigger_flags)
+	if(!.)
+		return FALSE
+
+	var/mob/living/carbon/human/H = owner
+	if(!istype(H))
+		return FALSE
+
+	if(!linked_armor || linked_armor.phase != 2)
+		to_chat(H, span_warning("The armor is not in a state that can be reforged!"))
+		return FALSE
+
+	to_chat(H, span_notice("You begin reforging the Iron Maiden..."))
+	playsound(get_turf(H), 'sound/weapons/fixer/generic/finisher1.ogg', 25, 0, 4)
+
+	if(!do_after(H, 5 SECONDS, H))
+		to_chat(H, span_warning("You were interrupted!"))
+		return FALSE
+
+	// Verify armor still exists and is still in phase 2
+	if(QDELETED(linked_armor) || linked_armor.phase != 2 || linked_armor.armor_wearer != H)
+		return FALSE
+
+	linked_armor.return_to_phase1()
+	return TRUE
+
+/datum/action/cooldown/reforge_iron_maiden/Destroy()
+	linked_armor = null
+	return ..()
+
+/// Iron Curtain movespeed modifier - massive slowdown during Iron Curtain activation
+/datum/movespeed_modifier/iron_curtain
+	multiplicative_slowdown = 3
+
+/// Iron Maiden fractured speed boost - flips 0.75 slowdown to 1.25 speed boost in phase 2
+/datum/movespeed_modifier/iron_maiden_fractured
+	multiplicative_slowdown = -1
+
+/// Fascia leap miss slowdown - applied when landing with no adjacent enemies
+/datum/movespeed_modifier/fascia_leap_miss
+	multiplicative_slowdown = 1

--- a/code/modules/clothing/suits/ego_gear/non_abnormality/ring.dm
+++ b/code/modules/clothing/suits/ego_gear/non_abnormality/ring.dm
@@ -95,11 +95,9 @@
 		if(phase == 2)
 			armor_wearer.remove_movespeed_modifier(/datum/movespeed_modifier/iron_maiden_fractured)
 		remove_reforge_action()
-		// Clean up spirit when armor is removed
+		// Spirit is already sheltered by remove_phase1/2_weapon — keep it safe in the armor
 		if(bound_spirit)
-			to_chat(bound_spirit, span_userdanger("The armor is removed! You are cast out!"))
-			QDEL_NULL(bound_spirit)
-			possessed = FALSE
+			to_chat(bound_spirit, span_notice("The armor is removed. You remain sheltered within, waiting..."))
 		armor_wearer = null
 		// Reset to phase 1
 		phase = 1

--- a/code/modules/jobs/job_types/trusted_players/corporist_maestro.dm
+++ b/code/modules/jobs/job_types/trusted_players/corporist_maestro.dm
@@ -1,1 +1,186 @@
-// Stub - populated by the Ring sub-PR
+// The Corporist Maestro - A high-ranking member of The Ring's Corporist school
+/datum/job/corporist_maestro
+	title = "Corporist Maestro"
+	outfit = /datum/outfit/job/corporist_maestro
+	department_head = list("the Ring")
+	faction = "Station"
+	supervisors = "the Ring's artistic vision"
+	selection_color = "#f5f5dc"
+	total_positions = 0
+	spawn_positions = 0
+	display_order = JOB_DISPLAY_ORDER_SYNDICATEHEAD
+	trusted_only = TRUE
+	access = list(ACCESS_SYNDICATE, ACCESS_SYNDICATE_LEADER)
+	minimal_access = list(ACCESS_SYNDICATE, ACCESS_SYNDICATE_LEADER)
+	departments = DEPARTMENT_COMMAND | DEPARTMENT_CITY_ANTAGONIST
+	paycheck = 1000
+	maptype = list("city", "fixers")
+	job_important = "You are a Maestro of the Corporist school, a high-ranking member of the Ring. \
+		The Ring is a Syndicate devoted to creating art that reflects the human condition through causing and exhibiting human suffering. \
+		As a Corporist, you specialize in utilizing the interaction between human bones and muscles, the contraction and elongation thereof. \
+		You have buffed stats. You automatically dodge the first attack every 30 seconds, and have a 50% chance to dodge attacks when not holding a weapon. \
+		However, all damage you take also inflicts 5% unhealable damage."
+	job_notice = "Avoid killing other players without artistic purpose. Your art is your justification."
+
+	roundstart_attributes = list(
+		FORTITUDE_ATTRIBUTE = 300,
+		PRUDENCE_ATTRIBUTE = 300,
+		TEMPERANCE_ATTRIBUTE = 100,
+		JUSTICE_ATTRIBUTE = 100
+	)
+
+/datum/job/corporist_maestro/after_spawn(mob/living/carbon/human/H, mob/M)
+	ADD_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE, JOB_TRAIT)
+	ADD_TRAIT(H, TRAIT_WORK_FORBIDDEN, JOB_TRAIT)
+	ADD_TRAIT(H, TRAIT_RING_ARTIST, JOB_TRAIT)
+	H.AddComponent(/datum/component/nursefather_passive)
+	H.set_species(/datum/species/corporist_maestro)
+
+	// Re-equip hand items after species change (set_species can drop held items)
+	var/obj/item/ego_weapon/city/ring/tibia/weapon = new(H)
+	H.put_in_l_hand(weapon)
+	var/obj/item/clothing/suit/armor/ego_gear/city/ring_maestro/armor = new(H)
+	H.put_in_r_hand(armor)
+
+	// Add artistic EXP component with starting bonus
+	var/datum/component/artistic_exp/exp_comp = H.AddComponent(/datum/component/artistic_exp)
+	exp_comp.grant_starting_points("maestro")
+
+	// Grant Maestro actions
+	var/datum/action/cooldown/sculpt_corpse/sculpt = new(H)
+	sculpt.Grant(H)
+	var/datum/action/cooldown/demonstrate_artistry/demo = new(H)
+	demo.Grant(H)
+	var/datum/action/cooldown/judge_artwork/judge = new(H)
+	judge.Grant(H)
+	var/datum/action/cooldown/describe_artwork/describe = new(H)
+	describe.Grant(H)
+	var/datum/action/cooldown/reset_artistry/reset = new(H)
+	reset.Grant(H)
+	var/datum/action/innate/ring_skill_tree/tree = new(H)
+	tree.Grant(H)
+
+	// Add antagonist datum for rules/round end tracking
+	if(H.mind)
+		H.mind.add_antag_datum(/datum/antagonist/ring_artist/maestro)
+
+	. = ..()
+
+/datum/outfit/job/corporist_maestro
+	name = "Corporist Maestro"
+	jobtype = /datum/job/corporist_maestro
+
+	id = /obj/item/card/id/silver/plastic
+	belt = /obj/item/pda/security
+	uniform = /obj/item/clothing/under/suit/charcoal
+	shoes = /obj/item/clothing/shoes/laceup
+	// l_hand and r_hand are equipped in after_spawn() after set_species()
+	l_pocket = /obj/item/apprentice_recruitment/ring_corporist
+
+// Ring Corporist Apprentice Recruitment Scroll
+/obj/item/apprentice_recruitment/ring_corporist
+	name = "corporist apprenticeship contract"
+	desc = "An ornate contract that allows you to recruit an apprentice into the Corporist school of the Ring."
+
+/obj/item/apprentice_recruitment/ring_corporist/get_offer_text(mob/living/user)
+	return "[user] is offering to make you their Corporist Apprentice. Do you accept?"
+
+/obj/item/apprentice_recruitment/ring_corporist/get_offer_title()
+	return "Apprenticeship Offer"
+
+/obj/item/apprentice_recruitment/ring_corporist/recruit_apprentice(mob/living/carbon/human/H, mob/living/user)
+	// Set attributes
+	H.set_attribute_limit(200)
+
+	var/datum/attribute/fort = H.attributes[FORTITUDE_ATTRIBUTE]
+	var/datum/attribute/prud = H.attributes[PRUDENCE_ATTRIBUTE]
+	var/datum/attribute/temp = H.attributes[TEMPERANCE_ATTRIBUTE]
+	var/datum/attribute/just = H.attributes[JUSTICE_ATTRIBUTE]
+
+	if(fort)
+		fort.level = 200
+		fort.on_update(H)
+	if(prud)
+		prud.level = 200
+		prud.on_update(H)
+	if(temp)
+		temp.level = 100
+		temp.on_update(H)
+	if(just)
+		just.level = 100
+		just.on_update(H)
+
+	// Give armor (mask auto-equips when worn, weapon is summoned from armor via ability)
+	var/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/armor = new(H.loc)
+	H.put_in_hands(armor)
+
+	// Update ID card
+	update_id_card(H, "Corporist Apprentice")
+
+	// Update mind role and add antagonist datum
+	if(H.mind)
+		H.mind.assigned_role = "Corporist Apprentice"
+		// Remove any existing ring_artist datum (if they were a student)
+		var/datum/antagonist/ring_artist/old_antag = H.mind.has_antag_datum(/datum/antagonist/ring_artist)
+		if(old_antag)
+			H.mind.remove_antag_datum(old_antag.type)
+		// Add apprentice antagonist datum
+		H.mind.add_antag_datum(/datum/antagonist/ring_artist/apprentice)
+
+	// Set the apprentice species (full prosthetic body)
+	H.set_species(/datum/species/corporist_apprentice)
+
+	// Remove underwear/undershirt/socks for full prosthetic body
+	H.underwear = "Nude"
+	H.undershirt = "Nude"
+	H.socks = "Nude"
+	H.updateappearance()
+
+	// Force hair color to white after updateappearance (species sets it but updateappearance can reset it)
+	H.hair_color = "FFF"
+	if(H.gradient_style)
+		H.gradient_color = "888"
+	H.update_hair()
+
+	// Add the oracle proxy passive component and traits
+	ADD_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE, "corporist_apprentice")
+	ADD_TRAIT(H, TRAIT_WORK_FORBIDDEN, "corporist_apprentice")
+	ADD_TRAIT(H, TRAIT_RING_ARTIST, "corporist_apprentice")
+	H.AddComponent(/datum/component/nursefather_passive)
+
+	// Check if they already have artistic EXP (e.g., they were a student)
+	var/datum/component/artistic_exp/exp_comp = H.GetComponent(/datum/component/artistic_exp)
+	if(exp_comp)
+		// They were already a student - preserve their EXP and add 4 skill points
+		exp_comp.grant_starting_points("apprentice")
+		// Remove student component if they had one
+		var/datum/component/corporist_student/student_comp = H.GetComponent(/datum/component/corporist_student)
+		if(student_comp)
+			qdel(student_comp)
+	else
+		// New to the arts - create fresh component
+		exp_comp = H.AddComponent(/datum/component/artistic_exp)
+		exp_comp.grant_starting_points("apprentice")
+
+	// Grant Apprentice actions
+	var/datum/action/cooldown/sculpt_corpse/sculpt = new(H)
+	sculpt.Grant(H)
+	var/datum/action/cooldown/describe_artwork/describe = new(H)
+	describe.Grant(H)
+	var/datum/action/innate/ring_skill_tree/tree = new(H)
+	tree.Grant(H)
+
+	// Visual/audio feedback
+	to_chat(user, span_notice("You have recruited [H] as your apprentice."))
+	playsound(get_turf(H), 'sound/abnormalities/onesin/bless.ogg', 50, 0, 4)
+
+	// Show role explanation to the new apprentice
+	to_chat(H, span_userdanger("You have become a Corporist Apprentice!"))
+	to_chat(H, span_boldnotice("You are now an apprentice of [user], a Maestro of the Corporist school. \
+		The Ring is a Syndicate devoted to creating art that reflects the human condition. \
+		As a Corporist, you will learn to sculpt flesh and bone into masterpieces."))
+	to_chat(H, span_boldnotice("You have buffed stats. You automatically dodge the first attack every 30 seconds, \
+		and have a 50% chance to dodge attacks when not holding a weapon. \
+		However, all damage you take also inflicts 5% unhealable damage."))
+	to_chat(H, span_boldwarning("Avoid killing other players without artistic purpose. \
+		Your art is your justification."))

--- a/code/modules/jobs/job_types/trusted_players/corporist_maestro.dm
+++ b/code/modules/jobs/job_types/trusted_players/corporist_maestro.dm
@@ -184,3 +184,86 @@
 		However, all damage you take also inflicts 5% unhealable damage."))
 	to_chat(H, span_boldwarning("Avoid killing other players without artistic purpose. \
 		Your art is your justification."))
+
+////////////////////////////////////////////////////////////
+// DEBUG TRANSFORM ITEM
+// Use in hand to become the Corporist Maestro with full loadout.
+
+/obj/item/corporist_maestro_debug
+	name = "maestro's chisel"
+	desc = "A debug item. Use in hand to transform into the Corporist Maestro with full gear and abilities."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "hypertool"
+	w_class = WEIGHT_CLASS_TINY
+
+/obj/item/corporist_maestro_debug/attack_self(mob/living/user)
+	. = ..()
+	if(!ishuman(user))
+		to_chat(user, span_warning("Only humans can use this."))
+		return
+	var/mob/living/carbon/human/H = user
+
+	to_chat(H, span_boldnotice("Transforming into Corporist Maestro..."))
+
+	// Set attributes
+	H.set_attribute_limit(300)
+	for(var/attr_name in list(FORTITUDE_ATTRIBUTE, PRUDENCE_ATTRIBUTE, TEMPERANCE_ATTRIBUTE, JUSTICE_ATTRIBUTE))
+		var/datum/attribute/A = H.attributes[attr_name]
+		if(A)
+			if(attr_name in list(FORTITUDE_ATTRIBUTE, PRUDENCE_ATTRIBUTE))
+				A.level = 300
+			else
+				A.level = 100
+			A.on_update(H)
+
+	// Set role
+	if(H.mind)
+		H.mind.assigned_role = "Corporist Maestro"
+
+	// Add traits
+	ADD_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE, JOB_TRAIT)
+	ADD_TRAIT(H, TRAIT_WORK_FORBIDDEN, JOB_TRAIT)
+	ADD_TRAIT(H, TRAIT_RING_ARTIST, JOB_TRAIT)
+
+	// Add nursefather passive
+	H.AddComponent(/datum/component/nursefather_passive)
+
+	// Set species to corporist maestro prosthetics
+	H.set_species(/datum/species/corporist_maestro)
+
+	// Equip outfit basics
+	var/datum/outfit/job/corporist_maestro/outfit = new()
+	outfit.equip(H)
+
+	// Spawn weapon and armor into hands (after species change)
+	var/obj/item/ego_weapon/city/ring/tibia/weapon = new(H)
+	H.put_in_hands(weapon)
+	var/obj/item/clothing/suit/armor/ego_gear/city/ring_maestro/armor = new(H)
+	H.put_in_hands(armor)
+
+	// Add artistic EXP component with maestro starting bonus
+	var/datum/component/artistic_exp/exp_comp = H.AddComponent(/datum/component/artistic_exp)
+	exp_comp.grant_starting_points("maestro")
+
+	// Grant Maestro actions
+	var/datum/action/cooldown/sculpt_corpse/sculpt = new(H)
+	sculpt.Grant(H)
+	var/datum/action/cooldown/demonstrate_artistry/demo = new(H)
+	demo.Grant(H)
+	var/datum/action/cooldown/judge_artwork/judge = new(H)
+	judge.Grant(H)
+	var/datum/action/cooldown/describe_artwork/describe = new(H)
+	describe.Grant(H)
+	var/datum/action/cooldown/reset_artistry/reset = new(H)
+	reset.Grant(H)
+	var/datum/action/innate/ring_skill_tree/tree = new(H)
+	tree.Grant(H)
+
+	// Add antagonist datum
+	if(H.mind)
+		H.mind.add_antag_datum(/datum/antagonist/ring_artist/maestro)
+
+	to_chat(H, span_boldnotice("You are now the Corporist Maestro. Tibia and armor are in your hands."))
+
+	// Consume the debug item
+	qdel(src)

--- a/code/modules/jobs/job_types/trusted_players/corporist_maestro.dm
+++ b/code/modules/jobs/job_types/trusted_players/corporist_maestro.dm
@@ -34,6 +34,7 @@
 	ADD_TRAIT(H, TRAIT_WORK_FORBIDDEN, JOB_TRAIT)
 	ADD_TRAIT(H, TRAIT_RING_ARTIST, JOB_TRAIT)
 	H.AddComponent(/datum/component/nursefather_passive)
+	H.AddComponent(/datum/component/nursefather_music, NURSEFATHER_FINGER_RING)
 	H.set_species(/datum/species/corporist_maestro)
 
 	// Re-equip hand items after species change (set_species can drop held items)
@@ -208,6 +209,11 @@
 
 	to_chat(H, span_boldnotice("Transforming into Corporist Maestro..."))
 
+	// Drop all held and worn items
+	H.drop_all_held_items()
+	for(var/obj/item/I in H.get_equipped_items())
+		H.dropItemToGround(I, TRUE)
+
 	// Set attributes
 	H.set_attribute_limit(300)
 	for(var/attr_name in list(FORTITUDE_ATTRIBUTE, PRUDENCE_ATTRIBUTE, TEMPERANCE_ATTRIBUTE, JUSTICE_ATTRIBUTE))
@@ -230,6 +236,7 @@
 
 	// Add nursefather passive
 	H.AddComponent(/datum/component/nursefather_passive)
+	H.AddComponent(/datum/component/nursefather_music, NURSEFATHER_FINGER_RING)
 
 	// Set species to corporist maestro prosthetics
 	H.set_species(/datum/species/corporist_maestro)

--- a/code/modules/jobs/job_types/trusted_players/corporist_maestro.dm
+++ b/code/modules/jobs/job_types/trusted_players/corporist_maestro.dm
@@ -76,6 +76,7 @@
 	shoes = /obj/item/clothing/shoes/laceup
 	// l_hand and r_hand are equipped in after_spawn() after set_species()
 	l_pocket = /obj/item/apprentice_recruitment/ring_corporist
+	r_pocket = /obj/item/storage/box/corporist_toolkit
 
 // Ring Corporist Apprentice Recruitment Scroll
 /obj/item/apprentice_recruitment/ring_corporist
@@ -110,9 +111,11 @@
 		just.level = 100
 		just.on_update(H)
 
-	// Give armor (mask auto-equips when worn, weapon is summoned from armor via ability)
+	// Give armor and toolkit
 	var/obj/item/clothing/suit/armor/ego_gear/city/ring_apprentice/armor = new(H.loc)
 	H.put_in_hands(armor)
+	var/obj/item/storage/box/corporist_toolkit/toolkit = new(H.loc)
+	H.put_in_hands(toolkit)
 
 	// Update ID card
 	update_id_card(H, "Corporist Apprentice")

--- a/code/modules/jobs/job_types/trusted_players/corporist_maestro.dm
+++ b/code/modules/jobs/job_types/trusted_players/corporist_maestro.dm
@@ -277,3 +277,120 @@
 
 	// Consume the debug item
 	qdel(src)
+
+////////////////////////////////////////////////////////////
+// GHOST POLL SPAWN ITEM
+// Use in hand to poll trusted ghosts, then spawn the selected one as Corporist Maestro.
+
+/obj/item/corporist_maestro_ghost_spawn
+	name = "maestro's tuning fork"
+	desc = "A debug item. Use in hand to poll trusted ghosts for a Corporist Maestro player."
+	icon = 'icons/obj/radio.dmi'
+	icon_state = "radio"
+	w_class = WEIGHT_CLASS_TINY
+	/// Whether a poll is currently active
+	var/polling = FALSE
+
+/obj/item/corporist_maestro_ghost_spawn/attack_self(mob/living/user)
+	if(!ishuman(user))
+		to_chat(user, span_warning("Only humans can use this."))
+		return
+	if(polling)
+		to_chat(user, span_warning("A poll is already in progress!"))
+		return
+
+	polling = TRUE
+	to_chat(user, span_notice("Polling ghosts for a Corporist Maestro candidate..."))
+
+	var/turf/spawn_loc = get_turf(src)
+
+	var/list/candidates = pollGhostCandidates("Do you wish to become the Corporist Maestro?", ROLE_TRAITOR, poll_time = 300)
+
+	if(QDELETED(src))
+		return
+
+	// Filter for trusted players
+	var/list/trusted_candidates = list()
+	for(var/mob/dead/observer/candidate in candidates)
+		if(candidate.client && is_trusted_player(candidate.client))
+			trusted_candidates += candidate
+		else if(candidate.client)
+			to_chat(candidate, span_warning("You were not selected because this role requires trusted player status."))
+
+	if(!length(trusted_candidates))
+		to_chat(user, span_warning("No trusted candidates accepted the poll."))
+		polling = FALSE
+		return
+
+	var/mob/dead/observer/chosen = pick(trusted_candidates)
+	var/mob/living/carbon/human/H = makeBody(chosen)
+	if(!H)
+		to_chat(user, span_warning("Failed to create a body for the candidate."))
+		polling = FALSE
+		return
+
+	H.forceMove(spawn_loc)
+
+	// Set attributes
+	H.set_attribute_limit(300)
+	for(var/attr_name in list(FORTITUDE_ATTRIBUTE, PRUDENCE_ATTRIBUTE, TEMPERANCE_ATTRIBUTE, JUSTICE_ATTRIBUTE))
+		var/datum/attribute/A = H.attributes[attr_name]
+		if(A)
+			if(attr_name in list(FORTITUDE_ATTRIBUTE, PRUDENCE_ATTRIBUTE))
+				A.level = 300
+			else
+				A.level = 100
+			A.on_update(H)
+
+	// Set role
+	if(H.mind)
+		H.mind.assigned_role = "Corporist Maestro"
+
+	// Add traits
+	ADD_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE, JOB_TRAIT)
+	ADD_TRAIT(H, TRAIT_WORK_FORBIDDEN, JOB_TRAIT)
+	ADD_TRAIT(H, TRAIT_RING_ARTIST, JOB_TRAIT)
+
+	// Add nursefather components
+	H.AddComponent(/datum/component/nursefather_passive)
+	H.AddComponent(/datum/component/nursefather_music, NURSEFATHER_FINGER_RING)
+
+	// Set species
+	H.set_species(/datum/species/corporist_maestro)
+
+	// Equip outfit
+	var/datum/outfit/job/corporist_maestro/outfit = new()
+	outfit.equip(H)
+
+	// Spawn weapon and armor into hands (after species change)
+	var/obj/item/ego_weapon/city/ring/tibia/weapon = new(H)
+	H.put_in_hands(weapon)
+	var/obj/item/clothing/suit/armor/ego_gear/city/ring_maestro/armor = new(H)
+	H.put_in_hands(armor)
+
+	// Add artistic EXP component with maestro starting bonus
+	var/datum/component/artistic_exp/exp_comp = H.AddComponent(/datum/component/artistic_exp)
+	exp_comp.grant_starting_points("maestro")
+
+	// Grant Maestro actions
+	var/datum/action/cooldown/sculpt_corpse/sculpt = new(H)
+	sculpt.Grant(H)
+	var/datum/action/cooldown/demonstrate_artistry/demo = new(H)
+	demo.Grant(H)
+	var/datum/action/cooldown/judge_artwork/judge = new(H)
+	judge.Grant(H)
+	var/datum/action/cooldown/describe_artwork/describe = new(H)
+	describe.Grant(H)
+	var/datum/action/cooldown/reset_artistry/reset = new(H)
+	reset.Grant(H)
+	var/datum/action/innate/ring_skill_tree/tree = new(H)
+	tree.Grant(H)
+
+	// Add antagonist datum
+	if(H.mind)
+		H.mind.add_antag_datum(/datum/antagonist/ring_artist/maestro)
+
+	to_chat(H, span_boldnotice("You are the Corporist Maestro. Tibia and armor are in your hands."))
+
+	// Consume the item
+	qdel(src)

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -286,7 +286,7 @@ GLOBAL_LIST_INIT(city_antagonist_positions, list(
 
 	"Corporist Maestro",
 	"Ex Thumb Sottocapo",
-	"Ex Great Brother",
+	"Middle Ex-Great Brother",
 ))
 
 

--- a/code/modules/mob/living/carbon/human/species_types/corporist.dm
+++ b/code/modules/mob/living/carbon/human/species_types/corporist.dm
@@ -1,1 +1,215 @@
-// Stub - populated by the Ring sub-PR
+// Corporist Species - The Ring's Corporist School
+// Full-body prosthetic species for Maestro and Apprentice
+
+/datum/species/corporist_maestro
+	name = "Corporist Maestro"
+	id = "corporist_maestro"
+	say_mod = "states"
+	sexes = 0
+	use_skintones = FALSE
+	species_traits = list(NOBLOOD, NOEYESPRITES)
+	inherent_traits = list(
+		TRAIT_ADVANCEDTOOLUSER,
+		TRAIT_NOMETABOLISM,
+		TRAIT_TOXIMMUNE,
+		TRAIT_RESISTHEAT,
+		TRAIT_NOBREATH,
+		TRAIT_RESISTCOLD,
+		TRAIT_RESISTHIGHPRESSURE,
+		TRAIT_RESISTLOWPRESSURE,
+		TRAIT_RADIMMUNE,
+		TRAIT_GENELESS,
+		TRAIT_PIERCEIMMUNE,
+		TRAIT_NOHUNGER,
+		TRAIT_LIMBATTACHMENT
+	)
+	inherent_biotypes = MOB_ROBOTIC|MOB_HUMANOID
+	meat = null
+	damage_overlay_type = "synth"
+	mutanttongue = /obj/item/organ/tongue/robot
+	species_language_holder = /datum/language_holder/synthetic
+	limbs_id = "maestro"
+	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
+	bodypart_overides = list(
+		BODY_ZONE_L_ARM = /obj/item/bodypart/l_arm/corporist_maestro,
+		BODY_ZONE_R_ARM = /obj/item/bodypart/r_arm/corporist_maestro,
+		BODY_ZONE_HEAD = /obj/item/bodypart/head/corporist_maestro,
+		BODY_ZONE_L_LEG = /obj/item/bodypart/l_leg/corporist_maestro,
+		BODY_ZONE_R_LEG = /obj/item/bodypart/r_leg/corporist_maestro,
+		BODY_ZONE_CHEST = /obj/item/bodypart/chest/corporist_maestro
+	)
+
+/datum/species/corporist_maestro/on_species_gain(mob/living/carbon/C)
+	. = ..()
+	for(var/obj/item/bodypart/BP in C.bodyparts)
+		BP.brute_reduction = 5
+		BP.burn_reduction = 4
+	C.set_safe_hunger_level()
+
+/datum/species/corporist_maestro/on_species_loss(mob/living/carbon/C)
+	. = ..()
+	for(var/obj/item/bodypart/BP in C.bodyparts)
+		BP.brute_reduction = initial(BP.brute_reduction)
+		BP.burn_reduction = initial(BP.burn_reduction)
+
+/datum/species/corporist_apprentice
+	name = "Corporist Apprentice"
+	id = "corporist_apprentice"
+	say_mod = "states"
+	sexes = 0
+	use_skintones = FALSE
+	species_traits = list(NOBLOOD, NOEYESPRITES, HAIR)
+
+	/// Stored original hair color to restore on species loss
+	var/original_hair_color
+	/// Stored original gradient color to restore on species loss
+	var/original_gradient_color
+	inherent_traits = list(
+		TRAIT_ADVANCEDTOOLUSER,
+		TRAIT_NOMETABOLISM,
+		TRAIT_TOXIMMUNE,
+		TRAIT_RESISTHEAT,
+		TRAIT_NOBREATH,
+		TRAIT_RESISTCOLD,
+		TRAIT_RESISTHIGHPRESSURE,
+		TRAIT_RESISTLOWPRESSURE,
+		TRAIT_RADIMMUNE,
+		TRAIT_GENELESS,
+		TRAIT_PIERCEIMMUNE,
+		TRAIT_NOHUNGER,
+		TRAIT_LIMBATTACHMENT
+	)
+	inherent_biotypes = MOB_ROBOTIC|MOB_HUMANOID
+	meat = null
+	damage_overlay_type = "synth"
+	mutanttongue = /obj/item/organ/tongue/robot
+	species_language_holder = /datum/language_holder/synthetic
+	limbs_id = "apprentice"
+	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
+	bodypart_overides = list(
+		BODY_ZONE_L_ARM = /obj/item/bodypart/l_arm/corporist_apprentice,
+		BODY_ZONE_R_ARM = /obj/item/bodypart/r_arm/corporist_apprentice,
+		BODY_ZONE_HEAD = /obj/item/bodypart/head/corporist_apprentice,
+		BODY_ZONE_L_LEG = /obj/item/bodypart/l_leg/corporist_apprentice,
+		BODY_ZONE_R_LEG = /obj/item/bodypart/r_leg/corporist_apprentice,
+		BODY_ZONE_CHEST = /obj/item/bodypart/chest/corporist_apprentice
+	)
+
+/datum/species/corporist_apprentice/on_species_gain(mob/living/carbon/C)
+	. = ..()
+	for(var/obj/item/bodypart/BP in C.bodyparts)
+		BP.brute_reduction = 5
+		BP.burn_reduction = 4
+	C.set_safe_hunger_level()
+	// Force hair to white and gradient to gray
+	if(ishuman(C))
+		var/mob/living/carbon/human/H = C
+		original_hair_color = H.hair_color
+		original_gradient_color = H.gradient_color
+		H.hair_color = "FFF"
+		if(H.gradient_style)
+			H.gradient_color = "888"
+		H.update_hair()
+
+/datum/species/corporist_apprentice/on_species_loss(mob/living/carbon/C)
+	. = ..()
+	for(var/obj/item/bodypart/BP in C.bodyparts)
+		BP.brute_reduction = initial(BP.brute_reduction)
+		BP.burn_reduction = initial(BP.burn_reduction)
+	// Restore original hair colors
+	if(ishuman(C))
+		var/mob/living/carbon/human/H = C
+		if(original_hair_color)
+			H.hair_color = original_hair_color
+		if(original_gradient_color)
+			H.gradient_color = original_gradient_color
+		H.update_hair()
+
+/// Override handle_hair to allow hair rendering despite robotic head
+/datum/species/corporist_apprentice/handle_hair(mob/living/carbon/human/H, forced_colour)
+	H.remove_overlay(HAIR_LAYER)
+	var/obj/item/bodypart/head/HD = H.get_bodypart(BODY_ZONE_HEAD)
+	if(!HD)
+		return
+
+	if(HAS_TRAIT(H, TRAIT_HUSK))
+		return
+
+	// Skip the BODYPART_ROBOTIC check - apprentices keep their hair
+	var/datum/sprite_accessory/S
+	var/list/standing = list()
+
+	var/hair_hidden = FALSE
+	var/facialhair_hidden = FALSE
+	var/dynamic_hair_suffix = ""
+	var/dynamic_fhair_suffix = ""
+
+	if(H.head)
+		var/obj/item/I = H.head
+		if(isclothing(I))
+			var/obj/item/clothing/C = I
+			dynamic_fhair_suffix = C.dynamic_fhair_suffix
+		if(I.flags_inv & HIDEFACIALHAIR)
+			facialhair_hidden = TRUE
+
+	if(H.wear_mask)
+		var/obj/item/I = H.wear_mask
+		if(isclothing(I))
+			var/obj/item/clothing/C = I
+			dynamic_fhair_suffix = C.dynamic_fhair_suffix
+		if(I.flags_inv & HIDEFACIALHAIR)
+			facialhair_hidden = TRUE
+
+	if(H.facial_hairstyle && (FACEHAIR in species_traits) && (!facialhair_hidden || dynamic_fhair_suffix))
+		S = GLOB.facial_hairstyles_list[H.facial_hairstyle]
+		if(S)
+			var/mutable_appearance/facial_overlay = mutable_appearance(S.icon, "[S.icon_state]", -HAIR_LAYER)
+			if(forced_colour)
+				facial_overlay.color = forced_colour
+			else
+				facial_overlay.color = "#[H.facial_hair_color]"
+			standing += facial_overlay
+
+	if(H.head)
+		var/obj/item/I = H.head
+		if(isclothing(I))
+			var/obj/item/clothing/C = I
+			dynamic_hair_suffix = C.dynamic_hair_suffix
+		if(I.flags_inv & HIDEHAIR)
+			hair_hidden = TRUE
+
+	if(H.wear_mask)
+		var/obj/item/I = H.wear_mask
+		if(I.flags_inv & HIDEHAIR)
+			hair_hidden = TRUE
+
+	if(H.hairstyle && (HAIR in species_traits) && (!hair_hidden || dynamic_hair_suffix))
+		S = GLOB.hairstyles_list[H.hairstyle]
+		if(S)
+			var/mutable_appearance/hair_overlay = mutable_appearance(S.icon, "[S.icon_state]", -HAIR_LAYER)
+			if(forced_colour)
+				hair_overlay.color = forced_colour
+			else
+				hair_overlay.color = "#[H.hair_color]"
+			if(OFFSET_FACE in offset_features)
+				hair_overlay.pixel_x += offset_features[OFFSET_FACE][1]
+				hair_overlay.pixel_y += offset_features[OFFSET_FACE][2]
+			standing += hair_overlay
+
+			if(H.gradient_style)
+				var/datum/sprite_accessory/gradient = GLOB.hair_gradients_list[H.gradient_style]
+				if(gradient)
+					var/icon/temp = icon(S.icon, S.icon_state)
+					temp.Blend(icon(gradient.icon, gradient.icon_state), ICON_ADD)
+					var/mutable_appearance/gradient_overlay = mutable_appearance(temp)
+					gradient_overlay.color = "#[H.gradient_color]"
+					gradient_overlay.layer = -HAIR_LAYER
+					if(OFFSET_FACE in offset_features)
+						gradient_overlay.pixel_x += offset_features[OFFSET_FACE][1]
+						gradient_overlay.pixel_y += offset_features[OFFSET_FACE][2]
+					standing += gradient_overlay
+
+	if(standing.len)
+		H.overlays_standing[HAIR_LAYER] = standing
+
+	H.apply_overlay(HAIR_LAYER)

--- a/code/modules/mob/living/carbon/human/species_types/corporist.dm
+++ b/code/modules/mob/living/carbon/human/species_types/corporist.dm
@@ -7,7 +7,7 @@
 	say_mod = "states"
 	sexes = 0
 	use_skintones = FALSE
-	species_traits = list(NOBLOOD, NOEYESPRITES)
+	species_traits = list(NOBLOOD, NOEYESPRITES, HAIR)
 	inherent_traits = list(
 		TRAIT_ADVANCEDTOOLUSER,
 		TRAIT_NOMETABOLISM,
@@ -51,6 +51,93 @@
 	for(var/obj/item/bodypart/BP in C.bodyparts)
 		BP.brute_reduction = initial(BP.brute_reduction)
 		BP.burn_reduction = initial(BP.burn_reduction)
+
+/// Override handle_hair to allow hair rendering despite robotic head
+/datum/species/corporist_maestro/handle_hair(mob/living/carbon/human/H, forced_colour)
+	H.remove_overlay(HAIR_LAYER)
+	var/obj/item/bodypart/head/HD = H.get_bodypart(BODY_ZONE_HEAD)
+	if(!HD)
+		return
+
+	if(HAS_TRAIT(H, TRAIT_HUSK))
+		return
+
+	var/datum/sprite_accessory/S
+	var/list/standing = list()
+
+	var/hair_hidden = FALSE
+	var/facialhair_hidden = FALSE
+	var/dynamic_hair_suffix = ""
+	var/dynamic_fhair_suffix = ""
+
+	if(H.head)
+		var/obj/item/I = H.head
+		if(isclothing(I))
+			var/obj/item/clothing/C = I
+			dynamic_fhair_suffix = C.dynamic_fhair_suffix
+		if(I.flags_inv & HIDEFACIALHAIR)
+			facialhair_hidden = TRUE
+
+	if(H.wear_mask)
+		var/obj/item/I = H.wear_mask
+		if(isclothing(I))
+			var/obj/item/clothing/C = I
+			dynamic_fhair_suffix = C.dynamic_fhair_suffix
+		if(I.flags_inv & HIDEFACIALHAIR)
+			facialhair_hidden = TRUE
+
+	if(H.facial_hairstyle && (FACEHAIR in species_traits) && (!facialhair_hidden || dynamic_fhair_suffix))
+		S = GLOB.facial_hairstyles_list[H.facial_hairstyle]
+		if(S)
+			var/mutable_appearance/facial_overlay = mutable_appearance(S.icon, "[S.icon_state]", -HAIR_LAYER)
+			if(forced_colour)
+				facial_overlay.color = forced_colour
+			else
+				facial_overlay.color = "#[H.facial_hair_color]"
+			standing += facial_overlay
+
+	if(H.head)
+		var/obj/item/I = H.head
+		if(isclothing(I))
+			var/obj/item/clothing/C = I
+			dynamic_hair_suffix = C.dynamic_hair_suffix
+		if(I.flags_inv & HIDEHAIR)
+			hair_hidden = TRUE
+
+	if(H.wear_mask)
+		var/obj/item/I = H.wear_mask
+		if(I.flags_inv & HIDEHAIR)
+			hair_hidden = TRUE
+
+	if(H.hairstyle && (HAIR in species_traits) && (!hair_hidden || dynamic_hair_suffix))
+		S = GLOB.hairstyles_list[H.hairstyle]
+		if(S)
+			var/mutable_appearance/hair_overlay = mutable_appearance(S.icon, "[S.icon_state]", -HAIR_LAYER)
+			if(forced_colour)
+				hair_overlay.color = forced_colour
+			else
+				hair_overlay.color = "#[H.hair_color]"
+			if(OFFSET_FACE in offset_features)
+				hair_overlay.pixel_x += offset_features[OFFSET_FACE][1]
+				hair_overlay.pixel_y += offset_features[OFFSET_FACE][2]
+			standing += hair_overlay
+
+			if(H.gradient_style)
+				var/datum/sprite_accessory/gradient = GLOB.hair_gradients_list[H.gradient_style]
+				if(gradient)
+					var/icon/temp = icon(S.icon, S.icon_state)
+					temp.Blend(icon(gradient.icon, gradient.icon_state), ICON_ADD)
+					var/mutable_appearance/gradient_overlay = mutable_appearance(temp)
+					gradient_overlay.color = "#[H.gradient_color]"
+					gradient_overlay.layer = -HAIR_LAYER
+					if(OFFSET_FACE in offset_features)
+						gradient_overlay.pixel_x += offset_features[OFFSET_FACE][1]
+						gradient_overlay.pixel_y += offset_features[OFFSET_FACE][2]
+					standing += gradient_overlay
+
+	if(standing.len)
+		H.overlays_standing[HAIR_LAYER] = standing
+		H.apply_overlay(HAIR_LAYER)
 
 /datum/species/corporist_apprentice
 	name = "Corporist Apprentice"

--- a/code/modules/surgery/bodyparts/corporist_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/corporist_bodyparts.dm
@@ -1,1 +1,257 @@
-// Stub - populated by the Ring sub-PR
+// Corporist Bodyparts - The Ring's Corporist School
+// Full-body prosthetics for Maestro and Apprentice species
+
+#define CORPORIST_LIGHT_BRUTE_MSG "marred"
+#define CORPORIST_MEDIUM_BRUTE_MSG "dented"
+#define CORPORIST_HEAVY_BRUTE_MSG "falling apart"
+
+#define CORPORIST_LIGHT_BURN_MSG "scorched"
+#define CORPORIST_MEDIUM_BURN_MSG "charred"
+#define CORPORIST_HEAVY_BURN_MSG "smoldering"
+
+// ============================================
+// CORPORIST MAESTRO BODYPARTS
+// Sleek metallic prosthetics with gaps, glass panes, sharp claws
+// ============================================
+
+/obj/item/bodypart/head/corporist_maestro
+	name = "corporist maestro head"
+	desc = "A sleek prosthetic head with glass panes revealing inner workings. The craftsmanship is disturbingly artistic."
+	icon = 'icons/mob/human_parts.dmi'
+	icon_state = "maestro_head"
+	species_id = "maestro"
+	status = BODYPART_ROBOTIC
+	brute_reduction = 5
+	burn_reduction = 4
+	light_brute_msg = CORPORIST_LIGHT_BRUTE_MSG
+	medium_brute_msg = CORPORIST_MEDIUM_BRUTE_MSG
+	heavy_brute_msg = CORPORIST_HEAVY_BRUTE_MSG
+	light_burn_msg = CORPORIST_LIGHT_BURN_MSG
+	medium_burn_msg = CORPORIST_MEDIUM_BURN_MSG
+	heavy_burn_msg = CORPORIST_HEAVY_BURN_MSG
+
+/// Override to use organic rendering path for [species_id]_[body_zone] icon pattern
+/obj/item/bodypart/head/corporist_maestro/is_organic_limb()
+	return TRUE
+
+/obj/item/bodypart/chest/corporist_maestro
+	name = "corporist maestro torso"
+	desc = "A massive prosthetic torso with metallic textures and glass panes showing innards. A masterwork of the Corporist school."
+	icon = 'icons/mob/human_parts.dmi'
+	icon_state = "maestro_chest"
+	species_id = "maestro"
+	status = BODYPART_ROBOTIC
+	brute_reduction = 5
+	burn_reduction = 4
+	light_brute_msg = CORPORIST_LIGHT_BRUTE_MSG
+	medium_brute_msg = CORPORIST_MEDIUM_BRUTE_MSG
+	heavy_brute_msg = CORPORIST_HEAVY_BRUTE_MSG
+	light_burn_msg = CORPORIST_LIGHT_BURN_MSG
+	medium_burn_msg = CORPORIST_MEDIUM_BURN_MSG
+	heavy_burn_msg = CORPORIST_HEAVY_BURN_MSG
+
+/obj/item/bodypart/chest/corporist_maestro/is_organic_limb()
+	return TRUE
+
+/obj/item/bodypart/l_arm/corporist_maestro
+	name = "corporist maestro left arm"
+	desc = "A prosthetic arm with large gaps in its center and sharp claws at the end. White chassis with gust-patterned design."
+	icon = 'icons/mob/human_parts.dmi'
+	icon_state = "maestro_l_arm"
+	species_id = "maestro"
+	status = BODYPART_ROBOTIC
+	brute_reduction = 5
+	burn_reduction = 4
+	light_brute_msg = CORPORIST_LIGHT_BRUTE_MSG
+	medium_brute_msg = CORPORIST_MEDIUM_BRUTE_MSG
+	heavy_brute_msg = CORPORIST_HEAVY_BRUTE_MSG
+	light_burn_msg = CORPORIST_LIGHT_BURN_MSG
+	medium_burn_msg = CORPORIST_MEDIUM_BURN_MSG
+	heavy_burn_msg = CORPORIST_HEAVY_BURN_MSG
+
+/obj/item/bodypart/l_arm/corporist_maestro/is_organic_limb()
+	return TRUE
+
+/obj/item/bodypart/r_arm/corporist_maestro
+	name = "corporist maestro right arm"
+	desc = "A prosthetic arm with large gaps in its center and sharp claws at the end. White chassis with gust-patterned design."
+	icon = 'icons/mob/human_parts.dmi'
+	icon_state = "maestro_r_arm"
+	species_id = "maestro"
+	status = BODYPART_ROBOTIC
+	brute_reduction = 5
+	burn_reduction = 4
+	light_brute_msg = CORPORIST_LIGHT_BRUTE_MSG
+	medium_brute_msg = CORPORIST_MEDIUM_BRUTE_MSG
+	heavy_brute_msg = CORPORIST_HEAVY_BRUTE_MSG
+	light_burn_msg = CORPORIST_LIGHT_BURN_MSG
+	medium_burn_msg = CORPORIST_MEDIUM_BURN_MSG
+	heavy_burn_msg = CORPORIST_HEAVY_BURN_MSG
+
+/obj/item/bodypart/r_arm/corporist_maestro/is_organic_limb()
+	return TRUE
+
+/obj/item/bodypart/l_leg/corporist_maestro
+	name = "corporist maestro left leg"
+	desc = "A full-bodied prosthetic leg with white chassis and gust-patterned design. Ends in a silver-adorned high-heel."
+	icon = 'icons/mob/human_parts.dmi'
+	icon_state = "maestro_l_leg"
+	species_id = "maestro"
+	status = BODYPART_ROBOTIC
+	brute_reduction = 5
+	burn_reduction = 4
+	light_brute_msg = CORPORIST_LIGHT_BRUTE_MSG
+	medium_brute_msg = CORPORIST_MEDIUM_BRUTE_MSG
+	heavy_brute_msg = CORPORIST_HEAVY_BRUTE_MSG
+	light_burn_msg = CORPORIST_LIGHT_BURN_MSG
+	medium_burn_msg = CORPORIST_MEDIUM_BURN_MSG
+	heavy_burn_msg = CORPORIST_HEAVY_BURN_MSG
+
+/obj/item/bodypart/l_leg/corporist_maestro/is_organic_limb()
+	return TRUE
+
+/obj/item/bodypart/r_leg/corporist_maestro
+	name = "corporist maestro right leg"
+	desc = "A full-bodied prosthetic leg with white chassis and gust-patterned design. Ends in a silver-adorned high-heel."
+	icon = 'icons/mob/human_parts.dmi'
+	icon_state = "maestro_r_leg"
+	species_id = "maestro"
+	status = BODYPART_ROBOTIC
+	brute_reduction = 5
+	burn_reduction = 4
+	light_brute_msg = CORPORIST_LIGHT_BRUTE_MSG
+	medium_brute_msg = CORPORIST_MEDIUM_BRUTE_MSG
+	heavy_brute_msg = CORPORIST_HEAVY_BRUTE_MSG
+	light_burn_msg = CORPORIST_LIGHT_BURN_MSG
+	medium_burn_msg = CORPORIST_MEDIUM_BURN_MSG
+	heavy_burn_msg = CORPORIST_HEAVY_BURN_MSG
+
+/obj/item/bodypart/r_leg/corporist_maestro/is_organic_limb()
+	return TRUE
+
+// ============================================
+// CORPORIST APPRENTICE BODYPARTS
+// Iron maiden style - white/yellow/gold, knightly appearance
+// ============================================
+
+/obj/item/bodypart/head/corporist_apprentice
+	name = "corporist apprentice head"
+	desc = "A humanoid prosthetic head with shapely lines running across the cheeks. Gold highlights accent the design, with black machinery visible at the neck."
+	icon = 'icons/mob/human_parts.dmi'
+	icon_state = "apprentice_head"
+	species_id = "apprentice"
+	status = BODYPART_ROBOTIC
+	brute_reduction = 5
+	burn_reduction = 4
+	light_brute_msg = CORPORIST_LIGHT_BRUTE_MSG
+	medium_brute_msg = CORPORIST_MEDIUM_BRUTE_MSG
+	heavy_brute_msg = CORPORIST_HEAVY_BRUTE_MSG
+	light_burn_msg = CORPORIST_LIGHT_BURN_MSG
+	medium_burn_msg = CORPORIST_MEDIUM_BURN_MSG
+	heavy_burn_msg = CORPORIST_HEAVY_BURN_MSG
+
+/obj/item/bodypart/head/corporist_apprentice/is_organic_limb()
+	return TRUE
+
+/obj/item/bodypart/chest/corporist_apprentice
+	name = "corporist apprentice torso"
+	desc = "A humanoid prosthetic torso with gold highlights. Black machinery and wires are visible at the chest, and the center resembles a human skeleton in its construction."
+	icon = 'icons/mob/human_parts.dmi'
+	icon_state = "apprentice_chest"
+	species_id = "apprentice"
+	status = BODYPART_ROBOTIC
+	brute_reduction = 5
+	burn_reduction = 4
+	light_brute_msg = CORPORIST_LIGHT_BRUTE_MSG
+	medium_brute_msg = CORPORIST_MEDIUM_BRUTE_MSG
+	heavy_brute_msg = CORPORIST_HEAVY_BRUTE_MSG
+	light_burn_msg = CORPORIST_LIGHT_BURN_MSG
+	medium_burn_msg = CORPORIST_MEDIUM_BURN_MSG
+	heavy_burn_msg = CORPORIST_HEAVY_BURN_MSG
+
+/obj/item/bodypart/chest/corporist_apprentice/is_organic_limb()
+	return TRUE
+
+/obj/item/bodypart/l_arm/corporist_apprentice
+	name = "corporist apprentice left arm"
+	desc = "A humanoid prosthetic arm with shapely lines where human joints would lie. Gold highlights accent the design, with the palm featuring black coloring."
+	icon = 'icons/mob/human_parts.dmi'
+	icon_state = "apprentice_l_arm"
+	species_id = "apprentice"
+	status = BODYPART_ROBOTIC
+	brute_reduction = 5
+	burn_reduction = 4
+	light_brute_msg = CORPORIST_LIGHT_BRUTE_MSG
+	medium_brute_msg = CORPORIST_MEDIUM_BRUTE_MSG
+	heavy_brute_msg = CORPORIST_HEAVY_BRUTE_MSG
+	light_burn_msg = CORPORIST_LIGHT_BURN_MSG
+	medium_burn_msg = CORPORIST_MEDIUM_BURN_MSG
+	heavy_burn_msg = CORPORIST_HEAVY_BURN_MSG
+
+/obj/item/bodypart/l_arm/corporist_apprentice/is_organic_limb()
+	return TRUE
+
+/obj/item/bodypart/r_arm/corporist_apprentice
+	name = "corporist apprentice right arm"
+	desc = "A humanoid prosthetic arm with shapely lines where human joints would lie. Gold highlights accent the design, with the palm featuring black coloring."
+	icon = 'icons/mob/human_parts.dmi'
+	icon_state = "apprentice_r_arm"
+	species_id = "apprentice"
+	status = BODYPART_ROBOTIC
+	brute_reduction = 5
+	burn_reduction = 4
+	light_brute_msg = CORPORIST_LIGHT_BRUTE_MSG
+	medium_brute_msg = CORPORIST_MEDIUM_BRUTE_MSG
+	heavy_brute_msg = CORPORIST_HEAVY_BRUTE_MSG
+	light_burn_msg = CORPORIST_LIGHT_BURN_MSG
+	medium_burn_msg = CORPORIST_MEDIUM_BURN_MSG
+	heavy_burn_msg = CORPORIST_HEAVY_BURN_MSG
+
+/obj/item/bodypart/r_arm/corporist_apprentice/is_organic_limb()
+	return TRUE
+
+/obj/item/bodypart/l_leg/corporist_apprentice
+	name = "corporist apprentice left leg"
+	desc = "A humanoid prosthetic leg with shapely lines at the joints. Gold highlights accent the design, with black machinery and wires visible at the thigh."
+	icon = 'icons/mob/human_parts.dmi'
+	icon_state = "apprentice_l_leg"
+	species_id = "apprentice"
+	status = BODYPART_ROBOTIC
+	brute_reduction = 5
+	burn_reduction = 4
+	light_brute_msg = CORPORIST_LIGHT_BRUTE_MSG
+	medium_brute_msg = CORPORIST_MEDIUM_BRUTE_MSG
+	heavy_brute_msg = CORPORIST_HEAVY_BRUTE_MSG
+	light_burn_msg = CORPORIST_LIGHT_BURN_MSG
+	medium_burn_msg = CORPORIST_MEDIUM_BURN_MSG
+	heavy_burn_msg = CORPORIST_HEAVY_BURN_MSG
+
+/obj/item/bodypart/l_leg/corporist_apprentice/is_organic_limb()
+	return TRUE
+
+/obj/item/bodypart/r_leg/corporist_apprentice
+	name = "corporist apprentice right leg"
+	desc = "A humanoid prosthetic leg with shapely lines at the joints. Gold highlights accent the design, with black machinery and wires visible at the thigh."
+	icon = 'icons/mob/human_parts.dmi'
+	icon_state = "apprentice_r_leg"
+	species_id = "apprentice"
+	status = BODYPART_ROBOTIC
+	brute_reduction = 5
+	burn_reduction = 4
+	light_brute_msg = CORPORIST_LIGHT_BRUTE_MSG
+	medium_brute_msg = CORPORIST_MEDIUM_BRUTE_MSG
+	heavy_brute_msg = CORPORIST_HEAVY_BRUTE_MSG
+	light_burn_msg = CORPORIST_LIGHT_BURN_MSG
+	medium_burn_msg = CORPORIST_MEDIUM_BURN_MSG
+	heavy_burn_msg = CORPORIST_HEAVY_BURN_MSG
+
+/obj/item/bodypart/r_leg/corporist_apprentice/is_organic_limb()
+	return TRUE
+
+#undef CORPORIST_LIGHT_BRUTE_MSG
+#undef CORPORIST_MEDIUM_BRUTE_MSG
+#undef CORPORIST_HEAVY_BRUTE_MSG
+
+#undef CORPORIST_LIGHT_BURN_MSG
+#undef CORPORIST_MEDIUM_BURN_MSG
+#undef CORPORIST_HEAVY_BURN_MSG

--- a/code/modules/surgery/bodyparts/corporist_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/corporist_bodyparts.dm
@@ -9,10 +9,8 @@
 #define CORPORIST_MEDIUM_BURN_MSG "charred"
 #define CORPORIST_HEAVY_BURN_MSG "smoldering"
 
-// ============================================
 // CORPORIST MAESTRO BODYPARTS
 // Sleek metallic prosthetics with gaps, glass panes, sharp claws
-// ============================================
 
 /obj/item/bodypart/head/corporist_maestro
 	name = "corporist maestro head"
@@ -129,10 +127,8 @@
 /obj/item/bodypart/r_leg/corporist_maestro/is_organic_limb()
 	return TRUE
 
-// ============================================
 // CORPORIST APPRENTICE BODYPARTS
 // Iron maiden style - white/yellow/gold, knightly appearance
-// ============================================
 
 /obj/item/bodypart/head/corporist_apprentice
 	name = "corporist apprentice head"

--- a/tgui/packages/tgui/interfaces/CarveBodyEditor.js
+++ b/tgui/packages/tgui/interfaces/CarveBodyEditor.js
@@ -1,0 +1,483 @@
+import {
+  Component,
+  createRef,
+} from 'inferno';
+import { useBackend } from '../backend';
+import {
+  Box,
+  Button,
+  Flex,
+  Section,
+  Stack,
+} from '../components';
+import { Window } from '../layouts';
+
+const MIN_PX = 4;
+const MAX_PX = 12;
+const TARGET_CANVAS = 640;
+const MIN_SECTION = 8;
+
+class CarveCanvas extends Component {
+  constructor(props) {
+    super(props);
+    this.canvasRef = createRef();
+    this.imgCache = null;
+    this.opaqueSet = null;
+    this.painting = false;
+    this.paintMode = 'select';
+    this.paintedPixels = [];
+    this.localSelected = {};
+    this.lastPos = null;
+  }
+
+  componentDidMount() {
+    this.buildOpaqueSet();
+    this.syncSelected();
+    this.drawCanvas();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.sourceBase64
+      !== this.props.sourceBase64) {
+      this.imgCache = null;
+      this.buildOpaqueSet();
+    }
+    if (prevProps.selectedPixels
+      !== this.props.selectedPixels) {
+      this.syncSelected();
+    }
+    this.drawCanvas();
+  }
+
+  buildOpaqueSet() {
+    const { opaquePixels } = this.props;
+    const s = {};
+    if (opaquePixels) {
+      for (const p of opaquePixels) {
+        s[p.x + ',' + p.y] = true;
+      }
+    }
+    this.opaqueSet = s;
+  }
+
+  syncSelected() {
+    const { selectedPixels } = this.props;
+    const s = {};
+    if (selectedPixels) {
+      for (const p of selectedPixels) {
+        s[p.x + ',' + p.y] = true;
+      }
+    }
+    this.localSelected = s;
+  }
+
+  getPxPerCell() {
+    const { sourceWidth } = this.props;
+    return Math.max(MIN_PX, Math.min(MAX_PX,
+      Math.floor(TARGET_CANVAS / sourceWidth)
+    ));
+  }
+
+  getPixelPos(e) {
+    const rect = this.canvasRef.current
+      .getBoundingClientRect();
+    const ppc = this.getPxPerCell();
+    const x = Math.floor(
+      (e.clientX - rect.left) / ppc
+    );
+    const y = Math.floor(
+      (e.clientY - rect.top) / ppc
+    );
+    return { x, y };
+  }
+
+  isOpaque(x, y) {
+    if (!this.opaqueSet) return false;
+    return !!this.opaqueSet[x + ',' + y];
+  }
+
+  handleMouseDown(e) {
+    const pos = this.getPixelPos(e);
+    if (!this.isOpaque(pos.x, pos.y)) return;
+
+    const key = pos.x + ',' + pos.y;
+    this.paintMode = this.localSelected[key]
+      ? 'deselect' : 'select';
+    this.painting = true;
+    this.paintedPixels = [];
+    this.lastPos = pos;
+    this.togglePixel(pos.x, pos.y);
+    this.drawCanvas();
+  }
+
+  handleMouseMove(e) {
+    if (!this.painting) return;
+    const pos = this.getPixelPos(e);
+    if (this.lastPos) {
+      this.paintLine(
+        this.lastPos.x, this.lastPos.y,
+        pos.x, pos.y
+      );
+    }
+    this.lastPos = pos;
+    this.drawCanvas();
+  }
+
+  handleMouseUp() {
+    if (!this.painting) return;
+    this.painting = false;
+    this.lastPos = null;
+    if (this.paintedPixels.length) {
+      const { onToggle } = this.props;
+      if (onToggle) {
+        onToggle(
+          this.paintedPixels,
+          this.paintMode
+        );
+      }
+      this.paintedPixels = [];
+    }
+  }
+
+  handleMouseLeave() {
+    if (this.painting) {
+      this.handleMouseUp();
+    }
+  }
+
+  togglePixel(x, y) {
+    if (!this.isOpaque(x, y)) return;
+    const key = x + ',' + y;
+    if (this.paintMode === 'select') {
+      if (this.localSelected[key]) return;
+      this.localSelected[key] = true;
+    } else {
+      if (!this.localSelected[key]) return;
+      delete this.localSelected[key];
+    }
+    this.paintedPixels.push({ x, y });
+  }
+
+  paintLine(x0, y0, x1, y1) {
+    const dx = Math.abs(x1 - x0);
+    const dy = -Math.abs(y1 - y0);
+    const sx = x0 < x1 ? 1 : -1;
+    const sy = y0 < y1 ? 1 : -1;
+    let err = dx + dy;
+    let x = x0;
+    let y = y0;
+    while (true) {
+      this.togglePixel(x, y);
+      if (x === x1 && y === y1) break;
+      const e2 = 2 * err;
+      if (e2 >= dy) { err += dy; x += sx; }
+      if (e2 <= dx) { err += dx; y += sy; }
+    }
+  }
+
+  loadImage() {
+    if (this.imgCache) return this.imgCache;
+    const { sourceBase64 } = this.props;
+    if (!sourceBase64) return null;
+    const img = new Image();
+    img.onload = () => {
+      this.imgCache = img;
+      this.drawCanvas();
+    };
+    img.src = 'data:image/png;base64,'
+      + sourceBase64;
+    return null;
+  }
+
+  drawCanvas() {
+    const canvas = this.canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    const { sourceWidth, sourceHeight }
+      = this.props;
+    const ppc = this.getPxPerCell();
+    const cw = sourceWidth * ppc;
+    const ch = sourceHeight * ppc;
+
+    ctx.clearRect(0, 0, cw, ch);
+    this.drawCheckerboard(ctx, ppc);
+    this.drawSprite(ctx, ppc);
+    this.drawTransparentOverlay(ctx, ppc);
+    this.drawSelection(ctx, ppc);
+    this.drawSectionOutlines(ctx, ppc);
+  }
+
+  drawCheckerboard(ctx, ppc) {
+    const { sourceWidth, sourceHeight }
+      = this.props;
+    for (let y = 0; y < sourceHeight; y++) {
+      for (let x = 0; x < sourceWidth; x++) {
+        ctx.fillStyle = (x + y) % 2 === 0
+          ? '#2a2a2a' : '#222222';
+        ctx.fillRect(
+          x * ppc, y * ppc, ppc, ppc
+        );
+      }
+    }
+  }
+
+  drawSprite(ctx, ppc) {
+    const img = this.loadImage();
+    if (!img) return;
+    const { sourceWidth, sourceHeight }
+      = this.props;
+    ctx.imageSmoothingEnabled = false;
+    ctx.drawImage(
+      img, 0, 0,
+      sourceWidth * ppc,
+      sourceHeight * ppc
+    );
+  }
+
+  drawTransparentOverlay(ctx, ppc) {
+    const { sourceWidth, sourceHeight }
+      = this.props;
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
+    for (let y = 0; y < sourceHeight; y++) {
+      for (let x = 0; x < sourceWidth; x++) {
+        if (!this.isOpaque(x, y)) {
+          ctx.fillRect(
+            x * ppc, y * ppc, ppc, ppc
+          );
+        }
+      }
+    }
+  }
+
+  drawSelection(ctx, ppc) {
+    ctx.fillStyle = 'rgba(68, 136, 255, 0.35)';
+    for (const key in this.localSelected) {
+      const [x, y] = key.split(',').map(Number);
+      ctx.fillRect(
+        x * ppc, y * ppc, ppc, ppc
+      );
+    }
+  }
+
+  drawSectionOutlines(ctx, ppc) {
+    const { sections } = this.props;
+    if (!sections) return;
+    for (const section of sections) {
+      const color = section.valid
+        ? 'rgba(0, 200, 0, 0.7)'
+        : 'rgba(200, 0, 0, 0.7)';
+      ctx.strokeStyle = color;
+      ctx.lineWidth = 2;
+      const pxSet = {};
+      for (const p of section.pixels) {
+        pxSet[p.x + ',' + p.y] = true;
+      }
+      for (const p of section.pixels) {
+        const px = p.x * ppc;
+        const py = p.y * ppc;
+        if (!pxSet[(p.x - 1) + ',' + p.y]) {
+          ctx.beginPath();
+          ctx.moveTo(px, py);
+          ctx.lineTo(px, py + ppc);
+          ctx.stroke();
+        }
+        if (!pxSet[(p.x + 1) + ',' + p.y]) {
+          ctx.beginPath();
+          ctx.moveTo(px + ppc, py);
+          ctx.lineTo(px + ppc, py + ppc);
+          ctx.stroke();
+        }
+        if (!pxSet[p.x + ',' + (p.y - 1)]) {
+          ctx.beginPath();
+          ctx.moveTo(px, py);
+          ctx.lineTo(px + ppc, py);
+          ctx.stroke();
+        }
+        if (!pxSet[p.x + ',' + (p.y + 1)]) {
+          ctx.beginPath();
+          ctx.moveTo(px, py + ppc);
+          ctx.lineTo(px + ppc, py + ppc);
+          ctx.stroke();
+        }
+      }
+    }
+  }
+
+  render() {
+    const { sourceWidth, sourceHeight }
+      = this.props;
+    const ppc = this.getPxPerCell();
+    return (
+      <canvas
+        ref={this.canvasRef}
+        width={sourceWidth * ppc}
+        height={sourceHeight * ppc}
+        tabIndex="0"
+        style={{
+          cursor: 'crosshair',
+          border: '1px solid #555',
+          outline: 'none',
+        }}
+        onMouseDown={e =>
+          this.handleMouseDown(e)}
+        onMouseMove={e =>
+          this.handleMouseMove(e)}
+        onMouseUp={() =>
+          this.handleMouseUp()}
+        onMouseLeave={() =>
+          this.handleMouseLeave()}
+      />
+    );
+  }
+}
+
+export const CarveBodyEditor = (
+  props, context
+) => {
+  const { act, data } = useBackend(context);
+  const {
+    selectedPixels = [],
+    sections = [],
+  } = data;
+  const sourceBase64 = data.sourceBase64 || '';
+  const sourceWidth = data.sourceWidth || 32;
+  const sourceHeight = data.sourceHeight || 32;
+  const opaquePixels = data.opaquePixels || [];
+  const mobName = data.mobName || 'creature';
+  const hasBoth = data.hasBothSprites || false;
+  const usingLiving = data.usingLiving || false;
+
+  const ppc = Math.max(MIN_PX, Math.min(MAX_PX,
+    Math.floor(TARGET_CANVAS / sourceWidth)
+  ));
+  const canvasW = sourceWidth * ppc;
+  const canvasH = sourceHeight * ppc;
+
+  const validCount = sections.filter(
+    s => s.valid
+  ).length;
+  const totalSelected = selectedPixels.length;
+
+  return (
+    <Window
+      width={Math.max(canvasW + 230, 500)}
+      height={Math.max(canvasH + 50, 400)}
+    >
+      <Window.Content>
+        <Flex>
+          <Flex.Item>
+            <CarveCanvas
+              sourceBase64={sourceBase64}
+              sourceWidth={sourceWidth}
+              sourceHeight={sourceHeight}
+              opaquePixels={opaquePixels}
+              selectedPixels={selectedPixels}
+              sections={sections}
+              onToggle={(pixels, mode) => {
+                act('toggle_pixels', {
+                  pixels,
+                  mode,
+                });
+              }}
+            />
+          </Flex.Item>
+          <Flex.Item
+            width="210px"
+            ml={1}
+          >
+            <Stack vertical fill>
+              <Stack.Item>
+                <Section title={mobName}>
+                  <Box>
+                    Size: {sourceWidth}
+                    x{sourceHeight}
+                  </Box>
+                  <Box mt={0.5}>
+                    Selected: {totalSelected}
+                    {' pixels'}
+                  </Box>
+                  <Box mt={0.5}>
+                    Valid groups: {validCount}
+                  </Box>
+                  {!!hasBoth && (
+                    <Box mt={1}>
+                      <Button
+                        fluid
+                        icon="sync"
+                        onClick={() => act(
+                          'switch_sprite'
+                        )}
+                      >
+                        {usingLiving
+                          ? 'Living'
+                          : 'Dead'}
+                        {' Sprite'}
+                      </Button>
+                    </Box>
+                  )}
+                </Section>
+              </Stack.Item>
+              <Stack.Item grow>
+                <Section
+                  title="Sections"
+                  fill
+                  scrollable
+                >
+                  {sections.length === 0 && (
+                    <Box color="label">
+                      Select pixels to
+                      create sections.
+                    </Box>
+                  )}
+                  {sections.map((s, i) => (
+                    <Box
+                      key={i}
+                      mb={0.5}
+                      color={s.valid
+                        ? 'good' : 'bad'}
+                    >
+                      Group {i + 1}:
+                      {' '}{s.size} pixels
+                      {s.valid
+                        ? '' : ' (need 8+)'}
+                    </Box>
+                  ))}
+                </Section>
+              </Stack.Item>
+              <Stack.Item>
+                <Stack>
+                  <Stack.Item grow>
+                    <Button
+                      fluid
+                      onClick={() => act(
+                        'clear_selection'
+                      )}
+                    >
+                      Clear
+                    </Button>
+                  </Stack.Item>
+                </Stack>
+              </Stack.Item>
+              <Stack.Item>
+                <Button
+                  fluid
+                  color="good"
+                  disabled={!validCount}
+                  textAlign="center"
+                  onClick={() => act(
+                    'carve_out'
+                  )}
+                >
+                  Carve Out
+                  ({validCount} piece
+                  {validCount !== 1
+                    ? 's' : ''})
+                </Button>
+              </Stack.Item>
+            </Stack>
+          </Flex.Item>
+        </Flex>
+      </Window.Content>
+    </Window>
+  );
+};

--- a/tgui/packages/tgui/interfaces/CustomArtworkEditor.js
+++ b/tgui/packages/tgui/interfaces/CustomArtworkEditor.js
@@ -7,6 +7,7 @@ import {
   Box,
   Button,
   Flex,
+  ProgressBar,
   Section,
   Stack,
 } from '../components';
@@ -62,6 +63,7 @@ class ArtworkCanvas extends Component {
   }
 
   componentDidUpdate() {
+    this._veinSet = null;
     this.drawCanvas();
   }
 
@@ -77,15 +79,25 @@ class ArtworkCanvas extends Component {
     return { x, y };
   }
 
+  getCropData(partId, rotation) {
+    const key = partId + '_' + (rotation || 0);
+    return this.imageCache[key] || null;
+  }
+
   getPartAtPos(x, y) {
     const { placedParts } = this.props;
     for (let i = placedParts.length - 1; i >= 0; i--) {
       const p = placedParts[i];
+      const crop = this.getCropData(p.id, p.rotation);
+      const ox = crop ? crop.offsetX : 0;
+      const oy = crop ? crop.offsetY : 0;
+      const w = crop ? crop.width : PART_SIZE;
+      const h = crop ? crop.height : PART_SIZE;
       if (
-        x >= p.gridX
-        && x < p.gridX + PART_SIZE
-        && y >= p.gridY
-        && y < p.gridY + PART_SIZE
+        x >= p.gridX + ox
+        && x < p.gridX + ox + w
+        && y >= p.gridY + oy
+        && y < p.gridY + oy + h
       ) {
         return p.id;
       }
@@ -93,22 +105,68 @@ class ArtworkCanvas extends Component {
     return null;
   }
 
-  paintCellAt(cx, cy) {
-    // 2x2 brush for visibility
-    for (let dx = 0; dx < 2; dx++) {
-      for (let dy = 0; dy < 2; dy++) {
-        const x = cx + dx;
-        const y = cy + dy;
-        if (x >= 1 && x <= GRID_SIZE
-          && y >= 1 && y <= GRID_SIZE) {
-          this.paintedCells[x + ',' + y] = { x, y };
-        }
+  getVeinSet() {
+    if (this._veinSet) return this._veinSet;
+    const { veinPixels } = this.props;
+    const s = {};
+    if (veinPixels) {
+      for (const p of veinPixels) {
+        s[p.x + ',' + p.y] = true;
       }
+    }
+    this._veinSet = s;
+    return s;
+  }
+
+  isVeinAt(x, y) {
+    const key = x + ',' + y;
+    if (this.paintedCells[key]) return true;
+    return !!this.getVeinSet()[key];
+  }
+
+  countCardinalNeighbors(x, y) {
+    let n = 0;
+    if (this.isVeinAt(x - 1, y)) n++;
+    if (this.isVeinAt(x + 1, y)) n++;
+    if (this.isVeinAt(x, y - 1)) n++;
+    if (this.isVeinAt(x, y + 1)) n++;
+    return n;
+  }
+
+  canPlaceVein(x, y) {
+    if (x < 1 || x > GRID_SIZE
+      || y < 1 || y > GRID_SIZE) {
+      return false;
+    }
+    if (this.isVeinAt(x, y)) return false;
+    const dirs = [
+      [-1, 0], [1, 0], [0, -1], [0, 1],
+    ];
+    let myNeighbors = 0;
+    for (const [dx, dy] of dirs) {
+      if (this.isVeinAt(x + dx, y + dy)) {
+        myNeighbors++;
+        const nn = this.countCardinalNeighbors(
+          x + dx, y + dy
+        );
+        if (nn >= 2) return false;
+      }
+    }
+    if (myNeighbors > 2) return false;
+    return true;
+  }
+
+  paintCellAt(cx, cy) {
+    if (this.canPlaceVein(cx, cy)) {
+      this.paintedCells[cx + ',' + cy] = {
+        x: cx,
+        y: cy,
+      };
     }
   }
 
   paintCellsAlongLine(x0, y0, x1, y1) {
-    // Bresenham's line algorithm, 2x2 brush at each step
+    // Bresenham's line algorithm
     const dx = Math.abs(x1 - x0);
     const dy = -Math.abs(y1 - y0);
     const sx = x0 < x1 ? 1 : -1;
@@ -169,7 +227,13 @@ class ArtworkCanvas extends Component {
     const cellX = pos.x + 1;
     const cellY = pos.y + 1;
 
-    if (this.veinPainting || this.veinErasing) {
+    if (this.dragging) {
+      this.dragPreviewX = pos.x - this.dragOffsetX;
+      this.dragPreviewY = pos.y - this.dragOffsetY;
+      this.drawCanvas();
+    } else if (
+      this.veinPainting || this.veinErasing
+    ) {
       if (!this.lastCell) {
         this.lastCell = { x: cellX, y: cellY };
       }
@@ -182,6 +246,31 @@ class ArtworkCanvas extends Component {
       this.lastCell = { x: cellX, y: cellY };
       this.drawCanvas();
     }
+  }
+
+  handleKeyDown(e) {
+    const { onMove, selectedPartId, placedParts }
+      = this.props;
+    if (!selectedPartId || !onMove) return;
+    const part = placedParts.find(
+      p => p.id === selectedPartId
+    );
+    if (!part) return;
+    let dx = 0;
+    let dy = 0;
+    switch (e.key) {
+      case 'ArrowUp': dy = -1; break;
+      case 'ArrowDown': dy = 1; break;
+      case 'ArrowLeft': dx = -1; break;
+      case 'ArrowRight': dx = 1; break;
+      default: return;
+    }
+    e.preventDefault();
+    onMove(
+      selectedPartId,
+      part.gridX + dx,
+      part.gridY + dy
+    );
   }
 
   handleMouseUp(e) {
@@ -203,9 +292,22 @@ class ArtworkCanvas extends Component {
       }
       this.dragging = false;
       this.dragPartId = null;
+      this.dragPreviewX = undefined;
+      this.dragPreviewY = undefined;
     } else if (tool === 'place' && selectedPartId) {
-      const placeX = pos.x - Math.floor(PART_SIZE / 2);
-      const placeY = pos.y - Math.floor(PART_SIZE / 2);
+      const { cropData } = this.props;
+      const rc = cropData
+        && cropData[selectedPartId]
+        && cropData[selectedPartId]['0']
+        || null;
+      const ox = rc ? rc.ox : 0;
+      const oy = rc ? rc.oy : 0;
+      const cw = rc ? rc.w : PART_SIZE;
+      const ch = rc ? rc.h : PART_SIZE;
+      const placeX = pos.x
+        - Math.floor(cw / 2) - ox;
+      const placeY = pos.y
+        - Math.floor(ch / 2) - oy;
       if (onPlace) {
         onPlace(selectedPartId, placeX, placeY);
       }
@@ -236,7 +338,7 @@ class ArtworkCanvas extends Component {
   }
 
   loadImage(partId, rotation) {
-    const { partIcons } = this.props;
+    const { partIcons, cropData } = this.props;
     const key = partId + '_' + rotation;
     if (this.imageCache[key]) {
       return this.imageCache[key];
@@ -245,12 +347,23 @@ class ArtworkCanvas extends Component {
     if (!icons) return null;
     const base64 = icons[String(rotation || 0)];
     if (!base64) return null;
+    const rotCrops = cropData
+      && cropData[partId] || null;
+    const crop = rotCrops
+      && rotCrops[String(rotation || 0)]
+      || null;
     const img = new Image();
     img.onload = () => {
-      this.imageCache[key] = img;
+      this.imageCache[key] = {
+        img,
+        offsetX: crop ? crop.ox : 0,
+        offsetY: crop ? crop.oy : 0,
+        width: crop ? crop.w : img.width,
+        height: crop ? crop.h : img.height,
+      };
       this.drawCanvas();
     };
-    img.src = base64;
+    img.src = 'data:image/png;base64,' + base64;
     return null;
   }
 
@@ -284,17 +397,45 @@ class ArtworkCanvas extends Component {
   }
 
   drawGroundLine(ctx) {
-    // Solid ground bar at the bottom of the canvas
-    const barHeight = PX_PER_CELL;
-    const barY = CANVAS_PX - barHeight;
-    ctx.fillStyle = '#3a2a1a';
-    ctx.fillRect(0, barY, CANVAS_PX, barHeight);
-    ctx.strokeStyle = '#5a3a2a';
-    ctx.lineWidth = 1;
-    ctx.beginPath();
-    ctx.moveTo(0, barY);
-    ctx.lineTo(CANVAS_PX, barY);
-    ctx.stroke();
+    const s = PX_PER_CELL;
+    const dark = '#8b745c';
+    const med = '#927d67';
+    const light = '#978471';
+    // Pedestal at grid (14,36)-(33,39)
+    // matches statue.dmi "base" icon
+    const bx = 14;
+    const by = 36;
+    const bw = 20;
+    // Row 0: solid dark top edge
+    ctx.fillStyle = dark;
+    ctx.fillRect(bx * s, by * s, bw * s, s);
+    // Row 1: dark edges, alternating pattern
+    ctx.fillStyle = dark;
+    ctx.fillRect(bx * s, (by + 1) * s, s, s);
+    ctx.fillRect((bx + bw - 1) * s,
+      (by + 1) * s, s, s);
+    for (let i = 1; i < bw - 1; i++) {
+      ctx.fillStyle = i % 2 === 0
+        ? med : light;
+      ctx.fillRect((bx + i) * s,
+        (by + 1) * s, s, s);
+    }
+    // Row 2: inset by 1 on each side
+    for (let i = 1; i < bw - 1; i++) {
+      ctx.fillStyle = (i % 3 === 0)
+        ? light : (i % 3 === 1)
+          ? med : dark;
+      ctx.fillRect((bx + i) * s,
+        (by + 2) * s, s, s);
+    }
+    // Row 3: full width, mixed pattern
+    for (let i = 0; i < bw; i++) {
+      ctx.fillStyle = (i % 3 === 0)
+        ? dark : (i % 3 === 1)
+          ? med : light;
+      ctx.fillRect((bx + i) * s,
+        (by + 3) * s, s, s);
+    }
   }
 
   drawVeins(ctx) {
@@ -337,27 +478,56 @@ class ArtworkCanvas extends Component {
 
     ctx.imageSmoothingEnabled = false;
     for (const part of placedParts) {
-      const img = this.loadImage(
+      const crop = this.loadImage(
         part.id,
         part.rotation
       );
-      if (!img) continue;
+      if (!crop) continue;
 
-      const px = part.gridX * PX_PER_CELL;
-      const py = part.gridY * PX_PER_CELL;
-      const pw = PART_SIZE * PX_PER_CELL;
-      const ph = PART_SIZE * PX_PER_CELL;
-
-      ctx.save();
-      ctx.drawImage(img, px, py, pw, ph);
+      const { img, offsetX, offsetY, width, height }
+        = crop;
+      let gx = part.gridX;
+      let gy = part.gridY;
+      if (this.dragging
+        && this.dragPartId === part.id
+        && this.dragPreviewX !== undefined) {
+        gx = this.dragPreviewX;
+        gy = this.dragPreviewY;
+      }
+      const px = (gx + offsetX) * PX_PER_CELL;
+      const py = (gy + offsetY) * PX_PER_CELL;
+      const pw = width * PX_PER_CELL;
+      const ph = height * PX_PER_CELL;
 
       if (part.tint && part.tint !== '#ffffff') {
-        ctx.globalCompositeOperation = 'multiply';
-        ctx.fillStyle = part.tint;
-        ctx.fillRect(px, py, pw, ph);
-        ctx.globalCompositeOperation = 'source-over';
+        const tc = document.createElement('canvas');
+        tc.width = pw;
+        tc.height = ph;
+        const tx = tc.getContext('2d');
+        tx.imageSmoothingEnabled = false;
+        tx.drawImage(
+          img,
+          offsetX, offsetY, width, height,
+          0, 0, pw, ph
+        );
+        tx.globalCompositeOperation = 'multiply';
+        tx.fillStyle = part.tint;
+        tx.fillRect(0, 0, pw, ph);
+        tx.globalCompositeOperation
+          = 'destination-in';
+        tx.drawImage(
+          img,
+          offsetX, offsetY, width, height,
+          0, 0, pw, ph
+        );
+        ctx.drawImage(tc, px, py);
+      } else {
+        ctx.drawImage(
+          img,
+          offsetX, offsetY, width, height,
+          px, py, pw, ph
+        );
       }
-      ctx.restore();
     }
   }
 
@@ -369,14 +539,31 @@ class ArtworkCanvas extends Component {
     );
     if (!part) return;
 
+    const crop = this.getCropData(
+      part.id, part.rotation
+    );
+    const ox = crop ? crop.offsetX : 0;
+    const oy = crop ? crop.offsetY : 0;
+    const w = crop ? crop.width : PART_SIZE;
+    const h = crop ? crop.height : PART_SIZE;
+
+    let gx = part.gridX;
+    let gy = part.gridY;
+    if (this.dragging
+      && this.dragPartId === part.id
+      && this.dragPreviewX !== undefined) {
+      gx = this.dragPreviewX;
+      gy = this.dragPreviewY;
+    }
+
     ctx.strokeStyle = '#4488ff';
     ctx.lineWidth = 2;
     ctx.setLineDash([4, 4]);
     ctx.strokeRect(
-      part.gridX * PX_PER_CELL,
-      part.gridY * PX_PER_CELL,
-      PART_SIZE * PX_PER_CELL,
-      PART_SIZE * PX_PER_CELL
+      (gx + ox) * PX_PER_CELL,
+      (gy + oy) * PX_PER_CELL,
+      w * PX_PER_CELL,
+      h * PX_PER_CELL
     );
     ctx.setLineDash([]);
   }
@@ -387,14 +574,24 @@ class ArtworkCanvas extends Component {
         ref={this.canvasRef}
         width={CANVAS_PX}
         height={CANVAS_PX}
+        tabIndex="0"
         style={{
           cursor: 'crosshair',
           border: '1px solid #555',
+          outline: 'none',
         }}
-        onMouseDown={e => this.handleMouseDown(e)}
-        onMouseMove={e => this.handleMouseMove(e)}
-        onMouseUp={e => this.handleMouseUp(e)}
-        onMouseLeave={e => this.handleMouseLeave(e)}
+        onMouseDown={e => {
+          this.handleMouseDown(e);
+          this.canvasRef.current.focus();
+        }}
+        onMouseMove={e =>
+          this.handleMouseMove(e)}
+        onMouseUp={e =>
+          this.handleMouseUp(e)}
+        onMouseLeave={e =>
+          this.handleMouseLeave(e)}
+        onKeyDown={e =>
+          this.handleKeyDown(e)}
       />
     );
   }
@@ -409,13 +606,8 @@ export const CustomArtworkEditor = (props, context) => {
     veinsAbove,
   } = data;
 
-  const staticData = data;
-  const partIcons = staticData.partIcons || {};
-
-  const [
-    selectedPartId,
-    setSelectedPartId,
-  ] = [null, () => {}];
+  const partIcons = data.partIcons || {};
+  const cropData = data.cropData || {};
 
   return (
     <Window width={790} height={640}>
@@ -427,6 +619,10 @@ export const CustomArtworkEditor = (props, context) => {
           veinPixels={veinPixels}
           veinsAbove={veinsAbove}
           partIcons={partIcons}
+          cropData={cropData}
+          storedBlood={data.storedBlood || 0}
+          bloodCost={data.bloodCost || 0}
+          bloodRefund={data.bloodRefund || 0}
         />
       </Window.Content>
     </Window>
@@ -450,6 +646,10 @@ class CustomArtworkEditorInner extends Component {
       veinPixels,
       veinsAbove,
       partIcons,
+      cropData,
+      storedBlood,
+      bloodCost,
+      bloodRefund,
     } = this.props;
     const { tool, selectedPartId } = this.state;
 
@@ -465,6 +665,7 @@ class CustomArtworkEditorInner extends Component {
             veinPixels={veinPixels}
             veinsAbove={veinsAbove}
             partIcons={partIcons}
+            cropData={cropData}
             tool={tool}
             selectedPartId={selectedPartId}
             onSelect={id => {
@@ -615,6 +816,26 @@ class CustomArtworkEditorInner extends Component {
             )}
             <Stack.Item>
               <Section title="Veins">
+                <Box mb={0.5}>
+                  <ProgressBar
+                    value={storedBlood}
+                    maxValue={500}
+                    color="red"
+                  >
+                    {storedBlood
+                      + 'u / 500u Blood'}
+                  </ProgressBar>
+                </Box>
+                {!!bloodCost && (
+                  <Box mb={0.5} color="bad">
+                    Cost: {bloodCost}u
+                  </Box>
+                )}
+                {!!bloodRefund && (
+                  <Box mb={0.5} color="good">
+                    Refund: {bloodRefund}u
+                  </Box>
+                )}
                 <Stack>
                   <Stack.Item mr={0.5}>
                     <Button

--- a/tgui/packages/tgui/interfaces/CustomArtworkEditor.js
+++ b/tgui/packages/tgui/interfaces/CustomArtworkEditor.js
@@ -1,0 +1,658 @@
+import {
+  Component,
+  createRef,
+} from 'inferno';
+import { useBackend } from '../backend';
+import {
+  Box,
+  Button,
+  Flex,
+  Section,
+  Stack,
+} from '../components';
+import { Window } from '../layouts';
+
+const GRID_SIZE = 48;
+const PX_PER_CELL = 10;
+const CANVAS_PX = GRID_SIZE * PX_PER_CELL;
+const PART_SIZE = 32;
+
+const TINTS = [
+  { label: 'Normal', color: '#ffffff' },
+  { label: 'Bloody', color: '#ff4444' },
+  { label: 'Drained', color: '#888888' },
+  { label: 'Pale', color: '#ddcccc' },
+  { label: 'Necrotic', color: '#445544' },
+];
+
+const TOOLS = [
+  { id: 'select', label: 'Select' },
+  { id: 'place', label: 'Place' },
+  { id: 'move', label: 'Move' },
+  { id: 'vein', label: 'Draw Vein' },
+  { id: 'erase_vein', label: 'Erase Vein' },
+];
+
+const ZONE_LABELS = {
+  head: 'Head',
+  chest: 'Chest',
+  l_arm: 'L. Arm',
+  r_arm: 'R. Arm',
+  l_leg: 'L. Leg',
+  r_leg: 'R. Leg',
+};
+
+class ArtworkCanvas extends Component {
+  constructor(props) {
+    super(props);
+    this.canvasRef = createRef();
+    this.imageCache = {};
+    this.dragging = false;
+    this.dragPartId = null;
+    this.dragOffsetX = 0;
+    this.dragOffsetY = 0;
+    this.veinPainting = false;
+    this.veinErasing = false;
+    this.paintedCells = {};
+    this.lastCell = null;
+  }
+
+  componentDidMount() {
+    this.drawCanvas();
+  }
+
+  componentDidUpdate() {
+    this.drawCanvas();
+  }
+
+  getGridPos(e) {
+    const rect = this.canvasRef.current
+      .getBoundingClientRect();
+    const x = Math.floor(
+      (e.clientX - rect.left) / PX_PER_CELL
+    );
+    const y = Math.floor(
+      (e.clientY - rect.top) / PX_PER_CELL
+    );
+    return { x, y };
+  }
+
+  getPartAtPos(x, y) {
+    const { placedParts } = this.props;
+    for (let i = placedParts.length - 1; i >= 0; i--) {
+      const p = placedParts[i];
+      if (
+        x >= p.gridX
+        && x < p.gridX + PART_SIZE
+        && y >= p.gridY
+        && y < p.gridY + PART_SIZE
+      ) {
+        return p.id;
+      }
+    }
+    return null;
+  }
+
+  paintCellAt(cx, cy) {
+    // 2x2 brush for visibility
+    for (let dx = 0; dx < 2; dx++) {
+      for (let dy = 0; dy < 2; dy++) {
+        const x = cx + dx;
+        const y = cy + dy;
+        if (x >= 1 && x <= GRID_SIZE
+          && y >= 1 && y <= GRID_SIZE) {
+          this.paintedCells[x + ',' + y] = { x, y };
+        }
+      }
+    }
+  }
+
+  paintCellsAlongLine(x0, y0, x1, y1) {
+    // Bresenham's line algorithm, 2x2 brush at each step
+    const dx = Math.abs(x1 - x0);
+    const dy = -Math.abs(y1 - y0);
+    const sx = x0 < x1 ? 1 : -1;
+    const sy = y0 < y1 ? 1 : -1;
+    let err = dx + dy;
+    let x = x0;
+    let y = y0;
+    while (true) {
+      this.paintCellAt(x, y);
+      if (x === x1 && y === y1) break;
+      const e2 = 2 * err;
+      if (e2 >= dy) { err += dy; x += sx; }
+      if (e2 <= dx) { err += dx; y += sy; }
+    }
+  }
+
+  handleMouseDown(e) {
+    const { tool, onSelect } = this.props;
+    const pos = this.getGridPos(e);
+    const cellX = pos.x + 1;
+    const cellY = pos.y + 1;
+
+    if (tool === 'select') {
+      const partId = this.getPartAtPos(pos.x, pos.y);
+      if (partId && onSelect) {
+        onSelect(partId);
+      }
+    } else if (tool === 'move') {
+      const partId = this.getPartAtPos(pos.x, pos.y);
+      if (partId) {
+        this.dragging = true;
+        this.dragPartId = partId;
+        const part = this.props.placedParts.find(
+          p => p.id === partId
+        );
+        if (part) {
+          this.dragOffsetX = pos.x - part.gridX;
+          this.dragOffsetY = pos.y - part.gridY;
+        }
+      }
+    } else if (tool === 'vein') {
+      this.veinPainting = true;
+      this.paintedCells = {};
+      this.lastCell = { x: cellX, y: cellY };
+      this.paintCellAt(cellX, cellY);
+      this.drawCanvas();
+    } else if (tool === 'erase_vein') {
+      this.veinErasing = true;
+      this.paintedCells = {};
+      this.lastCell = { x: cellX, y: cellY };
+      this.paintCellAt(cellX, cellY);
+      this.drawCanvas();
+    }
+  }
+
+  handleMouseMove(e) {
+    const pos = this.getGridPos(e);
+    const cellX = pos.x + 1;
+    const cellY = pos.y + 1;
+
+    if (this.veinPainting || this.veinErasing) {
+      if (!this.lastCell) {
+        this.lastCell = { x: cellX, y: cellY };
+      }
+      this.paintCellsAlongLine(
+        this.lastCell.x,
+        this.lastCell.y,
+        cellX,
+        cellY
+      );
+      this.lastCell = { x: cellX, y: cellY };
+      this.drawCanvas();
+    }
+  }
+
+  handleMouseUp(e) {
+    const {
+      tool,
+      onMove,
+      onPlace,
+      onPaintVeins,
+      onEraseVeins,
+      selectedPartId,
+    } = this.props;
+    const pos = this.getGridPos(e);
+
+    if (tool === 'move' && this.dragging) {
+      const newX = pos.x - this.dragOffsetX;
+      const newY = pos.y - this.dragOffsetY;
+      if (onMove) {
+        onMove(this.dragPartId, newX, newY);
+      }
+      this.dragging = false;
+      this.dragPartId = null;
+    } else if (tool === 'place' && selectedPartId) {
+      const placeX = pos.x - Math.floor(PART_SIZE / 2);
+      const placeY = pos.y - Math.floor(PART_SIZE / 2);
+      if (onPlace) {
+        onPlace(selectedPartId, placeX, placeY);
+      }
+    } else if (this.veinPainting) {
+      const cells = Object.values(this.paintedCells);
+      if (cells.length && onPaintVeins) {
+        onPaintVeins(cells);
+      }
+      this.veinPainting = false;
+      this.paintedCells = {};
+      this.lastCell = null;
+    } else if (this.veinErasing) {
+      const cells = Object.values(this.paintedCells);
+      if (cells.length && onEraseVeins) {
+        onEraseVeins(cells);
+      }
+      this.veinErasing = false;
+      this.paintedCells = {};
+      this.lastCell = null;
+    }
+  }
+
+  handleMouseLeave(e) {
+    // Cancel any in-progress drawing
+    if (this.veinPainting || this.veinErasing) {
+      this.handleMouseUp(e);
+    }
+  }
+
+  loadImage(partId, rotation) {
+    const { partIcons } = this.props;
+    const key = partId + '_' + rotation;
+    if (this.imageCache[key]) {
+      return this.imageCache[key];
+    }
+    const icons = partIcons[partId];
+    if (!icons) return null;
+    const base64 = icons[String(rotation || 0)];
+    if (!base64) return null;
+    const img = new Image();
+    img.onload = () => {
+      this.imageCache[key] = img;
+      this.drawCanvas();
+    };
+    img.src = base64;
+    return null;
+  }
+
+  drawCanvas() {
+    const canvas = this.canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, CANVAS_PX, CANVAS_PX);
+
+    this.drawCheckerboard(ctx);
+    if (!this.props.veinsAbove) {
+      this.drawVeins(ctx);
+    }
+    this.drawParts(ctx);
+    if (this.props.veinsAbove) {
+      this.drawVeins(ctx);
+    }
+    this.drawSelection(ctx);
+    this.drawGroundLine(ctx);
+  }
+
+  drawCheckerboard(ctx) {
+    const s = PX_PER_CELL;
+    for (let x = 0; x < GRID_SIZE; x++) {
+      for (let y = 0; y < GRID_SIZE; y++) {
+        ctx.fillStyle = (x + y) % 2 === 0
+          ? '#2a2a2a' : '#222222';
+        ctx.fillRect(x * s, y * s, s, s);
+      }
+    }
+  }
+
+  drawGroundLine(ctx) {
+    // Solid ground bar at the bottom of the canvas
+    const barHeight = PX_PER_CELL;
+    const barY = CANVAS_PX - barHeight;
+    ctx.fillStyle = '#3a2a1a';
+    ctx.fillRect(0, barY, CANVAS_PX, barHeight);
+    ctx.strokeStyle = '#5a3a2a';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(0, barY);
+    ctx.lineTo(CANVAS_PX, barY);
+    ctx.stroke();
+  }
+
+  drawVeins(ctx) {
+    const { veinPixels } = this.props;
+    const paintedLive = this.paintedCells || {};
+    const paintedSet = {};
+
+    if (veinPixels && veinPixels.length) {
+      for (const p of veinPixels) {
+        paintedSet[p.x + ',' + p.y] = true;
+      }
+    }
+
+    // Apply live painted cells to preview
+    if (this.veinPainting) {
+      for (const key in paintedLive) {
+        paintedSet[key] = true;
+      }
+    } else if (this.veinErasing) {
+      for (const key in paintedLive) {
+        delete paintedSet[key];
+      }
+    }
+
+    ctx.fillStyle = '#8b0000';
+    for (const key in paintedSet) {
+      const [cx, cy] = key.split(',').map(Number);
+      ctx.fillRect(
+        (cx - 1) * PX_PER_CELL,
+        (cy - 1) * PX_PER_CELL,
+        PX_PER_CELL,
+        PX_PER_CELL
+      );
+    }
+  }
+
+  drawParts(ctx) {
+    const { placedParts } = this.props;
+    if (!placedParts) return;
+
+    ctx.imageSmoothingEnabled = false;
+    for (const part of placedParts) {
+      const img = this.loadImage(
+        part.id,
+        part.rotation
+      );
+      if (!img) continue;
+
+      const px = part.gridX * PX_PER_CELL;
+      const py = part.gridY * PX_PER_CELL;
+      const pw = PART_SIZE * PX_PER_CELL;
+      const ph = PART_SIZE * PX_PER_CELL;
+
+      ctx.save();
+      ctx.drawImage(img, px, py, pw, ph);
+
+      if (part.tint && part.tint !== '#ffffff') {
+        ctx.globalCompositeOperation = 'multiply';
+        ctx.fillStyle = part.tint;
+        ctx.fillRect(px, py, pw, ph);
+        ctx.globalCompositeOperation = 'source-over';
+      }
+      ctx.restore();
+    }
+  }
+
+  drawSelection(ctx) {
+    const { placedParts, selectedPartId } = this.props;
+    if (!selectedPartId || !placedParts) return;
+    const part = placedParts.find(
+      p => p.id === selectedPartId
+    );
+    if (!part) return;
+
+    ctx.strokeStyle = '#4488ff';
+    ctx.lineWidth = 2;
+    ctx.setLineDash([4, 4]);
+    ctx.strokeRect(
+      part.gridX * PX_PER_CELL,
+      part.gridY * PX_PER_CELL,
+      PART_SIZE * PX_PER_CELL,
+      PART_SIZE * PX_PER_CELL
+    );
+    ctx.setLineDash([]);
+  }
+
+  render() {
+    return (
+      <canvas
+        ref={this.canvasRef}
+        width={CANVAS_PX}
+        height={CANVAS_PX}
+        style={{
+          cursor: 'crosshair',
+          border: '1px solid #555',
+        }}
+        onMouseDown={e => this.handleMouseDown(e)}
+        onMouseMove={e => this.handleMouseMove(e)}
+        onMouseUp={e => this.handleMouseUp(e)}
+        onMouseLeave={e => this.handleMouseLeave(e)}
+      />
+    );
+  }
+}
+
+export const CustomArtworkEditor = (props, context) => {
+  const { act, data } = useBackend(context);
+  const {
+    storedParts = [],
+    placedParts = [],
+    veinPixels = [],
+    veinsAbove,
+  } = data;
+
+  const staticData = data;
+  const partIcons = staticData.partIcons || {};
+
+  const [
+    selectedPartId,
+    setSelectedPartId,
+  ] = [null, () => {}];
+
+  return (
+    <Window width={790} height={640}>
+      <Window.Content>
+        <CustomArtworkEditorInner
+          act={act}
+          storedParts={storedParts}
+          placedParts={placedParts}
+          veinPixels={veinPixels}
+          veinsAbove={veinsAbove}
+          partIcons={partIcons}
+        />
+      </Window.Content>
+    </Window>
+  );
+};
+
+class CustomArtworkEditorInner extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      tool: 'select',
+      selectedPartId: null,
+    };
+  }
+
+  render() {
+    const {
+      act,
+      storedParts,
+      placedParts,
+      veinPixels,
+      veinsAbove,
+      partIcons,
+    } = this.props;
+    const { tool, selectedPartId } = this.state;
+
+    const selectedPlaced = placedParts.find(
+      p => p.id === selectedPartId
+    );
+
+    return (
+      <Flex>
+        <Flex.Item>
+          <ArtworkCanvas
+            placedParts={placedParts}
+            veinPixels={veinPixels}
+            veinsAbove={veinsAbove}
+            partIcons={partIcons}
+            tool={tool}
+            selectedPartId={selectedPartId}
+            onSelect={id => {
+              this.setState({
+                selectedPartId: id,
+              });
+            }}
+            onPlace={(id, x, y) => {
+              act('place_part', { id, x, y });
+            }}
+            onMove={(id, x, y) => {
+              act('move_part', { id, x, y });
+            }}
+            onPaintVeins={cells => {
+              act('paint_veins', { cells });
+            }}
+            onEraseVeins={cells => {
+              act('erase_veins', { cells });
+            }}
+          />
+        </Flex.Item>
+        <Flex.Item width="240px" ml={1}>
+          <Stack vertical fill>
+            <Stack.Item>
+              <Section title="Tools">
+                <Stack wrap>
+                  {TOOLS.map(t => (
+                    <Stack.Item
+                      key={t.id}
+                      mb={0.5}
+                      mr={0.5}
+                    >
+                      <Button
+                        selected={tool === t.id}
+                        onClick={() => {
+                          this.setState({
+                            tool: t.id,
+                          });
+                        }}
+                      >
+                        {t.label}
+                      </Button>
+                    </Stack.Item>
+                  ))}
+                </Stack>
+              </Section>
+            </Stack.Item>
+            <Stack.Item grow>
+              <Section
+                title="Body Parts"
+                fill
+                scrollable
+              >
+                {storedParts.map(part => (
+                  <Button
+                    key={part.id}
+                    fluid
+                    selected={
+                      selectedPartId === part.id
+                    }
+                    color={part.placed
+                      ? 'green' : 'default'}
+                    onClick={() => {
+                      this.setState({
+                        selectedPartId: part.id,
+                      });
+                    }}
+                  >
+                    {ZONE_LABELS[part.bodyZone]
+                      || part.bodyZone}
+                    {part.placed ? ' (placed)' : ''}
+                  </Button>
+                ))}
+              </Section>
+            </Stack.Item>
+            {!!selectedPlaced && (
+              <Stack.Item>
+                <Section title="Selected Part">
+                  <Box mb={1}>
+                    Rotation: {selectedPlaced.rotation}
+                    &deg;
+                  </Box>
+                  <Stack wrap>
+                    <Stack.Item mr={0.5} mb={0.5}>
+                      <Button
+                        onClick={() => act(
+                          'rotate_part',
+                          { id: selectedPartId }
+                        )}
+                      >
+                        Rotate
+                      </Button>
+                    </Stack.Item>
+                    <Stack.Item mr={0.5} mb={0.5}>
+                      <Button
+                        color="bad"
+                        onClick={() => act(
+                          'remove_part',
+                          { id: selectedPartId }
+                        )}
+                      >
+                        Remove
+                      </Button>
+                    </Stack.Item>
+                  </Stack>
+                  <Box mt={1}>Tint:</Box>
+                  <Stack wrap>
+                    {TINTS.map(t => (
+                      <Stack.Item
+                        key={t.color}
+                        mr={0.5}
+                        mb={0.5}
+                      >
+                        <Button
+                          selected={
+                            selectedPlaced.tint
+                              === t.color
+                          }
+                          onClick={() => act(
+                            'set_tint',
+                            {
+                              id: selectedPartId,
+                              tint: t.color,
+                            }
+                          )}
+                        >
+                          <Box
+                            inline
+                            width="12px"
+                            height="12px"
+                            style={{
+                              backgroundColor:
+                                t.color,
+                              border:
+                                '1px solid #888',
+                              verticalAlign:
+                                'middle',
+                              marginRight: '4px',
+                            }}
+                          />
+                          {t.label}
+                        </Button>
+                      </Stack.Item>
+                    ))}
+                  </Stack>
+                </Section>
+              </Stack.Item>
+            )}
+            <Stack.Item>
+              <Section title="Veins">
+                <Stack>
+                  <Stack.Item mr={0.5}>
+                    <Button
+                      onClick={() => act(
+                        'toggle_veins_layer'
+                      )}
+                    >
+                      {veinsAbove
+                        ? 'Above Parts'
+                        : 'Behind Parts'}
+                    </Button>
+                  </Stack.Item>
+                  <Stack.Item>
+                    <Button
+                      color="bad"
+                      onClick={() => act(
+                        'clear_veins'
+                      )}
+                    >
+                      Clear All
+                    </Button>
+                  </Stack.Item>
+                </Stack>
+              </Section>
+            </Stack.Item>
+            <Stack.Item>
+              <Button
+                fluid
+                color="good"
+                textAlign="center"
+                onClick={() => act('submit')}
+              >
+                Submit Artwork
+              </Button>
+            </Stack.Item>
+          </Stack>
+        </Flex.Item>
+      </Flex>
+    );
+  }
+}

--- a/tgui/packages/tgui/interfaces/RingSkillTree.js
+++ b/tgui/packages/tgui/interfaces/RingSkillTree.js
@@ -1,0 +1,378 @@
+import { useBackend, useLocalState } from '../backend';
+import {
+  Box,
+  Button,
+  Flex,
+  Icon,
+  NoticeBox,
+  ProgressBar,
+  Section,
+  Stack,
+  Tabs,
+} from '../components';
+import { Window } from '../layouts';
+
+// School color themes
+const SCHOOL_COLORS = {
+  fauvist: '#c44536',
+  pointillist: '#4a7c59',
+  cubist: '#5b7c99',
+  corporist: '#8b4513',
+};
+
+export const RingSkillTree = (props, context) => {
+  const { act, data } = useBackend(context);
+  const [selectedSchool, setSelectedSchool] = useLocalState(
+    context,
+    'selectedSchool',
+    'fauvist'
+  );
+
+  const {
+    exp = 0,
+    next_threshold = 50,
+    skill_points = 0,
+    skill_points_spent = 0,
+    schools_invested = [],
+    schools = [],
+    main_school = null,
+    max_schools = 2,
+  } = data;
+
+  const availablePoints = skill_points;
+  const currentSchool = schools.find(s => s.id === selectedSchool);
+  const canInvestInSchool
+    = schools_invested.length < max_schools
+    || schools_invested.includes(selectedSchool);
+
+  // Get the display name for a school
+  const getSchoolDisplayName = id => {
+    const schoolNames = {
+      fauvist: 'Fauvist',
+      pointillist: 'Pointillist',
+      cubist: 'Cubist',
+      corporist: 'Corporist',
+    };
+    return schoolNames[id] || id;
+  };
+
+  return (
+    <Window width={700} height={550} title="Ring Skill Tree">
+      <Window.Content>
+        <Stack vertical fill>
+          {/* Header with EXP and Points */}
+          <Stack.Item>
+            <Section>
+              <Stack>
+                <Stack.Item grow>
+                  <Box bold>Artistic EXP</Box>
+                  <ProgressBar
+                    value={exp}
+                    maxValue={next_threshold}
+                    color="purple"
+                  >
+                    {exp} / {next_threshold}
+                  </ProgressBar>
+                </Stack.Item>
+                <Stack.Item basis="200px">
+                  <Box bold>Skill Points</Box>
+                  <Box fontSize="1.5em" textAlign="center" color="gold">
+                    {availablePoints} available
+                    <Box fontSize="0.6em" color="gray">
+                      ({skill_points_spent} spent)
+                    </Box>
+                  </Box>
+                </Stack.Item>
+              </Stack>
+              {schools_invested.length > 0 && (
+                <Box mt={1} fontSize="0.9em" color="gray">
+                  Schools invested:{' '}
+                  {schools_invested.map(s => getSchoolDisplayName(s))
+                    .join(', ')}
+                  {schools_invested.length >= max_schools && (
+                    <Box as="span" color="orange" ml={1}>
+                      (Maximum reached)
+                    </Box>
+                  )}
+                </Box>
+              )}
+              {schools_invested.length > 0 && (
+                <Box mt={1}>
+                  <Box as="span" fontSize="0.9em" color="gray" mr={1}>
+                    Main School:
+                  </Box>
+                  {schools_invested.map(school => (
+                    <Button
+                      key={school}
+                      selected={main_school === school}
+                      color={main_school === school
+                        ? SCHOOL_COLORS[school]
+                        : 'default'}
+                      onClick={() => act('set_main_school', { school })}
+                    >
+                      {getSchoolDisplayName(school)}
+                    </Button>
+                  ))}
+                  {main_school && (
+                    <Box
+                      as="span"
+                      ml={1}
+                      fontSize="0.85em"
+                      color="label"
+                      italic
+                    >
+                      (Visible when examined)
+                    </Box>
+                  )}
+                </Box>
+              )}
+            </Section>
+          </Stack.Item>
+
+          {/* School Tabs */}
+          <Stack.Item>
+            <Tabs fluid>
+              {schools.map(school => (
+                <Tabs.Tab
+                  key={school.id}
+                  selected={selectedSchool === school.id}
+                  onClick={() => setSelectedSchool(school.id)}
+                  color={
+                    selectedSchool === school.id
+                      ? SCHOOL_COLORS[school.id]
+                      : null
+                  }
+                >
+                  {school.name}
+                </Tabs.Tab>
+              ))}
+            </Tabs>
+          </Stack.Item>
+
+          {/* School Content */}
+          <Stack.Item grow>
+            {currentSchool ? (
+              <SchoolDisplay
+                school={currentSchool}
+                canInvest={canInvestInSchool}
+                availablePoints={availablePoints}
+              />
+            ) : (
+              <NoticeBox color="red">No school data available</NoticeBox>
+            )}
+          </Stack.Item>
+        </Stack>
+      </Window.Content>
+    </Window>
+  );
+};
+
+const SchoolDisplay = (props, context) => {
+  const { school, canInvest, availablePoints } = props;
+  const schoolColor = SCHOOL_COLORS[school.id] || 'white';
+
+  return (
+    <Section
+      fill
+      scrollable
+      title={
+        <Box inline>
+          <Box as="span" color={schoolColor} bold>
+            {school.name}
+          </Box>
+          <Box as="span" color="gray" ml={2} fontSize="0.9em">
+            {school.theme}
+          </Box>
+        </Box>
+      }
+    >
+      <Box mb={2} color="label" italic>
+        {school.desc}
+      </Box>
+
+      {!canInvest && (
+        <NoticeBox color="orange" mb={2}>
+          You have already invested in your maximum number of schools. You
+          cannot learn skills from this school.
+        </NoticeBox>
+      )}
+
+      <Stack vertical>
+        {school.tiers.map(tier => (
+          <Stack.Item key={tier.tier}>
+            <TierDisplay
+              tier={tier}
+              schoolId={school.id}
+              schoolColor={schoolColor}
+              canInvest={canInvest}
+              availablePoints={availablePoints}
+            />
+          </Stack.Item>
+        ))}
+      </Stack>
+    </Section>
+  );
+};
+
+const TierDisplay = (props, context) => {
+  const { tier, schoolId, schoolColor, canInvest, availablePoints } = props;
+  const { act } = useBackend(context);
+
+  const tierLocked = tier.choices.some(c => c.locked);
+  const tierCompleted = tier.choices.some(c => c.selected);
+
+  return (
+    <Box
+      mb={2}
+      p={1}
+      style={{
+        border: `1px solid ${tierCompleted ? schoolColor : tierLocked ? '#444' : '#666'}`,
+        borderRadius: '4px',
+        backgroundColor: tierLocked ? 'rgba(0,0,0,0.3)' : 'transparent',
+      }}
+    >
+      <Flex align="center" mb={1}>
+        <Flex.Item>
+          <Box bold color={tierLocked ? 'gray' : schoolColor}>
+            Tier {tier.tier}
+          </Box>
+        </Flex.Item>
+        <Flex.Item grow />
+        <Flex.Item>
+          <Box color={tierLocked ? 'gray' : 'gold'} fontSize="0.9em">
+            Cost: {tier.cost} point{tier.cost > 1 ? 's' : ''}
+          </Box>
+        </Flex.Item>
+        {tierLocked && (
+          <Flex.Item ml={1}>
+            <Icon name="lock" color="gray" />
+          </Flex.Item>
+        )}
+        {tierCompleted && (
+          <Flex.Item ml={1}>
+            <Icon name="check" color="green" />
+          </Flex.Item>
+        )}
+      </Flex>
+
+      <Stack>
+        {tier.choices.map(choice => (
+          <Stack.Item key={choice.id} grow basis={0}>
+            <SkillChoice
+              choice={choice}
+              schoolId={schoolId}
+              tier={tier.tier}
+              schoolColor={schoolColor}
+              canInvest={canInvest}
+              availablePoints={availablePoints}
+            />
+          </Stack.Item>
+        ))}
+      </Stack>
+    </Box>
+  );
+};
+
+const SkillChoice = (props, context) => {
+  const {
+    choice,
+    schoolId,
+    tier,
+    schoolColor,
+    canInvest,
+    availablePoints,
+  } = props;
+  const { act } = useBackend(context);
+
+  // Determine the visual state
+  let borderColor = '#555';
+  let bgColor = 'transparent';
+  let textColor = 'white';
+  let statusIcon = null;
+  let statusColor = null;
+
+  if (choice.selected) {
+    borderColor = schoolColor;
+    bgColor = 'rgba(255,255,255,0.1)';
+    statusIcon = 'check-circle';
+    statusColor = 'green';
+  } else if (choice.excluded) {
+    borderColor = '#333';
+    bgColor = 'rgba(0,0,0,0.3)';
+    textColor = 'gray';
+    statusIcon = 'times-circle';
+    statusColor = 'red';
+  } else if (choice.locked) {
+    borderColor = '#333';
+    bgColor = 'rgba(0,0,0,0.2)';
+    textColor = 'gray';
+    statusIcon = 'lock';
+    statusColor = 'gray';
+  } else if (choice.available && canInvest && availablePoints >= tier) {
+    borderColor = 'gold';
+    statusIcon = 'plus-circle';
+    statusColor = 'gold';
+  }
+
+  const canSelect
+    = choice.available
+    && canInvest
+    && availablePoints >= tier
+    && !choice.selected
+    && !choice.excluded;
+
+  return (
+    <Box
+      p={1}
+      m={0.5}
+      style={{
+        border: `1px solid ${borderColor}`,
+        borderRadius: '4px',
+        backgroundColor: bgColor,
+        cursor: canSelect ? 'pointer' : 'default',
+        transition: 'all 0.2s',
+      }}
+      onClick={() => {
+        if (canSelect) {
+          act('select_skill', {
+            skill_type: choice.type,
+            school: schoolId,
+            tier: tier,
+          });
+        }
+      }}
+    >
+      <Flex align="center" mb={0.5}>
+        <Flex.Item grow>
+          <Box bold color={textColor} fontSize="1.1em">
+            {choice.name}
+          </Box>
+        </Flex.Item>
+        {statusIcon && (
+          <Flex.Item>
+            <Icon name={statusIcon} color={statusColor} size={1.2} />
+          </Flex.Item>
+        )}
+      </Flex>
+      <Box color={choice.locked || choice.excluded ? 'gray' : 'label'} fontSize="0.85em">
+        {choice.desc}
+      </Box>
+      {canSelect && (
+        <Button
+          mt={1}
+          fluid
+          color="good"
+          content="Learn Skill"
+          onClick={e => {
+            e.stopPropagation();
+            act('select_skill', {
+              skill_type: choice.type,
+              school: schoolId,
+              tier: tier,
+            });
+          }}
+        />
+      )}
+    </Box>
+  );
+};

--- a/tgui/packages/tgui/interfaces/RingSkillTree.js
+++ b/tgui/packages/tgui/interfaces/RingSkillTree.js
@@ -220,13 +220,16 @@ const TierDisplay = (props, context) => {
 
   const tierLocked = tier.choices.some(c => c.locked);
   const tierCompleted = tier.choices.some(c => c.selected);
+  const tierBorder = tierCompleted
+    ? schoolColor
+    : tierLocked ? '#444' : '#666';
 
   return (
     <Box
       mb={2}
       p={1}
       style={{
-        border: `1px solid ${tierCompleted ? schoolColor : tierLocked ? '#444' : '#666'}`,
+        border: `1px solid ${tierBorder}`,
         borderRadius: '4px',
         backgroundColor: tierLocked ? 'rgba(0,0,0,0.3)' : 'transparent',
       }}
@@ -354,7 +357,9 @@ const SkillChoice = (props, context) => {
           </Flex.Item>
         )}
       </Flex>
-      <Box color={choice.locked || choice.excluded ? 'gray' : 'label'} fontSize="0.85em">
+      <Box
+        color={choice.locked || choice.excluded ? 'gray' : 'label'}
+        fontSize="0.85em">
         {choice.desc}
       </Box>
       {canSelect && (

--- a/tgui/packages/tgui/interfaces/SculptingMinigame.js
+++ b/tgui/packages/tgui/interfaces/SculptingMinigame.js
@@ -1,0 +1,506 @@
+import { useBackend } from '../backend';
+import { Box, Button, Section, Stack } from '../components';
+import { Window } from '../layouts';
+
+const RESULT_COLORS = {
+  'PERFECT!': '#ffd700',
+  'Good': '#7cfc00',
+  'Okay': '#daa520',
+  'Miss': '#dc143c',
+};
+
+const GRADE_COLORS = {
+  F: '#8b0000',
+  C: '#cd853f',
+  B: '#b8860b',
+  A: '#228b22',
+  S: '#ffd700',
+};
+
+export const SculptingMinigame = (props, context) => {
+  const { act, data } = useBackend(context);
+  const {
+    active,
+    currentRound,
+    totalRounds,
+    score,
+    combo,
+    bestCombo,
+    needlePosition,
+    sweetSpots = [],
+    awaitingInput,
+    lastHitResult,
+    difficulty,
+    gameOver,
+    finalGrade,
+  } = data;
+
+  return (
+    <Window width={520} height={400} title="Sculpting">
+      <Window.Content
+        style={{
+          background:
+            'linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f0f23 100%)',
+        }}
+      >
+        <Stack vertical fill>
+          {!active && !gameOver && <StartScreen />}
+          {!!active && !gameOver && (
+            <GameScreen
+              currentRound={currentRound}
+              totalRounds={totalRounds}
+              score={score}
+              combo={combo}
+              bestCombo={bestCombo}
+              needlePosition={needlePosition}
+              sweetSpots={sweetSpots}
+              awaitingInput={awaitingInput}
+              lastHitResult={lastHitResult}
+              difficulty={difficulty}
+            />
+          )}
+          {!!gameOver && (
+            <GameOverScreen
+              score={score}
+              bestCombo={bestCombo}
+              finalGrade={finalGrade}
+            />
+          )}
+        </Stack>
+      </Window.Content>
+    </Window>
+  );
+};
+
+const StartScreen = (props, context) => {
+  const { act } = useBackend(context);
+
+  return (
+    <Section
+      fill
+      style={{
+        border: '2px solid #8b4513',
+        borderRadius: '8px',
+        background: 'rgba(0, 0, 0, 0.4)',
+      }}
+    >
+      <Stack vertical fill justify="center" align="center">
+        <Stack.Item>
+          <Box
+            fontSize="1.8em"
+            bold
+            textAlign="center"
+            mb={1}
+            style={{
+              color: '#d4af37',
+              textShadow: '0 0 10px rgba(212, 175, 55, 0.5)',
+              fontStyle: 'italic',
+            }}
+          >
+            The Art of Refinement
+          </Box>
+        </Stack.Item>
+        <Stack.Item>
+          <Box
+            textAlign="center"
+            color="label"
+            mb={2}
+            style={{ lineHeight: '1.6' }}
+          >
+            Time your sculpts to strike the golden zones.
+            <br />
+            <Box as="span" color="#ffd700">
+              Perfect strikes
+            </Box>{' '}
+            at the center yield greater rewards.
+            <br />
+            Chain your successes to build{' '}
+            <Box as="span" color="#7cfc00">
+              artistic momentum
+            </Box>
+            .
+          </Box>
+        </Stack.Item>
+        <Stack.Item mt={2}>
+          <Button
+            fluid
+            fontSize="1.3em"
+            icon="palette"
+            content="Begin Refinement"
+            onClick={() => act('start')}
+            style={{
+              background: 'linear-gradient(135deg, #8b4513, #d4af37)',
+              border: 'none',
+              padding: '10px 30px',
+            }}
+          />
+        </Stack.Item>
+      </Stack>
+    </Section>
+  );
+};
+
+const GameScreen = (props, context) => {
+  const { act } = useBackend(context);
+  const {
+    currentRound,
+    totalRounds,
+    score,
+    combo,
+    bestCombo,
+    needlePosition,
+    sweetSpots,
+    awaitingInput,
+    lastHitResult,
+  } = props;
+
+  return (
+    <Stack vertical fill>
+      {/* Header Stats */}
+      <Stack.Item>
+        <Section
+          style={{
+            border: '1px solid #8b4513',
+            background: 'rgba(0, 0, 0, 0.3)',
+          }}
+        >
+          <Stack justify="space-between" align="center">
+            <Stack.Item>
+              <Box bold color="#d4af37">
+                Round: {currentRound}/{totalRounds}
+              </Box>
+            </Stack.Item>
+            <Stack.Item>
+              <Box
+                bold
+                fontSize="1.2em"
+                style={{
+                  color: '#ffd700',
+                  textShadow: '0 0 5px rgba(255, 215, 0, 0.3)',
+                }}
+              >
+                Score: {score || 0}
+              </Box>
+            </Stack.Item>
+            <Stack.Item>
+              <Box bold color={combo >= 3 ? '#7cfc00' : '#aaa'}>
+                Combo: {combo || 0}
+                {!!combo && combo >= 5 && ' (x2)'}
+                {!!combo && combo >= 3 && combo < 5 && ' (x1.5)'}
+              </Box>
+            </Stack.Item>
+            <Stack.Item>
+              <Box color="label" fontSize="0.9em">
+                Best: {bestCombo || 0}
+              </Box>
+            </Stack.Item>
+          </Stack>
+        </Section>
+      </Stack.Item>
+
+      {/* The Bar */}
+      <Stack.Item grow>
+        <Section
+          fill
+          style={{
+            border: '1px solid #8b4513',
+            background: 'rgba(0, 0, 0, 0.3)',
+          }}
+        >
+          <Stack vertical fill justify="center">
+            <Stack.Item>
+              <TimingBar
+                needlePosition={needlePosition}
+                sweetSpots={sweetSpots}
+              />
+            </Stack.Item>
+
+            {/* Result Display */}
+            <Stack.Item>
+              <Box
+                textAlign="center"
+                fontSize="2em"
+                bold
+                mt={2}
+                style={{
+                  minHeight: '2.5em',
+                  color: RESULT_COLORS[lastHitResult] || 'transparent',
+                  textShadow: lastHitResult
+                    ? `0 0 15px ${RESULT_COLORS[lastHitResult] || '#fff'}`
+                    : 'none',
+                  fontStyle: 'italic',
+                }}
+              >
+                {lastHitResult || '\u00A0'}
+              </Box>
+            </Stack.Item>
+          </Stack>
+        </Section>
+      </Stack.Item>
+
+      {/* Input Button */}
+      <Stack.Item>
+        <Button
+          fluid
+          disabled={!awaitingInput}
+          fontSize="1.4em"
+          icon="hammer"
+          content={awaitingInput ? 'SCULPT! (Click or Spacebar)' : 'Wait...'}
+          onClick={() => act('sculpt')}
+          style={{
+            background: awaitingInput
+              ? 'linear-gradient(135deg, #228b22, #32cd32)'
+              : 'linear-gradient(135deg, #333, #444)',
+            border: awaitingInput ? '2px solid #7cfc00' : '2px solid #555',
+            padding: '12px',
+            transition: 'all 0.2s ease',
+          }}
+        />
+      </Stack.Item>
+    </Stack>
+  );
+};
+
+const TimingBar = props => {
+  const { needlePosition, sweetSpots } = props;
+  const safePosition = needlePosition || 0;
+
+  return (
+    <Box
+      style={{
+        position: 'relative',
+        height: '80px',
+        background:
+          'linear-gradient(180deg, #1a1a1a 0%, #2d2d2d 50%, #1a1a1a 100%)',
+        border: '3px solid #8b4513',
+        borderRadius: '8px',
+        overflow: 'visible',
+        boxShadow: 'inset 0 2px 10px rgba(0, 0, 0, 0.5)',
+      }}
+    >
+      {/* Track markings */}
+      {[0, 25, 50, 75, 100].map(mark => (
+        <Box
+          key={mark}
+          style={{
+            position: 'absolute',
+            left: `${mark}%`,
+            top: '0',
+            width: '1px',
+            height: '100%',
+            backgroundColor: 'rgba(139, 69, 19, 0.3)',
+            zIndex: 1,
+          }}
+        />
+      ))}
+
+      {/* Sweet Spots */}
+      {sweetSpots.map((spot, index) => {
+        const width = (spot.end || 0) - (spot.start || 0);
+        const perfectWidth = (spot.perfectEnd || 0) - (spot.perfectStart || 0);
+        const perfectOffset = ((spot.perfectStart || 0) - (spot.start || 0))
+          / (width || 1) * 100;
+        const perfectWidthPct = perfectWidth / (width || 1) * 100;
+
+        return (
+          <Box
+            key={index}
+            style={{
+              position: 'absolute',
+              left: `${spot.start || 0}%`,
+              width: `${width}%`,
+              height: '100%',
+              background:
+                'linear-gradient(180deg, rgba(34, 139, 34, 0.6) 0%, '
+                + 'rgba(34, 139, 34, 0.4) 50%, rgba(34, 139, 34, 0.6) 100%)',
+              borderLeft: '2px solid #32cd32',
+              borderRight: '2px solid #32cd32',
+              zIndex: 2,
+              boxSizing: 'border-box',
+            }}
+          >
+            {/* Perfect Center Zone */}
+            <Box
+              style={{
+                position: 'absolute',
+                left: `${perfectOffset}%`,
+                width: `${perfectWidthPct}%`,
+                height: '100%',
+                background:
+                  'linear-gradient(180deg, rgba(255, 215, 0, 0.8) 0%, '
+                  + 'rgba(255, 215, 0, 0.6) 50%, rgba(255, 215, 0, 0.8) 100%)',
+                boxShadow: '0 0 10px rgba(255, 215, 0, 0.5)',
+              }}
+            />
+          </Box>
+        );
+      })}
+
+      {/* Needle Glow */}
+      <Box
+        style={{
+          position: 'absolute',
+          left: `${safePosition}%`,
+          top: '0',
+          width: '20px',
+          height: '100%',
+          background:
+            'radial-gradient(ellipse at center, '
+            + 'rgba(255, 255, 255, 0.3) 0%, transparent 70%)',
+          transform: 'translateX(-50%)',
+          zIndex: 3,
+          pointerEvents: 'none',
+        }}
+      />
+
+      {/* Needle */}
+      <Box
+        style={{
+          position: 'absolute',
+          left: `${safePosition}%`,
+          top: '0',
+          width: '4px',
+          height: '100%',
+          backgroundColor: '#fff',
+          boxShadow: '0 0 8px #fff, 0 0 15px rgba(255, 255, 255, 0.5)',
+          transform: 'translateX(-50%)',
+          zIndex: 4,
+        }}
+      />
+
+      {/* Needle Arrow at top */}
+      <Box
+        style={{
+          position: 'absolute',
+          left: `${safePosition}%`,
+          top: '-12px',
+          transform: 'translateX(-50%)',
+          width: '0',
+          height: '0',
+          borderLeft: '10px solid transparent',
+          borderRight: '10px solid transparent',
+          borderTop: '12px solid #ffd700',
+          filter: 'drop-shadow(0 0 4px rgba(255, 215, 0, 0.8))',
+          zIndex: 5,
+        }}
+      />
+    </Box>
+  );
+};
+
+const GameOverScreen = (props, context) => {
+  const { act } = useBackend(context);
+  const { score, bestCombo, finalGrade } = props;
+
+  const gradeColor = GRADE_COLORS[finalGrade] || '#fff';
+  const isExcellent = finalGrade === 'S' || finalGrade === 'A';
+
+  return (
+    <Section
+      fill
+      style={{
+        border: '2px solid #8b4513',
+        borderRadius: '8px',
+        background: 'rgba(0, 0, 0, 0.4)',
+      }}
+    >
+      <Stack vertical fill justify="center" align="center">
+        <Stack.Item>
+          <Box
+            fontSize="1.6em"
+            bold
+            textAlign="center"
+            mb={1}
+            style={{
+              color: '#d4af37',
+              fontStyle: 'italic',
+            }}
+          >
+            Refinement Complete
+          </Box>
+        </Stack.Item>
+
+        <Stack.Item>
+          <Box
+            fontSize="5em"
+            bold
+            textAlign="center"
+            style={{
+              color: gradeColor,
+              textShadow: isExcellent
+                ? `0 0 30px ${gradeColor}, 0 0 60px ${gradeColor}`
+                : `0 0 15px ${gradeColor}`,
+              fontFamily: 'serif',
+            }}
+          >
+            {finalGrade}
+          </Box>
+        </Stack.Item>
+
+        <Stack.Item>
+          <Box textAlign="center" color="label" mb={2} fontSize="1.1em">
+            <Box>
+              Final Score:{' '}
+              <Box as="span" color="#ffd700" bold>
+                {score || 0}
+              </Box>
+            </Box>
+            <Box mt={0.5}>
+              Best Combo:{' '}
+              <Box as="span" color="#7cfc00" bold>
+                {bestCombo || 0}
+              </Box>
+            </Box>
+          </Box>
+        </Stack.Item>
+
+        <Stack.Item>
+          <GradeDescription grade={finalGrade} />
+        </Stack.Item>
+
+        <Stack.Item mt={2}>
+          <Button
+            fluid
+            icon="check"
+            content="Complete"
+            onClick={() => act('close')}
+            style={{
+              background: 'linear-gradient(135deg, #8b4513, #d4af37)',
+              border: 'none',
+              padding: '10px 40px',
+              fontSize: '1.1em',
+            }}
+          />
+        </Stack.Item>
+      </Stack>
+    </Section>
+  );
+};
+
+const GradeDescription = props => {
+  const { grade } = props;
+
+  const descriptions = {
+    F: 'The work speaks of untrained hands and wavering vision.',
+    C: 'Competence emerges, though refinement remains elusive.',
+    B: 'A steady hand guides deliberate strokes of intention.',
+    A: 'Mastery flows through each precise, purposeful motion.',
+    S: 'Transcendence - where artist and art become one.',
+  };
+
+  return (
+    <Box
+      textAlign="center"
+      italic
+      fontSize="1.05em"
+      style={{
+        color: GRADE_COLORS[grade] || '#aaa',
+        textShadow: `0 0 8px ${GRADE_COLORS[grade] || '#aaa'}33`,
+        padding: '0 20px',
+        lineHeight: '1.5',
+      }}
+    >
+      &quot;{descriptions[grade] || 'Unknown'}&quot;
+    </Box>
+  );
+};


### PR DESCRIPTION
## About The Pull Request

This is the Ring Nursefather sub-PR, branched off the CoL Major Update: The House of Spiders [Core PR]. It adds the **Corporist Maestro** trusted role and the Ring's artwork/skill tree system.

## Corporist Maestro

### Role Overview
- A high-ranking Maestro of the Ring's Corporist school, devoted to creating art from flesh and bone
- Spawns with the Tibia weapon, Maestro armor, and an Apprenticeship Contract
- Available on city and fixers maps
- Trusted player role with 300 FOR/PRU, 100 TEM/JUS, full prosthetic body
- Nursefather Passive: automatically dodges the first attack every 30 seconds, 50% chance to dodge when unarmed, but all damage inflicts 5% unhealable clone damage
- Can recruit one apprentice using an Apprenticeship Contract

### Tibia (Maestro Weapon)
- 68 RED damage, collects Corpus Ingredients (Bones and Blood) on hit
- Stuns targets for half the weapon's recovery time
- 4 ranged attack modes using collected resources:
  - **Bone Shrapnel** — ranged bone projectile
  - **Marrow Lance** — piercing lance attack
  - **Crimson Needle** — blood-based needle attack
  - **Sanguine Deluge** — devastating ultimate attack consuming large amounts of resources

### Fascia (Apprentice Weapon)
- 90 RED damage with bleed
- **Phase 1 — Iron Curtain**: Defensive mode
- **Phase 2 — Unleashed**: Offensive mode with leap attack
- **Ghost Possession**: A ghost can inhabit the Fascia to provide Empower Strike and Compel Dash abilities

## Artwork System

### Basic Artwork
- **Sculpt Corpse**: Create sculptures from dead creatures (choose "Basic Sculpture")
- **Enhance Artwork**: Add bodyparts and corpses to increase tier (1-5, plus hidden Magnum Opus tier at 60+ materials)
- **Refine Artwork**: Timing minigame to earn technique grades (F through S)
- **Judge Artwork**: Maestro assigns final grades affecting artist EXP
- **Vandalism**: Spray paint to permanently deface artwork
- **Wrenching**: Anchor/unanchor artwork

### Custom Artwork
A freeform pixel-level composition system using a 48x48 grid editor:
- **Sculpt Corpse → "Custom Artwork"**: Creates an empty pedestal for freeform composition
- **Add materials**: Hit pedestal with bodyparts or carved pieces to store them
- **Blood storage**: Hit pedestal with blood-filled reagent containers (up to 500u)
- **Editor**: Click pedestal to open the TGUI editor with:
  - **Tools**: Select, Place, Move, Draw Vein, Erase Vein
  - **Part controls**: Rotate (90° increments), Remove, Tint (Normal/Bloody/Drained/Pale/Necrotic)
  - **Vein drawing**: Thin organic vein lines (max 2 cardinal neighbors per pixel) using stored blood (1u per pixel)
  - **Arrow key nudging**: Precisely move selected parts 1 pixel at a time
  - **Live drag preview**: Parts follow cursor while dragging
  - **Blood bar**: ProgressBar showing stored blood, cost for new veins, refund for removed veins
  - **Stone pedestal**: Visual preview matching the in-game base sprite
- **Submit validation**: Parts must be connected (directly or via veins), at least one must touch pedestal, blood cost deducted
- **Rename**: Change the artwork's name (max 60 chars)
- **Vandalism & Wrenching**: Same as basic artwork — spray to deface, wrench to anchor/unanchor

### Carve Body
Pixel-level mob carving system for creating custom art pieces:
- **Sculpt Corpse → "Carve Body"**: Opens a pixel editor showing the dead creature's south-facing sprite
- **Living/Dead toggle**: Switch between the creature's living and dead sprites
- **Pixel selection**: Click/drag to select regions of the sprite (only non-transparent pixels)
- **Section validation**: Contiguous groups of 8+ selected pixels form valid sections (green outline), groups under 8 are invalid (red outline)
- **Carve Out**: Each valid section becomes a carved piece item dropped at the creature's location, then the creature is gibbed
- **Artwork integration**: Carved pieces can be added to custom artwork pedestals and placed/rotated/tinted like bodyparts
- **Dynamic scaling**: Editor canvas scales to fit any mob sprite size (32x32 through 128x128)

### Artist Progression
| Stage | How Obtained | Schools |
|-------|-------------|---------|
| Inspired Artist | Watch a Maestro demonstration (10 min temporary) | None |
| Student | Create 1 artwork (basic or custom) | Invest in 2 schools |
| Apprentice | Recruited by Maestro (prosthetic body) | Invest in 3 schools |
| Maestro | Roundstart role | All 4 schools, 8 starting skill points |

### Inspiration Filtering (UPDATED)
- Regular Roles — **Can** be inspired
- Roaming Association Fixers — **Can** be inspired
- Association Fixers, Veterans, Directors — **Cannot** be inspired
- Other Trusted Roles — **Cannot** be inspired

### EXP Sources
| Activity | EXP |
|----------|-----|
| Create artwork (basic or custom) | +5 |
| Add body part / carved piece to custom artwork | +3 |
| Refine basic artwork (F/C/B/A/S) | +5/+10/+15/+25/+40 |

Note: Submitting/arranging in the custom artwork editor no longer grants EXP to prevent spam.

### Student Competition
- Students compete for highest Artistic EXP at round end
- Sabotage of rival artwork is permitted
- Top artist is celebrated in round end report

## Ring Skill Tree

Four schools with 3 tiers each, all synergizing with Bleed:

### Fauvist — Predatory Aggression
| Tier | Skill | Effect |
|------|-------|--------|
| 1a | Predator's Scent | +15% damage vs bleeding targets |
| 1b | Maddening Maw | Attacks on bleeding targets deal 15% as additional WHITE damage |
| 2a | Rending Claws | Attacks apply 2 bleed stacks |
| 2b | Savage Instinct | After hitting a bleeding target, +15% damage for 4 seconds |
| 3a | Spreading Wounds | When hitting bleeding target, adjacent enemies gain 3 bleed |
| 3b | Primal Terror | Hitting targets with 10+ bleed deals 20 WHITE damage and removes 5 bleed stacks |

### Pointillist — Random Status Effects
| Tier | Skill | Effect |
|------|-------|--------|
| 1a | Hematic Coloring | Attacks apply 3 stacks of a random effect |
| 1b | Sanguine Pointillism | Attacks apply 1 stack of TWO random effects |
| 2a | Assignment Evaluation | Heal 5 SP when hitting targets, +3 SP per status effect |
| 2b | Beat the Brush | +5% damage per status effect on target (max 20%) |
| 3a | Paint Over | 2x effect stacks, +10% chance to apply ALL four effects |
| 3b | Practices on Aesthetics | +10% damage and +2 bleed per status effect on target |

### Cubist — Area Control
| Tier | Skill | Effect |
|------|-------|--------|
| 1a | Fractured Reflection | Attackers gain 3 bleed when hitting you |
| 1b | Geometric Reach | Attacks apply 5 bleed to enemies adjacent to target |
| 2a | Abstract Suffering | Bonus WHITE damage equal to target's bleed stacks x2 |
| 2b | Warped Space | Targets with 8+ bleed get 20% slowdown for 3 seconds |
| 3a | Spatial Anchor | Enemies within 6 tiles cannot have bleed reduced below 5 |
| 3b | Crimson Dimension | Active (30s CD): Create 3x3 zone applying 2 bleed/sec for 10s; gain Protection while inside |

### Corporist — Pain and Power Duality
| Tier | Skill | Effect |
|------|-------|--------|
| 1a | Butcher - Ribs | Apply 2 bleed, gain Protection, heal 5% SP |
| 1b | Rotator Crush | Apply 2 bleed, gain Damage Up, heal 5% SP |
| 2a | Repressed Flesh | If target bleeds and you have a buff, heal 5 HP + 2 extra bleed |
| 2b | Tendon Tear | If target bleeds and you have a buff, deal 10 bonus RED damage |
| 3a | Anatomize | If target bleeds below 25% HP with both buffs, consume all bleed for massive damage + full SP |
| 3b | Exhibition Arrangements | Active (30s CD): For 8s, attacks apply 3 bleed + random effect AND grant Protection + Damage Up. On expiry, consume all bleed for 3 dmg/stack |

## Refactoring Notes

This sub-PR includes the following changes from the original PR (#288) to work with the atomized structure:
- Switched `AddComponent(/datum/component/oracle_proxy_passive)` to `AddComponent(/datum/component/nursefather_passive)` in `corporist_maestro.dm`
- Added `COMSIG_NURSEFATHER_RECRUITMENT_OVERRIDE` signal handlers to `corporist_student.dm`, `inspired_artist.dm`, `ring_artist.dm`, and the base `ring_skill` component in `_schools.dm` — these self-clean when a mob is recruited into a different Nursefather role
- Ring rules-action subtypes (`view_role_rules/ring_artist`, `view_role_rules/fascia`) remain in `corporist_actions.dm`, inheriting from the base class in the fundamental PR

## Why It's Good For The Game

The Corporist Maestro transforms how non-trusted players engage with the round by turning corpses into the centerpiece of a competitive art system. Any player can become an Inspired Artist just by watching a demonstration, and dedicated players can progress to Student status through a single artwork. This gives bystanders, fixers, and even facility staff a reason to interact with the Maestro beyond combat.

The custom artwork editor gives artists a pixel-level creative tool — they can compose body parts and carved creature pieces on a 48x48 grid, connected by blood veins drawn from collected blood reagents. The carve body system lets artists dissect any mob sprite at the pixel level, selecting exactly which parts of a creature to incorporate into their work.

The student competition mechanic creates emergent conflict between artists competing for the highest EXP at round end, including the ability to sabotage rival work. This generates player-vs-player tension that doesn't require violence — an artist can grief another artist's sculpture and spark a rivalry that plays out through art, not weapons.

The 4-school skill tree gives apprentices meaningful build diversity. Since all schools synergize with Bleed differently (Fauvist for raw aggression, Pointillist for status stacking, Cubist for area control, Corporist for sustained dueling), apprentices on the same team will play differently from each other, which makes encounters with Ring members less predictable for other players.

The Fascia's ghost possession system gives dead players another avenue to participate — a ghost can inhabit the apprentice's weapon and actively contribute to combat through Empower Strike and Compel Dash, turning a spectator into a combat partner.

Roaming Association Fixers can now be inspired by the Maestro's demonstrations, while local Association members (Fixers, Veterans, Directors) cannot — reflecting the roaming fixer's openness to new experiences versus the local association's rigid structure.

### Did you test this PR?

* [X] This PR compiles
* [ ] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

## Attribution

## Changelog
:cl:
add: Added Corporist Maestro, a new trusted player role for city/fixers maps
add: Added Tibia weapon with bone/blood collection and 4 ranged attack modes including Sanguine Deluge
add: Added Fascia apprentice weapon with phase transformation and ghost possession
add: Artwork system — create, enhance, and refine sculptures from corpses with a timing minigame
add: Custom Artwork editor — 48x48 grid composer with body parts, carved pieces, blood veins, tinting, and rotation
add: Carve Body — pixel-level mob sprite carving tool with living/dead sprite toggle and section validation
add: Blood vein system — store blood in artworks, spend 1u per vein pixel on submit, refund on removal
add: Custom artwork naming, vandalism (spray paint), and wrench anchoring
add: Ring Skill Tree with 4 schools (Fauvist, Pointillist, Cubist, Corporist), each with 6 skills across 3 tiers
add: Artist progression system (Inspired -> Student -> Apprentice -> Maestro)
add: Inspired artists now only need 1 artwork to become a Student and can create custom artworks
add: Roaming Association Fixers can now be inspired; local Association members cannot
add: Student competition with sabotage mechanics and round end reporting
add: Apprentice recruitment via contract with full prosthetic body transformation
add: Corporist species with custom prosthetic bodyparts for Maestro and Apprentice
code: Ring components register COMSIG_NURSEFATHER_RECRUITMENT_OVERRIDE for clean role transitions
code: Removed spammable EXP from artwork submit/arrange — EXP now only from adding parts
/:cl:
