### PR TITLE
House of Spiders: Thumb Nursefather

### DIFF
--- a/ModularLobotomy/ego_weapons/melee/city/thumb_apprentice_design.md
+++ b/ModularLobotomy/ego_weapons/melee/city/thumb_apprentice_design.md
@@ -1,0 +1,927 @@
+# Thumb Apprentice Progression Design Document
+
+## Current State
+- Apprentice starts at **40 all stats** with tier 1 gear
+- Gear has 4 tiers: tier 1 (40 attr), tier 2 (60 attr), tier 3 (80 attr), tier 4 (100 attr)
+- `set_tier()` proc exists on armor, katana, and greatsword but has no trigger yet
+- Weapons: katana (fast, force 22/32/44/65) and greatsword (slow, force 33/48/66/98)
+- Armor: 60/90/130/210 total armor points per tier
+- **Dual-wield by tier:**
+  - Tier 1: no dual-wield
+  - Tier 2-3: every 2nd hit triggers partner weapon at 25% damage + inflicts 1 Duel Escalates
+  - Tier 4: every hit triggers partner weapon at 25% damage + inflicts 1 Duel Escalates
+- Implemented via `set_tier()` — adjusts `swing_threshold` var (2 at tier 2-3, 1 at tier 4). At tier 1, dual-wield is disabled.
+
+## Progression Trigger
+- **Duels** are the main progression mechanic
+- When the apprentice wins OR loses a duel, they gain attributes
+- Attribute gain scales with the opponent's attributes — stronger opponents = more growth
+- Max attributes: **200 all**
+- Gear tiers up when: `(apprentice attributes / 2) >= gear tier requirement`
+  - Tier 2 unlocks at 120 attributes (120/2 = 60)
+  - Tier 3 unlocks at 160 attributes (160/2 = 80)
+  - Tier 4 unlocks at 200 attributes (200/2 = 100)
+
+---
+
+## Duel System (PvP)
+
+### How to Start a Duel
+**Option A: Action button**
+- Apprentice gets a `/datum/action` button (granted on recruitment)
+- Click the action, then click a target player — sends them a duel challenge
+- Target gets an alert: "X challenges you to a duel. Accept?"
+
+**Option B: Item-based**
+- Apprentice gets a "duel gauntlet" item
+- Hit another player with it to challenge them
+
+**Option C: Verb-based**
+- Right-click another player -> "Challenge to Duel"
+
+### Duel Arena (based on elite_tumor pattern)
+- A ring of visual markers spawns around the midpoint between the two players
+- Uses `RANGE_TURFS(radius, center)` + `get_dist() == radius` to place markers on the border
+- **Barrier does NOT block movement** — stepping on a barrier tile instantly ends the duel (the player who stepped on it loses)
+- Markers refresh on a timer loop since they're temp_visuals with a duration
+
+### Win/Loss Conditions
+- A player **enters crit** (SOFT_CRIT via `COMSIG_MOB_STATCHANGE`) → loser
+- A player **steps on a barrier tile** (Crossed()) → auto-lose
+- A player is **deleted/disconnects** → auto-lose
+
+### Post-Duel Healing
+- **Winner**: healed for **50% of their missing HP**
+- **Loser**: healed for **25% of their missing HP**
+
+---
+
+## Duelable Roles
+
+### Association Members (`ModularLobotomy/associations`)
+- Grants association EXP back to the association member on duel
+- Grants Palermitan EXP + role-specific passive progress to apprentice
+
+### City Roles
+- `code/modules/jobs/job_types/city/carnival.dm` — Carnival members
+- `code/modules/jobs/job_types/city/backstreets_butcher.dm` — Backstreets Butchers
+- `code/modules/jobs/job_types/city/rat.dm` — Rats
+- `code/modules/jobs/job_types/city/syndicate.dm` — Syndicate members
+- `code/modules/jobs/job_types/city/civilian.dm` — Civilians
+- `code/modules/jobs/job_types/city/misc/blade_lineage_misc.dm` — Blade Lineage
+
+### Trusted Roles
+- `code/modules/jobs/job_types/trusted_players/association/roaming.dm` — Roaming association members
+
+---
+
+## Dual Reward System
+
+### Apprentice Gets (from every duel):
+1. **Attribute growth** — scales with opponent's attributes
+2. **Palermitan EXP** — goes toward the Palermitan Style skill tree
+3. **Role-specific passive progress** — tracked per role, unlocks passives from dueling that role repeatedly
+
+### Opponent Gets (when dueling the apprentice):
+- **Association members** → EXP for their association system
+- **Other roles** → partial healing only (the duel itself is the content)
+
+---
+
+## Palermitan Style Skill Tree
+
+### Overview (from Limbus Company lore, adapted to SS13)
+> The Palermitan Style has much in common with La Famiglia Bognatelli — renowned for relentlessly
+> focusing on a single prey during a hunt, concluded with a Coup de Grâce.
+> These executions are not carried out in the shadows, but proudly put on display.
+
+**Core mechanic: "The Duel Escalates"** — a stacking status effect inflicted on the target.
+The more you fight a single target, the stronger you become against them.
+
+### System Architecture (mirrors Ring skill tree exactly)
+- Uses the same pattern as `/datum/ring_skill_tree` + `/datum/component/ring_skill`
+- **4 schools**, each with **3 tiers** and **2 mutually exclusive choices per tier** (a/b)
+- Tier costs: 1, 2, 3 skill points per tier
+- Must complete tier N before accessing tier N+1 within a school
+- Max schools: **2** (same as Ring default — can invest in 2 of the 4 schools)
+- TGUI interface reuses `RingSkillTree.js` pattern with tabs per school
+- Skills are components registered via signals (`COMSIG_MOB_ITEM_ATTACK`, etc.)
+
+### New Status Effect: "The Duel Escalates"
+```
+/datum/status_effect/stacking/duel_escalates
+  id = "duel_escalates"
+  max_stacks = 20
+  tick_interval = 10 SECONDS
+  var/mob/living/duelist
+```
+- Gained by the TARGET when the apprentice hits them (1 stack per hit via "Duello" passive)
+- Expires if the apprentice doesn't hit the target for a full tick (10 seconds)
+- Grants the apprentice scaling bonuses against targets with this effect
+
+### Base Passive: "Duello" (always active, not a tree skill)
+- **On Hit**: Inflict 1 "The Duel Escalates" on target
+- **On Hit vs target with Duel Escalates**: Heal 3 sanity per stack (max 15 sanity per hit)
+- This is the foundation — tree schools enhance what Duel Escalates does
+
+### Base Passive: "Palermitan Style" (always active, scales with Duel Escalates)
+Per stack of Duel Escalates on target:
+- Deal **+5% damage** against that target
+- Take **-5% damage** from that target
+- At **5+ stacks**: +5 force bonus
+- At **10+ stacks**: +10 force bonus
+
+---
+
+### Skill Tree — 4 Schools
+
+#### School 1: "Terremoto" (Earthquake) — Tremor Focus
+**Color**: `#8b6914` (amber/brown)
+**Theme**: Destabilize the target with tremor, culminating in devastating tremor bursts.
+**Cross-school overlap**: Tier 3 options interact with Overheat (triggering tremor burst also applies burn effects).
+
+**Tremor Burst Progression:**
+- Base passives and Tier 1 skills apply tremor with `INFINITY` burst threshold (no burst).
+- Tier 2 **unlocks tremor bursting** — skills change the burst threshold to a reachable value (e.g., 15 or 20 stacks), or provide ways to force-trigger bursts.
+- Tier 3 provides powerful payoffs that proc on tremor burst, rewarding the investment.
+- Without investing in Terremoto tier 2+, tremor stacks just slow the target but never burst.
+
+##### Tier 1 (cost: 1)
+**1a: "Il Cacciatore" (The Hunter)**
+- On Hit: inflict 2 Tremor (`apply_lc_tremor`, INFINITY burst — no burst yet)
+- On Hit vs target with Duel Escalates: also gain 1 Offense Level Up
+- *Builds tremor stacks for slowdown. Burst unlocked at tier 2.*
+
+**1b: "Destabilizing Strikes"**
+- On Hit: inflict 1 Tremor (INFINITY burst). On Hit vs target with 3+ Duel Escalates: inflict 2 Tremor instead
+- At 7+ Duel Escalates: inflict 3 Tremor instead
+- *Slower tremor buildup that scales heavily with Duel Escalates commitment*
+
+##### Tier 2 (cost: 2)
+**2a: "Palermitan Rapier" (The Cleaving Blade)**
+- **Unlocks tremor bursting:** Your tremor applications now use a burst threshold of **15** instead of INFINITY
+- When your attacks trigger a Tremor Burst: gain 5 Offense Level Up and 5 Poise
+- *The key unlock — tremor now detonates at 15 stacks, rewarding you with OLU and Poise on burst*
+
+**2b: "Aftershock"**
+- **Unlocks tremor bursting:** Your tremor applications now use a burst threshold of **25** instead of INFINITY (higher threshold = more buildup before burst, but bigger tremor burst effect since stacks are higher)
+- On Hit vs target with 10+ Tremor: inflict 2 Offense Level Down on target
+- On Hit vs target with 20+ Tremor: inflict 3 Offense Level Down instead
+- *Higher burst threshold for bigger knockdowns, plus debuffs while building*
+
+##### Tier 3 (cost: 3)
+**3a: "Sezionatura di Cervo" (Butchering the Deer)**
+- Activated ability (60s CD). Next hit: inflict 4 Tremor + 4 Overheat, **force trigger Tremor Burst** (regardless of threshold), deal bonus RED = (Duel Escalates * 5). Consume 50% of Duel Escalates stacks (rounded down).
+- *Cross-school: Overheat application on the finisher. Guaranteed burst even if below threshold.*
+
+**3b: "Tectonic Collapse"**
+- On Tremor Burst: inflict 3 Fragile on the target and 3 Defense Level Down
+- Also inflict 2 Overheat on the target when tremor bursts
+- *Turns tremor bursts into a massive debuff window + cross-school overheat*
+
+---
+
+#### School 2: "Incendio" (Inferno) — Overheat Focus
+**Color**: `#c44536` (red/flame)
+**Theme**: Burn the target down with escalating overheat, using Duel Escalates to accelerate the burn.
+**Cross-school overlap**: Tier 3 options interact with Tremor (burn detonation also applies tremor).
+
+##### Tier 1 (cost: 1)
+**1a: "Colpi Sottani" (Low Blows)**
+- On Hit: inflict 2 Overheat (`apply_lc_overheat`)
+- On Hit vs target with Duel Escalates: inflict 3 Overheat instead
+
+**1b: "Scorching Pursuit"**
+- On Hit: inflict 1 Overheat. At 5+ Duel Escalates: inflict 2 Overheat instead
+- On Hit vs target with Overheat: gain 1 Offense Level Up
+
+##### Tier 2 (cost: 2)
+**2a: "Firestorm"**
+- On Hit vs target with 10+ Overheat: gain 3 Offense Level Up, 3 Poise
+- *Reward for sustained burn buildup — also feeds into Poise for crit potential*
+
+**2b: "Smoldering Wounds"**
+- On Hit vs target with Overheat: inflict 1 Defense Level Down per 5 Overheat stacks on target (max 3 DLD)
+- *Overheat weakens the target's defenses*
+
+##### Tier 3 (cost: 3)
+**3a: "La Spada di Palermo" (The Sword of Palermo)**
+- On Hit vs target with 10+ Duel Escalates (30s CD): gain 5 Offense Level Up + 3 Damage Up, consume 5 Duel Escalates
+- On activation: also inflict 3 Tremor on the target
+- *Cross-school: Tremor application on the power spike*
+
+**3b: "Conflagration"**
+- On Hit vs target with 15+ Overheat: deal bonus RED damage equal to (Overheat stacks), then reduce Overheat by 5
+- Also inflict 2 Tremor on detonation
+- *Consume burn stacks for burst damage + cross-school tremor*
+
+---
+
+#### School 3: "Eleganza" (Elegance) — Poise & Concentration Focus
+**Color**: `#5b7c99` (steel blue)
+**Theme**: Build Poise for critical strikes and Concentration to sustain momentum. The refined swordsman's path.
+**Cross-school overlap**: Tier 3 options enhance crits to apply Tremor or Overheat.
+
+##### Tier 1 (cost: 1)
+**1a: "Relentless Pursuit"**
+- On Hit vs target with **under 5** Duel Escalates: gain 1 Concentration (world.time CD, 10 sec)
+- On Hit vs target with **5+** Duel Escalates: gain 3 Poise instead (replaces the Concentration effect)
+- *Early duel: build Concentration as a safety net. Once the duel heats up (5+ stacks): shift to aggressive Poise building*
+
+**1b: "Focused Mind"**
+- On Hit vs target with **under 5** Duel Escalates: gain 1 Poise and 1 Concentration (world.time CD, 10 sec for the Concentration)
+- On Hit vs target with **5+** Duel Escalates: gain 3 Poise instead (replaces both effects)
+- *Early duel: balanced Poise + Concentration. Once committed (5+ stacks): pure Poise aggression. Concentration only comes from the opening exchanges*
+
+##### Tier 2 (cost: 2)
+**2a: "Duello Feroce" (Fierce Duel)**
+- On Hit vs target with Duel Escalates: gain 1 Poise per 3 stacks (max 3 Poise) and heal 2 HP per stack (max 10)
+- On Poise crit that **halved your Poise** (i.e., no Concentration was consumed to preserve it): gain 1 Concentration
+- *Crits that cost you Poise reward you with Concentration for next time. But if Concentration saved your Poise, you don't gain more — preventing infinite loops*
+
+**2b: "Severed Tendon"**
+- On Poise crit: inflict 3 Offense Level Down and 1 Fragile on the crit target
+- On Poise crit that **halved your Poise** (same condition as 2a): gain 1 Poise back (softens the halving, but doesn't prevent it)
+- *Crits devastate the target's offense. The Poise recovery on halving crits reduces the sting but doesn't create infinite loops since Poise is still halved*
+
+##### Tier 3 (cost: 3)
+**3a: "Valencina's Legacy" (The War Hero)**
+- On Poise crit: inflict 3 Tremor and 3 Overheat on the target
+- On Poise crit: Duel Escalates spread to enemies within 2 tiles
+- On Poise crit (world.time CD, 15 sec): gain 1 Concentration
+- *Cross-school: Crits feed both Tremor and Overheat schools. Concentration gain is cooldown-gated*
+
+**3b: "The Famiglia's Honor" (Bognatelli Perfection)**
+- Duel Escalates max stacks increased to 30
+- On Hit vs target with 15+ Duel Escalates: gain 2 Poise
+- On Poise crit that **halved your Poise** vs target with 15+ Duel Escalates: gain 1 Concentration
+- On Poise crit vs target with 20+ Duel Escalates: inflict 3 Fragile and 3 Defense Level Down on target
+- *Single-target mastery — extreme DE commitment feeds Poise. Concentration only from paid crits, preventing infinite loops*
+
+---
+
+#### School 4: "Fondamenti" (Fundamentals) — General Passives
+**Color**: `#8b8b8b` (grey/steel)
+**Theme**: Core combat improvements that benefit any build. No status effect specialization — pure fighting fundamentals.
+
+##### Tier 1 (cost: 1)
+**1a: "Iron Constitution"**
+- On taking damage: gain 2 Defense Level Up
+- *Simple survivability*
+
+**1b: "Aggressive Footwork"**
+- On Hit: gain 1 Offense Level Up
+- On taking melee damage: gain 1 Offense Level Up
+- *Reward both offense and defense with power*
+
+##### Tier 2 (cost: 2)
+**2a: "Predator's Instinct"**
+- On Hit vs target below 50% HP: inflict 2 Fragile and gain 2 Poise
+- On Hit vs target below 25% HP: also gain 5 Offense Level Up and 2 Poise
+- *Execute weakened prey — finishing blows build Poise for crits*
+
+**2b: "Enduring Spirit"**
+- On Hit vs target with Duel Escalates: heal 1 HP per stack (max 5)
+- On taking damage while Duel Escalates is active on any nearby target: gain 1 Defense Level Up
+- *Sustain while dueling*
+
+##### Tier 3 (cost: 3)
+**3a: "Coup de Grâce"**
+- On Hit vs target below 20% HP with 5+ Duel Escalates: deal bonus RED damage = (Duel Escalates * 3), consume 50% of stacks (rounded down)
+- *Universal finisher — works regardless of which status school you chose*
+
+**3b: "Unbreakable Will"**
+- When entering soft crit (world.time CD, 60 sec): gain 5 Defense Level Up + 3 Protection + heal 10% max HP
+- *Emergency survival tool*
+
+---
+
+### School Investment Rules
+- Max **3 schools** invested
+- Each school: 3 tiers, costs 1+2+3 = **6 points per school**
+- Full 2-school investment = **12 points**
+- 10 base skill points available from EXP thresholds
+- Remaining 2 points need bonus sources (nursefather mentor, completing role passives, etc.)
+
+### Cross-School Synergies
+The schools are designed so that picking one status school (Tremor OR Overheat) pairs well with either Elegance (Poise crits apply your chosen status) or Fundamentals (general power). Some tier 3 skills explicitly bridge between schools:
+- **Sezionatura** (Tremor T3a): also applies Overheat
+- **La Spada** (Overheat T3a): also applies Tremor
+- **Valencina** (Elegance T3a): crits apply both Tremor + Overheat
+- **Conflagration** (Overheat T3b): detonation also applies Tremor
+
+This encourages builds like:
+- **Tremor + Elegance**: Build tremor, use poise crits to detonate + spread
+- **Overheat + Fundamentals**: Burn them down, use general passives for survivability
+- **Tremor + Overheat**: Maximum status pressure, tier 3 finishers bridge both
+- **Elegance + Fundamentals**: Pure combat mastery without status specialization
+
+---
+
+## Role-Specific Passives (from repeated dueling)
+
+Each duelable role grants **one unique passive** that has **3 tiers** of increasing strength.
+Tier upgrades automatically as the apprentice duels that role more times.
+These are separate from the main Palermitan tree — earned purely through dueling, no skill points.
+
+### Structure
+- 1 passive per role, 3 tiers
+- Tier 1: unlocked at **1 duel** against that role
+- Tier 2: upgrades at **3 duels** against that role
+- Tier 3: upgrades at **5 duels** against that role
+- Passives are minor and thematic, not as powerful as main tree skills
+
+### Role Passives
+
+#### Butcher — "Predator's Instinct"
+*Learned from fighting someone who hunts and isolates prey.*
+- **Tier 1 (1 duel):** On Hit vs a target below 50% HP: deal +5% bonus damage
+- **Tier 2 (3 duels):** On Hit vs a target below 50% HP: deal +10% bonus damage
+- **Tier 3 (5 duels):** On Hit vs a target below 50% HP: deal +15% bonus damage, and heal 3 HP per hit against low-HP targets
+
+#### Blade Lineage — "Resolve of the Salsu"
+*Learned from fighting honorable duelists who risk everything on a single strike.*
+- **Tier 1 (1 duel):** When below 30% HP: gain +10% damage on all attacks
+- **Tier 2 (3 duels):** When below 30% HP: gain +15% damage on all attacks
+- **Tier 3 (5 duels):** When below 30% HP: gain +20% damage on all attacks, and your attacks cannot be dodged
+
+#### — SYNDICATE FACTIONS (each faction has its own passive) —
+
+#### Thumb / Thumb East — "Soldato's Discipline"
+*Learned from fighting organized soldiers who endure through sheer grit.*
+- **Tier 1 (1 duel):** On taking RED damage: gain 2 Defense Level Up (`apply_lc_defense_level_up`)
+- **Tier 2 (3 duels):** On taking RED damage: gain 3 Defense Level Up
+- **Tier 3 (5 duels):** On taking RED damage: gain 3 Defense Level Up and 1 Offense Level Up (`apply_lc_offense_level_up`)
+
+#### Kurokumo — "Way of the Drawn Blade"
+*Learned from fighting momentum-based swordsmen who grow deadlier with each swing.*
+- **Tier 1 (1 duel):** On Hit: gain 1 Poise (independent of tree skills)
+- **Tier 2 (3 duels):** On Hit: gain 1 Poise. At 10+ Poise: +5% crit damage
+- **Tier 3 (5 duels):** On Hit: gain 1 Poise. At 10+ Poise: +10% crit damage, and crits inflict 2 Tremor
+
+#### Index — "Prescript Discipline"
+*Learned from fighting mission-focused killers who designate and destroy their prey.*
+- **Tier 1 (1 duel):** On Hit: inflict 1 Offense Level Down (`apply_lc_offense_level_down`) on target
+- **Tier 2 (3 duels):** On Hit: inflict 1 Offense Level Down and 1 Defense Level Down (`apply_lc_defense_level_down`) on target
+- **Tier 3 (5 duels):** On Hit: inflict 2 Offense Level Down and 1 Defense Level Down on target
+
+#### Insurgence — "Nightwatch Tremors"
+*Learned from fighting agents who use tremors to lock down their prey.*
+- **Tier 1 (1 duel):** On Hit: 15% chance to inflict 1 Tremor (no burst)
+- **Tier 2 (3 duels):** On Hit: 20% chance to inflict 1 Tremor (no burst)
+- **Tier 3 (5 duels):** On Hit: 25% chance to inflict 2 Tremor (no burst), and targets with 10+ Tremor take +5% more damage from you
+
+#### Middle — "Vengeance Mark"
+*Learned from fighting retaliatory brawlers who get stronger the more you hit them.*
+- **Tier 1 (1 duel):** On taking melee damage: gain +3% damage on your next attack (doesn't stack)
+- **Tier 2 (3 duels):** On taking melee damage: gain +5% damage on your next attack (doesn't stack)
+- **Tier 3 (5 duels):** On taking melee damage: gain +8% damage on your next two attacks, and the counter-hit inflicts 1 Duel Escalates
+
+#### N-Corp — "Methodical Strikes"
+*Learned from fighting systematic enforcers who mark and punish their targets.*
+- **Tier 1 (1 duel):** On Hit: inflict 1 Defense Level Down (`apply_lc_defense_level_down`) on target and inflict 1 Overheat (`apply_lc_overheat`)
+- **Tier 2 (3 duels):** On Hit: inflict 1 Defense Level Down and 2 Overheat on target
+- **Tier 3 (5 duels):** On Hit: inflict 2 Defense Level Down and 2 Overheat on target
+
+#### Rat — "Scavenger's Luck"
+*Learned from fighting unpredictable scavengers who make do with junk.*
+- **Tier 1 (1 duel):** On Hit: 5% chance to deal +50% bonus damage on that hit (lucky strike)
+- **Tier 2 (3 duels):** On Hit: 8% chance to deal +50% bonus damage on that hit
+- **Tier 3 (5 duels):** On Hit: 10% chance to deal +50% bonus damage on that hit, and lucky strikes also inflict 2 Tremor
+
+#### Carnival — "Silk Hunter's Patience"
+*Learned from fighting mechanical predators who wait for the perfect moment to strike.*
+- **Tier 1 (1 duel):** After not attacking for 3+ seconds, your next attack deals +10% damage
+- **Tier 2 (3 duels):** After not attacking for 3+ seconds, your next attack deals +20% damage
+- **Tier 3 (5 duels):** After not attacking for 3+ seconds, your next attack deals +30% damage and inflicts 2 Overheat
+
+#### Civilian — <!-- TBD (later) -->
+
+#### — ASSOCIATION FACTIONS (passive depends on which association the member belongs to) —
+
+#### Zwei — "Guardian's Resilience"
+*Learned from fighting defensive tanks who endure and outlast.*
+- **Tier 1 (1 duel):** On taking damage: gain 2 Defense Level Up (`apply_lc_defense_level_up`)
+- **Tier 2 (3 duels):** On taking damage: gain 3 Defense Level Up
+- **Tier 3 (5 duels):** On taking damage: gain 3 Defense Level Up and inflict 1 Offense Level Down (`apply_lc_offense_level_down`) on the attacker
+
+#### Seven — "Analyst's Eye"
+*Learned from fighting intelligence operatives who exploit weaknesses with precision.*
+- **Tier 1 (1 duel):** On Hit vs target with any debuff (tremor/overheat/bleed/mental decay/fragile/DLD/OLD): gain 1 Offense Level Up (`apply_lc_offense_level_up`)
+- **Tier 2 (3 duels):** On Hit vs debuffed target: gain 2 Offense Level Up
+- **Tier 3 (5 duels):** On Hit vs debuffed target: gain 2 Offense Level Up and inflict 1 additional Duel Escalates
+
+#### Dieci — "Scholar's Insight"
+*Learned from fighting knowledge-wielders who control the battlefield with status effects.*
+- **Tier 1 (1 duel):** On Hit vs a target with any status effect (tremor/overheat/bleed/mental decay): deal +3% damage per distinct effect type
+- **Tier 2 (3 duels):** On Hit vs a target with any status effect: deal +5% damage per distinct effect type
+- **Tier 3 (5 duels):** On Hit vs a target with any status effect: deal +7% damage per distinct effect type (max +28% with all 4)
+
+#### Cinq — "Duelist's Finesse"
+*Learned from fighting refined duelists with precise swordwork. (Roaming fixer only)*
+- **Tier 1 (1 duel):** On Hit: gain 2 Poise (`apply_lc_poise`)
+- **Tier 2 (3 duels):** On Hit: gain 3 Poise
+- **Tier 3 (5 duels):** On Hit: gain 3 Poise. On Poise crit that **halved your Poise**: gain 1 Concentration
+
+#### — ROAMING FIXER (passive depends on which association variant spawned) —
+*Roaming fixers spawn as a random association variant. The passive granted matches the association they represent.*
+*Dueling a Zwei roaming fixer grants progress toward the Zwei passive, a Shi roaming fixer grants Shi progress, etc.*
+
+#### Shi — "Assassin's Sacrifice"
+*Learned from fighting assassins who sacrifice their own flesh for lethal strikes.*
+- **Tier 1 (1 duel):** On Hit vs target below 30% HP (world.time cooldown, 3 sec): gain 3 Offense Level Up (`apply_lc_offense_level_up`) but lose 3% of your max HP
+- **Tier 2 (3 duels):** On Hit vs target below 30% HP (3 sec cooldown): gain 4 Offense Level Up but lose 3% of your max HP
+- **Tier 3 (5 duels):** On Hit vs target below 30% HP (3 sec cooldown): gain 5 Offense Level Up and inflict 2 Fragile (`apply_lc_fragile`) on target, but lose 3% of your max HP
+
+#### Liu — "Burning Fist"
+*Learned from fighting martial artists who channel fire through their strikes.*
+- **Tier 1 (1 duel):** On Hit: inflict 1 Overheat
+- **Tier 2 (3 duels):** On Hit: inflict 1 Overheat. Every 4th consecutive hit: inflict 2 additional Overheat
+- **Tier 3 (5 duels):** On Hit: inflict 1 Overheat. Every 3rd consecutive hit: inflict 3 additional Overheat
+
+#### Devyat — "Berserker's Escalation"
+*Learned from fighting couriers whose rage builds with every exchange of blows.*
+- **Tier 1 (1 duel):** On Hit (world.time cooldown, 3 sec): gain 2 Offense Level Up (`apply_lc_offense_level_up`) but lose 2% of your max HP
+- **Tier 2 (3 duels):** On Hit (3 sec cooldown): gain 3 Offense Level Up but lose 2% of your max HP
+- **Tier 3 (5 duels):** On Hit (3 sec cooldown): gain 3 Offense Level Up but lose 2% of your max HP. On Hit while below 50% HP: also gain 2 Defense Level Up (`apply_lc_defense_level_up`)
+
+#### Hana — "Adaptive Form"
+*Learned from fighting versatile fixers who switch between sword, spear, and fist.*
+- **Tier 1 (1 duel):** On attacking with a different weapon than your last attack (world.time cooldown, 5 sec): gain 2 Offense Level Up (`apply_lc_offense_level_up`)
+- **Tier 2 (3 duels):** On attacking with a different weapon: gain 2 Offense Level Up and 2 Defense Level Up (`apply_lc_defense_level_up`)
+- **Tier 3 (5 duels):** On attacking with a different weapon: gain 3 Offense Level Up and 2 Defense Level Up
+- **Implementation:** Track `var/obj/item/last_weapon_used` and `var/last_switch_bonus_time` on the component. In `on_attack`, compare current weapon to `last_weapon_used`. If different and `world.time > last_switch_bonus_time + 5 SECONDS`, grant bonus and update both vars. Always update `last_weapon_used` at end of proc. No extra signals needed — just a var comparison in the existing `COMSIG_MOB_ITEM_ATTACK` handler.
+
+### Implementation Note: No Timers
+All passives use only:
+- Simple var tracking (hit counters, last target refs, buffed_next_attack flags)
+- `world.time` comparisons for cooldowns (e.g., `if(world.time > last_proc_time + cooldown)`)
+- Direct checks on `on_attack` / `on_take_damage` signal handlers
+- No `addtimer()`, `sleep()`, or `spawn()` calls
+
+---
+
+## Implementation Architecture (mirrors Ring system)
+
+### Files to Create
+```
+ModularLobotomy/thumb_spider/palermitan_tree.dm        — TGUI datum + skill definitions (like ring_skill_tree.dm)
+ModularLobotomy/thumb_spider/palermitan_exp.dm          — EXP/skill point component (like artistic_exp.dm)
+ModularLobotomy/thumb_spider/palermitan_skills.dm       — Skill components (like schools/_schools.dm)
+ModularLobotomy/thumb_spider/palermitan_status.dm       — "The Duel Escalates" + "Severed Tendon" status effects
+ModularLobotomy/thumb_spider/palermitan_actions.dm      — Action buttons (tree, duel challenge)
+tgui/packages/tgui/interfaces/PalermitanSkillTree.js    — React UI (based on RingSkillTree.js)
+```
+
+### Key Datums
+```
+/datum/component/palermitan_exp              — tracks EXP, skill points, role duel counts
+/datum/palermitan_skill_tree                 — TGUI datum, serves tree data
+/datum/component/palermitan_skill            — base skill component (signals for on_attack etc.)
+/datum/component/palermitan_skill/tier1a     — Severed Tendon
+/datum/component/palermitan_skill/tier1b     — Relentless Pursuit
+/datum/component/palermitan_skill/tier2a     — Il Cacciatore
+/datum/component/palermitan_skill/tier2b     — Colpi Sottani
+/datum/component/palermitan_skill/tier3a     — Palermitan Rapier
+/datum/component/palermitan_skill/tier3b     — Duello Feroce
+/datum/component/palermitan_skill/tier4a     — Sezionatura di Cervo
+/datum/component/palermitan_skill/tier4b     — La Spada di Palermo
+/datum/component/palermitan_skill/tier5a     — Valencina's Legacy
+/datum/component/palermitan_skill/tier5b     — The Famiglia's Honor
+/datum/status_effect/stacking/duel_escalates — target debuff
+/datum/status_effect/stacking/severed_tendon — target debuff (force reduction)
+/datum/action/innate/palermitan_tree         — opens skill tree UI
+/datum/action/innate/thumb_duel_challenge    — challenges players to duels
+```
+
+### Reference Code (Ring system to mirror)
+- `ModularLobotomy/ring/ring_skills/ring_skill_tree.dm` — tree structure + TGUI datum
+- `ModularLobotomy/ring/ring_skills/artistic_exp.dm` — EXP component
+- `ModularLobotomy/ring/ring_skills/schools/_schools.dm` — base skill component with signal registration
+- `ModularLobotomy/ring/ring_skills/schools/corporist.dm` — example school with complex skills
+- `ModularLobotomy/ring/actions/corporist_actions.dm` — tree action
+- `tgui/packages/tgui/interfaces/RingSkillTree.js` — React UI
+
+---
+
+## Concept Code
+
+### Duel Datum
+```dm
+/datum/thumb_duel
+	var/mob/living/carbon/human/challenger
+	var/mob/living/carbon/human/opponent
+	var/turf/arena_center
+	var/arena_radius = 7
+	var/active = FALSE
+	var/check_timer
+	var/list/arena_walls = list()
+
+/datum/thumb_duel/proc/start_duel()
+	// Calculate midpoint, spawn walls, register COMSIG_MOB_STATCHANGE signals
+	// Start arena_check_loop()
+
+/datum/thumb_duel/proc/spawn_arena_walls()
+	// RANGE_TURFS(arena_radius, arena_center), get_dist() == arena_radius
+	// Spawn non-dense /obj/effect/temp_visual/duel_wall with Crossed() detection
+
+/datum/thumb_duel/proc/arena_check_loop()
+	// Refresh walls every 5 seconds, queue next check
+
+/datum/thumb_duel/proc/on_barrier_crossed(mob/living/crosser)
+	// crosser == challenger -> opponent wins, crosser == opponent -> challenger wins
+
+/datum/thumb_duel/proc/end_duel(mob/living/winner, mob/living/loser, reason)
+	// Cleanup signals + walls, heal winner 50% / loser 25%, grant_duel_rewards()
+
+/datum/thumb_duel/proc/grant_duel_rewards(mob/living/winner, mob/living/loser)
+	// Attribute growth to apprentice
+	// Palermitan EXP to apprentice
+	// Role-specific duel count increment
+	// Association EXP to opponent if applicable
+	// Check gear tier-up
+```
+
+### Duel Wall (non-dense, Crossed triggers loss)
+```dm
+/obj/effect/temp_visual/duel_wall
+	icon = 'icons/turf/walls/hierophant_wall_temp.dmi'
+	icon_state = "hierophant_wall_temp-0"
+	base_icon_state = "hierophant_wall_temp"
+	smoothing_flags = SMOOTH_BITMASK
+	smoothing_groups = list(SMOOTH_GROUP_HIERO_WALL)
+	canSmoothWith = list(SMOOTH_GROUP_HIERO_WALL)
+	duration = 6 SECONDS
+	density = FALSE
+	color = "#c4a000"
+	var/datum/thumb_duel/duel_ref
+
+/obj/effect/temp_visual/duel_wall/Crossed(atom/movable/crossing)
+	// If crossing is a duel participant, call duel_ref.on_barrier_crossed()
+```
+
+---
+
+## Stat Growth from Duels
+
+**Base gain:** 6 per attribute per duel (~30 duels to max at 200, assuming mixed wins/losses vs equal opponents)
+
+**Win/Loss modifier:**
+- Win: 100% of base gain
+- Loss: 25% of base gain (75% less)
+
+**Attribute difference multiplier:**
+Compare the apprentice's average attributes vs the opponent's average attributes.
+- `ratio = opponent_avg / apprentice_avg`
+- If apprentice is weaker (ratio > 1): gain is multiplied by `ratio` (capped at 2x)
+- If apprentice is stronger (ratio < 1): gain is multiplied by `ratio` (minimum 0.25x)
+- If equal: 1x multiplier
+
+**Formula:**
+```
+opponent_avg = (opponent FORT + PRUD + TEMP + JUST) / 4
+apprentice_avg = (apprentice FORT + PRUD + TEMP + JUST) / 4
+ratio = clamp(opponent_avg / apprentice_avg, 0.25, 2.0)
+win_modifier = won ? 1.0 : 0.25
+gain_per_attribute = round(base_gain * ratio * win_modifier)
+```
+Each attribute gains `gain_per_attribute`, capped at 200.
+
+**Examples (base_gain = 6):**
+| Scenario | Ratio | Win Mod | Gain per Attr |
+|----------|-------|---------|---------------|
+| Apprentice (40 avg) beats opponent (100 avg) | 2.0 (capped) | 1.0 | 12 |
+| Apprentice (40 avg) loses to opponent (100 avg) | 2.0 (capped) | 0.25 | 3 |
+| Apprentice (100 avg) beats opponent (40 avg) | 0.4 | 1.0 | 2 |
+| Apprentice (100 avg) beats opponent (100 avg) | 1.0 | 1.0 | 6 |
+| Apprentice (100 avg) loses to opponent (40 avg) | 0.4 | 0.25 | 1 |
+
+**Progression pacing (vs equal opponents, ~70% win rate):**
+- Avg gain/duel: ~4.6 per attribute
+- Tier 2 (need 120 attrs, gain 80): ~17 duels
+- Tier 3 (need 160 attrs, gain 120): ~26 duels
+- Tier 4 / max (need 200 attrs, gain 160): ~35 duels
+
+**Gear tier-up check:** After applying attribute gains, check if `(new_attributes / 2) >= next tier requirement` and call `set_tier()` on armor + both weapons if so.
+
+---
+
+## Palermitan EXP & Skill Points
+
+### EXP Gain from Duels
+
+**Base EXP:** 20 EXP per duel
+
+**Win/Loss modifier:**
+- Win: 100% of base EXP
+- Loss: 25% of base EXP (75% less)
+
+**Attribute difference multiplier (same formula as stat growth):**
+```
+ratio = clamp(opponent_avg / apprentice_avg, 0.25, 2.0)
+win_modifier = won ? 1.0 : 0.25
+exp_gained = round(base_exp * ratio * win_modifier)
+```
+
+**Examples (base_exp = 20):**
+| Scenario | Ratio | Win Mod | EXP Gained |
+|----------|-------|---------|------------|
+| Weak apprentice (40) beats strong opponent (100) | 2.0 | 1.0 | 40 |
+| Weak apprentice (40) loses to strong opponent (100) | 2.0 | 0.25 | 10 |
+| Equal (100) beats equal (100) | 1.0 | 1.0 | 20 |
+| Strong apprentice (100) beats weak opponent (40) | 0.4 | 1.0 | 8 |
+| Strong apprentice (100) loses to weak opponent (40) | 0.4 | 0.25 | 2 |
+
+### Skill Point Thresholds
+
+Palermitan tree has 5 tiers with a/b choices. Maximum useful skill points = 5 (one per tier, costing 1+2+3+4+5 = 15 total points).
+
+EXP thresholds are designed so:
+- First few points come quickly (early progression feels rewarding)
+- Later points require significantly more duels
+- Total of **10 skill points** available (gives room to unlock all 5 tiers, with some spare for future expansion)
+
+```
+var/static/list/exp_thresholds = list(
+    20,     // Skill point 1  — ~1 duel vs equal opponent
+    50,     // Skill point 2  — ~2 more duels
+    80,     // Skill point 3  — ~2 more duels
+    120,    // Skill point 4  — ~2 more duels
+    170,    // Skill point 5  — ~3 more duels (enough to fill tiers 1-2)
+    220,    // Skill point 6  — ~3 more duels (enough to fill tiers 1-3)
+    280,    // Skill point 7  — ~3 more duels
+    350,    // Skill point 8  — ~4 more duels
+    430,    // Skill point 9  — ~4 more duels
+    500,    // Skill point 10 — ~4 more duels (enough to fill tiers 1-4)
+)
+```
+
+**Skill point costs per tier:**
+| Tier | Cost | Cumulative Points Spent | Approx. Total EXP Needed | Approx. Duels (vs equal, all wins) |
+|------|------|------------------------|--------------------------|-------------------------------------|
+| 1 | 1 | 1 | 20 | ~1 |
+| 2 | 2 | 3 | 80 | ~4 |
+| 3 | 3 | 6 | 220 | ~11 |
+| 4 | 4 | 10 | 500 | ~25 |
+| 5 | 5 | 15 | Need 15 points but only 10 available — **see note** |  |
+
+**Note:** With 10 skill points max and tier 5 costing 5 points (cumulative 15 needed), the apprentice **cannot reach tier 5 with base skill points alone**. This is intentional — tier 5 mastery skills should require an additional source of skill points (e.g., bonus points from the nursefather mentor, or from completing all role-specific passives, or a quest). This gates the pinnacle behind more than just grinding duels.
+
+Alternatively, if you want tier 5 to be reachable purely through EXP, increase the threshold list to 15 entries:
+```
+// Extended version (15 skill points, enough for all 5 tiers)
+var/static/list/exp_thresholds = list(
+    20,     // SP 1
+    50,     // SP 2
+    80,     // SP 3
+    120,    // SP 4
+    170,    // SP 5
+    220,    // SP 6
+    280,    // SP 7
+    350,    // SP 8
+    430,    // SP 9
+    500,    // SP 10
+    580,    // SP 11
+    660,    // SP 12
+    740,    // SP 13
+    820,    // SP 14
+    900,    // SP 15
+)
+```
+
+### How EXP is Tracked
+Same pattern as the Ring's `/datum/component/artistic_exp`:
+- `var/exp = 0` — total accumulated EXP
+- `var/skill_points = 0` — available to spend
+- `var/skill_points_spent = 0` — already used
+- `check_skill_points()` — called after gaining EXP, iterates thresholds to see if new points earned
+- EXP never decreases — only gains, no loss on death or duel loss
+
+---
+
+## Restrictions / Limitations
+<!-- Cooldown between duels? -->
+<!-- Can they lose progress? -->
+<!-- Can they duel anyone, or only certain players? -->
+
+
+## Interaction with Nursefather
+
+### 1. Sharing Drinks (EXP)
+**Trigger:** Apprentice uses `give()` to offer a drink to the nursefather (or vice versa), where the drink is a `/obj/item/reagent_containers/food/drinks` that has `foodtype & ALCOHOL` or contains `/datum/reagent/consumable/ethanol`.
+- **EXP gained:** 5 EXP per drink shared
+- **Cooldown:** 2 minutes (`world.time` check) between EXP-granting drinks
+- **Implementation:** Register `COMSIG_ITEM_OFFER_TAKEN` on the apprentice component. When fired, check:
+  - Is the offered item a drink with alcohol?
+  - Is the other party the nursefather (check `mind.assigned_role == "Ex Thumb Sottocapo"`)
+  - Has 2 minutes passed since last drink EXP? (`world.time > last_drink_exp_time + 2 MINUTES`)
+
+### 2. Glass Bottle Impact (EXP)
+**Trigger:** Apprentice is hit by a `/obj/item/reagent_containers/food/drinks` that has `isGlass = TRUE`, either via:
+- **Thrown:** Detected via `COMSIG_ATOM_HITBY` on the apprentice — check if `AM` is a glass drink and `throwingdatum.thrower` is the nursefather
+- **Melee attack:** Detected via `COMSIG_MOB_APPLY_DAMGE` or `COMSIG_PARENT_ATTACKBY` — check if the item used is a glass drink and the attacker is the nursefather
+- **EXP gained:** 3 EXP per impact
+- **Cooldown:** 30 seconds (`world.time` check)
+- **Implementation:** Register `COMSIG_ATOM_HITBY` on the apprentice mob. In handler:
+  ```
+  if(istype(AM, /obj/item/reagent_containers/food/drinks))
+      var/obj/item/reagent_containers/food/drinks/D = AM
+      if(D.isGlass && throwingdatum?.thrower is nursefather)
+          grant EXP
+  ```
+
+### 3. Post-Duel Correction (Attributes + EXP)
+**Trigger:** After the apprentice **loses** a duel, within 1.5 minutes, if the nursefather punches them (unarmed melee attack).
+
+**Effect:**
+- Small animation of the nursefather "disciplining" the apprentice
+- Deals damage equal to a % of apprentice's **current HP** (scales with usage)
+- Grants **0.25x** of the attributes they would have gained from a win (so losing + correction = 50% of win value)
+- Grants **5 EXP**
+
+**Escalating severity** (tracked via `var/correction_count` on the component, animation tier = `round(correction_count / 2) + 1`, capped at 5):
+| Correction # | Animation Tier | Damage (% current HP) | Animation |
+|-------------|---------------|----------------------|-----------|
+| 1-2 | 1 | 5% | Light slap, apprentice flinches |
+| 3-4 | 2 | 10% | Backhand, small pixel flinch |
+| 5-6 | 3 | 20% | Cutscene: 2-hit combo with pixel shifting |
+| 7-8 | 4 | 30% | Cutscene: 3-hit combo, knockdown |
+| 9+ | 5 (capped) | 50% (capped) | Cutscene: 5-hit full beating, heavy knockdown |
+
+**Implementation:**
+- On duel loss: set `var/correction_eligible = TRUE` and `var/correction_deadline = world.time + 1.5 MINUTES` on the apprentice component. Store `var/potential_correction_attrs` (the 0.25x attribute value from the last lost duel)
+- Register `COMSIG_MOB_APPLY_DAMGE` or `COMSIG_PARENT_ATTACKBY` on the apprentice
+- When attacked: check if attacker is nursefather, attacker is unarmed (no held weapon or bare hands), `correction_eligible == TRUE`, and `world.time < correction_deadline`
+- If valid:
+  1. Set `correction_eligible = FALSE`
+  2. Calculate damage: `apprentice.health * escalation_percent`
+  3. Deal RED damage to apprentice
+  4. Play animation (visible_message + playsound, scaling with `correction_count`)
+  5. Grant `potential_correction_attrs` to all 4 attributes
+  6. Grant 5 EXP
+  7. Increment `correction_count`
+  8. Check gear tier-up
+
+**Animation concept:**
+```dm
+/// correction_count is the raw count of times used. Animation tier = clamp(round(correction_count / 2) + 1, 1, 5)
+/proc/nursefather_correction(mob/living/carbon/human/nursefather, mob/living/carbon/human/apprentice, correction_count)
+    // Calculate animation tier from correction count (upgrades every 2 uses)
+    var/anim_tier = clamp(round(correction_count / 2) + 1, 1, 5)
+    var/list/damage_percents = list(0.05, 0.10, 0.20, 0.30, 0.50)
+    var/damage = apprentice.health * damage_percents[anim_tier]
+    
+    switch(anim_tier)
+        // --- TIER 1-2: Simple hits, no lockdown ---
+        if(1)
+            nursefather.visible_message(
+                span_warning("[nursefather] lightly slaps [apprentice]."),
+                span_warning("You correct [apprentice] with a light slap."))
+            playsound(apprentice, 'sound/weapons/punch1.ogg', 25)
+            nursefather.do_attack_animation(apprentice)
+            apprentice.deal_damage(damage, RED_DAMAGE, nursefather)
+        if(2)
+            nursefather.visible_message(
+                span_warning("[nursefather] backhands [apprentice] across the face."),
+                span_warning("You backhand [apprentice]."))
+            playsound(apprentice, 'sound/weapons/punch2.ogg', 35)
+            nursefather.do_attack_animation(apprentice)
+            // Small pixel flinch
+            animate(apprentice, pixel_x = apprentice.base_pixel_x + 4, time = 1)
+            animate(pixel_x = apprentice.base_pixel_x, time = 2)
+            apprentice.deal_damage(damage, RED_DAMAGE, nursefather)
+
+        // --- TIER 3+: Cutscene lockdown with pixel-shift animations ---
+        if(3)
+            // Lock both in place, block outside damage
+            var/combo_duration = 1.5 SECONDS
+            nursefather.Immobilize(combo_duration)
+            nursefather.changeNext_move(combo_duration)
+            apprentice.Immobilize(combo_duration)
+            apprentice.AddComponent(/datum/component/cutscene_duel, nursefather)
+            nursefather.face_atom(apprentice)
+
+            // Hit 1: Hard backhand — apprentice pixel-shifts right
+            nursefather.do_attack_animation(apprentice)
+            playsound(apprentice, 'sound/weapons/punch3.ogg', 45)
+            animate(apprentice, pixel_x = apprentice.base_pixel_x + 8, time = 1)
+            apprentice.deal_damage(damage * 0.5, RED_DAMAGE, nursefather, DAMAGE_FORCED)
+            sleep(0.4 SECONDS)
+
+            // Hit 2: Follow-up — apprentice shifts back the other way
+            nursefather.do_attack_animation(apprentice)
+            playsound(apprentice, 'sound/weapons/punch4.ogg', 50)
+            animate(apprentice, pixel_x = apprentice.base_pixel_x - 6, time = 1)
+            apprentice.deal_damage(damage * 0.5, RED_DAMAGE, nursefather, DAMAGE_FORCED)
+            shake_camera(apprentice, 1, 2)
+            sleep(0.4 SECONDS)
+
+            // Return to position
+            animate(apprentice, pixel_x = apprentice.base_pixel_x, pixel_y = apprentice.base_pixel_y, time = 2)
+            qdel(apprentice.GetComponent(/datum/component/cutscene_duel))
+
+            nursefather.visible_message(
+                span_danger("[nursefather] strikes [apprentice] twice in quick succession."),
+                span_danger("You discipline [apprentice] with two hard strikes."))
+
+        if(4)
+            // Longer cutscene — 3 hits with increasing pixel shift
+            var/combo_duration = 2.5 SECONDS
+            nursefather.Immobilize(combo_duration)
+            nursefather.changeNext_move(combo_duration)
+            apprentice.Immobilize(combo_duration)
+            apprentice.AddComponent(/datum/component/cutscene_duel, nursefather)
+            nursefather.face_atom(apprentice)
+
+            // Hit 1: Body blow — apprentice bends forward (pixel_y down)
+            nursefather.do_attack_animation(apprentice)
+            playsound(apprentice, 'sound/weapons/punch3.ogg', 50)
+            animate(apprentice, pixel_y = apprentice.base_pixel_y - 4, pixel_x = apprentice.base_pixel_x + 2, time = 1)
+            apprentice.deal_damage(damage * 0.33, RED_DAMAGE, nursefather, DAMAGE_FORCED)
+            sleep(0.5 SECONDS)
+
+            // Hit 2: Uppercut — apprentice shifts up and back
+            nursefather.do_attack_animation(apprentice)
+            playsound(apprentice, 'sound/weapons/punch4.ogg', 55)
+            animate(apprentice, pixel_y = apprentice.base_pixel_y + 6, pixel_x = apprentice.base_pixel_x - 4, time = 1)
+            apprentice.deal_damage(damage * 0.33, RED_DAMAGE, nursefather, DAMAGE_FORCED)
+            shake_camera(apprentice, 2, 2)
+            sleep(0.5 SECONDS)
+
+            // Hit 3: Finishing blow — apprentice slammed down
+            nursefather.do_attack_animation(apprentice)
+            playsound(apprentice, 'sound/weapons/punch4.ogg', 65)
+            animate(apprentice, pixel_y = apprentice.base_pixel_y - 8, pixel_x = apprentice.base_pixel_x, time = 1)
+            apprentice.deal_damage(damage * 0.34, RED_DAMAGE, nursefather, DAMAGE_FORCED)
+            shake_camera(apprentice, 3, 3)
+            apprentice.Knockdown(10)
+            sleep(0.5 SECONDS)
+
+            // Return to position
+            animate(apprentice, pixel_x = apprentice.base_pixel_x, pixel_y = apprentice.base_pixel_y, time = 3)
+            qdel(apprentice.GetComponent(/datum/component/cutscene_duel))
+
+            nursefather.visible_message(
+                span_danger("[nursefather] beats [apprentice] with a brutal three-hit combination."),
+                span_danger("You beat some sense into [apprentice]."))
+
+        if(5 to INFINITY)
+            // Full beating — 5 hits, heavy pixel shifting, knockdown
+            var/combo_duration = 4 SECONDS
+            nursefather.Immobilize(combo_duration)
+            nursefather.changeNext_move(combo_duration)
+            apprentice.Immobilize(combo_duration)
+            apprentice.AddComponent(/datum/component/cutscene_duel, nursefather)
+            nursefather.face_atom(apprentice)
+
+            var/hit_damage = damage / 5
+
+            // Hit 1: Grab — pull apprentice toward nursefather
+            playsound(apprentice, 'sound/weapons/thudswoosh.ogg', 40)
+            animate(apprentice, pixel_x = apprentice.base_pixel_x + 10, time = 1)
+            sleep(0.3 SECONDS)
+
+            // Hit 2: Gut punch — apprentice bends forward
+            nursefather.do_attack_animation(apprentice)
+            playsound(apprentice, 'sound/weapons/punch3.ogg', 55)
+            animate(apprentice, pixel_y = apprentice.base_pixel_y - 6, pixel_x = apprentice.base_pixel_x + 4, time = 1)
+            apprentice.deal_damage(hit_damage, RED_DAMAGE, nursefather, DAMAGE_FORCED)
+            sleep(0.4 SECONDS)
+
+            // Hit 3: Backhand — apprentice flung to the side
+            nursefather.do_attack_animation(apprentice)
+            playsound(apprentice, 'sound/weapons/punch4.ogg', 60)
+            animate(apprentice, pixel_x = apprentice.base_pixel_x - 10, pixel_y = apprentice.base_pixel_y, time = 1)
+            apprentice.deal_damage(hit_damage, RED_DAMAGE, nursefather, DAMAGE_FORCED)
+            shake_camera(apprentice, 2, 3)
+            sleep(0.4 SECONDS)
+
+            // Hit 4: Knee — apprentice forced down
+            nursefather.do_attack_animation(apprentice)
+            playsound(apprentice, 'sound/weapons/punch4.ogg', 65)
+            animate(apprentice, pixel_y = apprentice.base_pixel_y - 10, pixel_x = apprentice.base_pixel_x - 2, time = 1)
+            apprentice.deal_damage(hit_damage, RED_DAMAGE, nursefather, DAMAGE_FORCED)
+            shake_camera(apprentice, 3, 3)
+            sleep(0.5 SECONDS)
+
+            // Hit 5: Final slam — heavy downward, then knockdown
+            nursefather.do_attack_animation(apprentice)
+            playsound(apprentice, 'sound/weapons/punch4.ogg', 75)
+            animate(apprentice, pixel_y = apprentice.base_pixel_y - 14, pixel_x = apprentice.base_pixel_x, time = 1)
+            apprentice.deal_damage(hit_damage * 2, RED_DAMAGE, nursefather, DAMAGE_FORCED)
+            shake_camera(apprentice, 4, 4)
+            apprentice.Knockdown(20)
+            sleep(0.6 SECONDS)
+
+            // Slow recovery — apprentice pixel-shifts back to normal
+            animate(apprentice, pixel_x = apprentice.base_pixel_x, pixel_y = apprentice.base_pixel_y, time = 5, easing = QUAD_EASING)
+            qdel(apprentice.GetComponent(/datum/component/cutscene_duel))
+
+            nursefather.visible_message(
+                span_userdanger("[nursefather] gives [apprentice] a thorough, brutal beating."),
+                span_userdanger("You give [apprentice] the correction they deserve."))
+```
+
+## Other Notes
+<!-- Anything else about the system -->
+

--- a/ModularLobotomy/ego_weapons/melee/city/thumb_apprentice_implementation.md
+++ b/ModularLobotomy/ego_weapons/melee/city/thumb_apprentice_implementation.md
@@ -1,0 +1,424 @@
+# Thumb Apprentice — Implementation Plan
+
+Each step produces working, testable code. Later steps build on earlier ones but each step compiles and can be verified independently.
+
+---
+
+## Step 1: Status Effects — "The Duel Escalates" + "Severed Tendon" [CODED]
+**Files to create/modify:**
+- `code/datums/status_effects/debuffs.dm` — add both new stacking status effects
+
+**What to implement:**
+- `/datum/status_effect/stacking/duel_escalates` — max 20 stacks, 10s tick, tracks which mob inflicted it, expires if no new stacks added
+- `/mob/living/proc/apply_duel_escalates(stacks, mob/living/duelist)` — mob helper proc
+- `/datum/status_effect/stacking/severed_tendon` — max 3 stacks, 10s decay (lose 1/tick), reduces target's melee force by 5 per stack
+- `/mob/living/proc/apply_severed_tendon(stacks)` — mob helper proc
+
+**How to test:**
+- Spawn the Palermitan Debug Kit from object spawner (search "palermitan")
+- Use "Grant Base Passives" then attack a mob — verify Duel Escalates stacks appear on target
+- Verify stacks decay after 10s of not hitting
+- (Severed Tendon tested in Step 9 when skill is implemented)
+
+---
+
+## Step 2: Base Passives — Duello + Palermitan Style Component [CODED]
+**Files to create:**
+- `ModularLobotomy/thumb_spider/palermitan_base.dm` — component that grants base passives
+
+**What to implement:**
+- `/datum/component/palermitan_apprentice` — attaches to the apprentice mob
+- Registers `COMSIG_MOB_ITEM_ATTACK` signal
+- **Duello:** On Hit → inflict 1 Duel Escalates on target. If target has Duel Escalates, heal 3 sanity per stack (max 15)
+- **Palermitan Style:** On Hit → check target's Duel Escalates stacks:
+  - Per stack: deal +5% bonus damage, take -5% damage from target
+  - At 5+ stacks: +5 force bonus
+  - At 10+ stacks: +10 force bonus
+- Vars: `var/mob/living/nursefather_ref` (set on recruitment), `var/correction_count`, `var/correction_eligible`, `var/correction_deadline`, `var/potential_correction_attrs`
+
+**How to test:**
+- Use debug kit → "Grant Base Passives"
+- Attack a mob repeatedly, verify Duel Escalates stacks appear on target
+- Verify sanity healing when hitting a target with stacks
+- Verify damage bonus scales with stacks
+
+---
+
+## Step 3: Apprentice Weapons — Dual-Wield by Tier + Duel Escalates on Follow-Up [CODED]
+**Files to modify:**
+- `ModularLobotomy/ego_weapons/melee/city/thumb_spider.dm` — update `set_tier()` on both apprentice weapons
+
+**What to implement:**
+- Add to both katana and greatsword:
+  - `var/swing_threshold = 0` — 0 = disabled, 1 = every hit, 2 = every 2nd hit
+  - `var/swing_count = 0`
+  - `var/busy_dual_strike = FALSE`
+- Update `set_tier()` to set `swing_threshold`: tier 1 = 0, tier 2-3 = 2, tier 4 = 1
+- Add `attack()` override on both weapons for dual-wield follow-up logic (same pattern as thumbfather)
+- Follow-up inflicts 1 Duel Escalates on target via `apply_duel_escalates()` from Step 1
+- Helper proc to find partner apprentice weapon in other hand
+
+**How to test:**
+- Use debug kit → "Spawn Gear Set" then "Set Weapon Tier → 2"
+- Equip both weapons, attack a mob — verify every 2nd hit triggers partner follow-up at 25% damage
+- Verify follow-up inflicts Duel Escalates on target
+- Use debug kit → "Set Weapon Tier → 4", verify every hit triggers follow-up
+- Use debug kit → "Set Weapon Tier → 1", verify no follow-up
+
+---
+
+## Step 4: Palermitan EXP + Skill Point Component [CODED]
+**Files to create:**
+- `ModularLobotomy/thumb_spider/palermitan_exp.dm` — EXP tracking component
+
+**What to implement:**
+- `/datum/component/palermitan_exp` — tracks EXP, skill points, role duel counts
+- Vars: `exp`, `skill_points`, `skill_points_spent`, `role_duel_counts` (assoc list keyed by role name)
+- `var/static/list/exp_thresholds` — the threshold list from the design doc
+- Procs: `modify_exp(amount)`, `check_skill_points()`, `spend_skill_point(cost)`, `get_next_threshold()`, `increment_role_duel(role_name)`
+- Attach to apprentice mob (added in Step 2's component or separately)
+
+**How to test:**
+- Use debug kit → "Grant EXP Component"
+- Use debug kit → "Add EXP → 50", verify skill points granted (should get SP 1 at 20, SP 2 at 50)
+- Use debug kit → "Add EXP → 200" repeatedly, verify thresholds work correctly
+- Check that skill_points and skill_points_spent track correctly in the examine text or debug output
+
+---
+
+## Step 5: Duel System — Core Datum + Arena + Win/Loss [CODED]
+**Files to create:**
+- `ModularLobotomy/thumb_spider/palermitan_duel.dm` — duel datum, wall effect, challenge action
+
+**What to implement:**
+- `/datum/thumb_duel` — manages a single duel instance
+  - `start_duel()` — calculate midpoint, spawn walls, register `COMSIG_MOB_STATCHANGE` signals
+  - `spawn_arena_walls()` — non-dense temp_visuals at `get_dist() == radius` with `Crossed()` detection
+  - `arena_check_loop()` — refresh walls every 5 seconds
+  - `on_barrier_crossed()` — player who steps on wall loses
+  - `end_duel(winner, loser)` — cleanup, heal winner 50% / loser 25%
+- `/obj/effect/temp_visual/duel_wall` — non-dense, gold-colored, `Crossed()` triggers loss
+- `/datum/action/innate/thumb_duel_challenge` — action button to challenge nearby players
+- No rewards yet — just the duel mechanics
+
+**How to test:**
+- Use debug kit → "Force Start Duel vs Dummy" — spawns a dummy and immediately starts a duel
+- Verify gold arena walls spawn at the midpoint between you and the dummy
+- Walk into the wall tiles — verify you auto-lose and the duel ends
+- Start another duel vs dummy. Kill the dummy until it enters crit — verify you win
+- Verify you are healed 50% of missing HP after winning
+- Verify walls disappear and clean up after duel ends
+- Use debug kit → "Spawn Duel Dummy", then use the Duel Challenge action button manually — click the dummy, verify the duel starts (dummy auto-accepts)
+
+---
+
+## Step 6: Duel Rewards — Attributes + EXP + Role Tracking [CODED]
+**Files to modify:**
+- `ModularLobotomy/thumb_spider/palermitan_duel.dm` — add `grant_duel_rewards()` implementation
+
+**What to implement:**
+- `grant_duel_rewards(winner, loser)`:
+  - Determine which participant is the apprentice
+  - Calculate attribute gain: `base_gain(6) * ratio * win_modifier`
+  - Apply to all 4 attributes, cap at 200
+  - Calculate EXP gain: `base_exp(20) * ratio * win_modifier`
+  - Call `modify_exp()` on the palermitan_exp component
+  - Increment role duel count based on opponent's `mind.assigned_role`
+  - Check gear tier-up: `(attrs / 2) >= requirement` → call `set_tier()` on armor + weapons
+  - If opponent is association member: grant them association EXP
+- Store last duel result on the palermitan component for correction eligibility
+
+**How to test:**
+- Use debug kit → "Full Setup" (grants everything + sets 40 attrs)
+- Use debug kit → "Force Start Duel vs Dummy" (dummy has 100 attrs by default)
+- Win the duel — verify attributes increase (should gain ~12 per attr with ratio 2.0 since you're 40 vs 100)
+- Check EXP gained (should be ~40 EXP)
+- Use debug kit → "Simulate Duel Loss" — verify gain is 75% less (~3 per attr, ~10 EXP)
+- Use debug kit → "Simulate Duel Win" repeatedly to rapidly test progression
+- Keep simulating until attributes hit 120 — verify gear auto-tiers to tier 2 (examine armor for changed values, check weapon force)
+- Continue to 160 → tier 3, 200 → tier 4
+- Verify dual-wield activates at tier 2 (equip both weapons, attack dummy)
+
+---
+
+## Step 7: Nursefather Interactions — Drinks, Glass, Correction [CODED]
+**Files to modify:**
+- `ModularLobotomy/thumb_spider/palermitan_base.dm` — add signal handlers for interactions
+
+**What to implement:**
+- **Drink sharing:** Register `COMSIG_ITEM_OFFER_TAKEN` — check for alcohol drink + nursefather, grant 5 EXP (2 min cooldown)
+- **Glass bottle impact:** Register `COMSIG_ATOM_HITBY` — check for glass drink thrown by nursefather, grant 3 EXP (30 sec cooldown)
+- **Post-duel correction:** Register `COMSIG_PARENT_ATTACKBY` — check for nursefather unarmed punch within 1.5 min of duel loss
+  - Escalating animation proc with cutscene_duel component for tier 3+
+  - Deals damage (5% → 50% of current HP based on `correction_count / 2`)
+  - Grants 0.25x of lost duel's potential attributes + 5 EXP
+  - Increments correction_count
+
+**How to test:**
+- **Drinks:** Use debug kit → "Spawn Nursefather Drink" — simulates the full give/take flow and grants 5 EXP. Verify EXP increases. Use it again immediately — verify cooldown message. Wait 2 minutes (or use debug kit to reset cooldown if added), try again — verify EXP granted.
+- **Glass bottle:** Use debug kit → "Spawn Glass Bottle + Throw at Self" — simulates being hit by a glass bottle from the nursefather. Verify 3 EXP gained. Use again — verify 30 second cooldown.
+- **Correction:** Use debug kit → "Simulate Duel Loss + Correction" — simulates losing a duel, spawns a temporary nursefather dummy mob adjacent to you, and runs the full correction animation with the dummy acting as the nursefather (punching, pixel shifting, etc.). The dummy is deleted after the animation completes. Verify HP damage dealt, attributes + EXP granted, and chat messages.
+- Use "Simulate Duel Loss + Correction" repeatedly — verify animation escalates every 2 uses (tier 1 at corrections 1-2, tier 2 at 3-4, etc.)
+- After 8+ uses, verify the full tier 5 cutscene plays with the dummy nursefather performing the multi-hit combo, pixel shifting on the apprentice, camera shake, and knockdown
+- Verify the dummy nursefather is cleaned up (deleted) after each correction animation
+
+---
+
+## Step 8: Skill Tree — Definitions + TGUI [CODED]
+**Status:** Previously coded for 5-tier single-school. Needs full rewrite for 4-school system.
+
+**Files to modify:**
+- `ModularLobotomy/thumb_spider/palermitan_tree.dm` — rewrite TGUI datum + skill definitions for 4 schools
+- `tgui/packages/tgui/interfaces/PalermitanSkillTree.js` — rewrite React UI with school tabs
+
+**What to implement:**
+- `/datum/palermitan_skill_tree` — TGUI datum (mirrors Ring's `ring_skill_tree` exactly)
+  - `GLOB.palermitan_skill_definitions` — 4 schools, 3 tiers each, 2 choices per tier (24 skills total)
+  - `ui_data()` — serves school data with tabs, tier data with availability/lock/selected flags
+  - `ui_act("select_skill")` — validates school investment limit (max 2), tier prerequisites, point cost
+  - School investment tracking via `palermitan_exp` component (add `schools_invested`, `max_schools` vars)
+- React UI based on `RingSkillTree.js` with 4 school tabs:
+  - Terremoto (amber `#8b6914`), Incendio (red `#c44536`), Eleganza (blue `#5b7c99`), Fondamenti (grey `#8b8b8b`)
+- `/datum/action/innate/palermitan_tree` — opens the tree UI (already exists, keep)
+
+**What to update on palermitan_exp.dm:**
+- Add `var/list/schools_invested = list()` — tracks which schools player has invested in
+- Add `var/max_schools = 2` — max schools allowed
+- Add `proc/can_invest_in_school(school_id)` — checks if max not reached or already invested
+- Add `proc/invest_in_school(school_id)` — registers investment
+
+**How to test:**
+- Use debug kit → "Grant Skill Tree Action" + "Grant EXP Component"
+- Use debug kit → "Add EXP → 500" (grants all 10 skill points for testing)
+- Click "Palermitan Skill Tree" action — verify TGUI opens with 4 school tabs
+- Select Terremoto tab — verify 3 tiers display with a/b choices
+- Select Terremoto 1a — verify it highlights green, 1b becomes excluded
+- Select Terremoto 2a — verify it unlocks (previous tier completed)
+- Switch to Incendio tab — select 1a — verify it works (2nd school)
+- Try to select Eleganza 1a — verify it's blocked ("max 2 schools")
+- Use debug kit → "Reset All" and reopen — verify tree is blank
+
+---
+
+## Step 9: Skill Components — Terremoto + Incendio Schools [CODED]
+**Status:** Previously coded for old tier 1-3 skills. Needs full rewrite for new school skills.
+
+**Files to modify:**
+- `ModularLobotomy/thumb_spider/palermitan_skills.dm` — rewrite all skill components
+
+**What to implement:**
+- `/datum/component/palermitan_skill` — base component (keep existing pattern)
+- Add `var/tremor_burst_threshold = INFINITY` tracking on the base component or apprentice component
+  - Terremoto T2 skills modify this to 15 or 25
+
+**Terremoto school (6 skills):**
+- **T1a Il Cacciatore:** On Hit: 2 Tremor (INFINITY). Vs DE: +1 OLU
+- **T1b Destabilizing Strikes:** On Hit: 1/2/3 Tremor scaling with DE stacks
+- **T2a Palermitan Rapier:** Unlocks burst at 15. On burst: +5 OLU +2 Poise
+- **T2b Aftershock:** Unlocks burst at 25. On Hit vs 10+ Tremor: 2 OLD. Vs 20+: 3 OLD
+- **T3a Sezionatura:** Activated (60s CD). 4 Tremor + 4 Overheat + force burst + RED = (DE*5). Consume 50% DE
+- **T3b Tectonic Collapse:** On burst: 3 Fragile + 3 DLD + 2 Overheat
+
+**Incendio school (6 skills):**
+- **T1a Colpi Sottani:** On Hit: 2 Overheat. Vs DE: 3 Overheat instead
+- **T1b Scorching Pursuit:** On Hit: 1 Overheat (2 at 5+ DE). Vs Overheat target: +1 OLU
+- **T2a Firestorm:** On Hit vs 10+ Overheat: +3 OLU +1 Poise +1 Fragile
+- **T2b Smoldering Wounds:** On Hit: 1 DLD per 5 Overheat on target (max 3)
+- **T3a La Spada:** On Hit vs 10+ DE (30s CD): +5 OLU +3 Damage Up, consume 5 DE, inflict 3 Tremor
+- **T3b Conflagration:** On Hit vs 15+ Overheat: bonus RED = Overheat stacks, reduce by 5, inflict 2 Tremor
+
+**How to test:**
+- Use debug kit → full setup + "Add EXP → 500"
+- Open tree, select Terremoto 1a → attack mob, verify 2 Tremor applied (no burst)
+- Select Terremoto 2a → attack mob, verify tremor now bursts at 15 stacks. Verify +5 OLU +2 Poise on burst
+- Reset, select Terremoto 2b → verify burst at 25 stacks. Verify OLD on 10+/20+ Tremor targets
+- Select Terremoto 3a → verify Sezionatura action button appears. Use it, verify force burst + effects
+- Reset, test Incendio school similarly
+- Test cross-school: Terremoto T3b (Tectonic Collapse) procs Overheat on burst
+
+---
+
+## Step 10: Skill Components — Eleganza + Fondamenti Schools [CODED]
+**Files to modify:**
+- `ModularLobotomy/thumb_spider/palermitan_skills.dm` — add remaining school skills
+
+**What to implement:**
+
+**Eleganza school (6 skills):**
+- **T1a Relentless Pursuit:** Under 5 DE: +1 Concentration (10s CD). 5+ DE: +3 Poise instead
+- **T1b Focused Mind:** Under 5 DE: +1 Poise +1 Concentration (10s CD). 5+ DE: +3 Poise instead
+- **T2a Duello Feroce:** On Hit vs DE: +1 Poise per 3 stacks (max 3) + heal 2 HP/stack (max 10). Halving crit: +1 Concentration
+- **T2b Severed Tendon:** On crit: 3 OLD + 1 Fragile. Halving crit: +1 Poise back
+- **T3a Valencina's Legacy:** On crit: 3 Tremor + 3 Overheat + DE spread 2 tiles. On crit (15s CD): +1 Concentration
+- **T3b Famiglia's Honor:** DE max → 30. At 15+ DE: +2 Poise. Halving crit at 15+ DE: +1 Concentration. Crit at 20+ DE: 3 Fragile + 3 DLD
+
+**Fondamenti school (6 skills):**
+- **T1a Iron Constitution:** On taking damage: +2 DLU
+- **T1b Aggressive Footwork:** On Hit: +1 OLU. On taking melee damage: +1 OLU
+- **T2a Predator's Instinct:** On Hit vs <50% HP: 2 Fragile +1 Poise. Vs <25%: +2 OLU
+- **T2b Enduring Spirit:** On Hit vs DE target: heal 1 HP/stack (max 5). On taking damage near DE target: +1 DLU
+- **T3a Coup de Grâce:** On Hit vs <20% HP with 5+ DE: bonus RED = (DE*3), consume 50% DE stacks
+- **T3b Unbreakable Will:** On entering soft crit (60s CD): +5 DLU +3 Protection +heal 10% max HP
+
+**How to test:**
+- Use debug kit → full setup + "Add EXP → 500"
+- **Eleganza T1a:** Select, attack mob. Under 5 DE: verify Concentration gain (check cooldown). At 5+ DE: verify 3 Poise, no Concentration
+- **Eleganza T2a:** Verify Poise gain scales with DE stacks. Trigger a crit that halves Poise: verify +1 Concentration. Trigger a crit where Concentration was consumed: verify NO Concentration gained
+- **Eleganza T3a Valencina:** Trigger Poise crit, verify 3 Tremor + 3 Overheat on target. Verify DE spreads to nearby mobs
+- **Fondamenti T1a:** Take damage, verify +2 DLU
+- **Fondamenti T3a Coup de Grâce:** Attack low HP mob with 5+ DE, verify bonus RED damage and 50% stack consumption
+- **Fondamenti T3b Unbreakable Will:** Get hit until soft crit, verify +5 DLU +3 Protection +heal
+
+---
+
+## Step 11: Role-Specific Passives [CODED]
+**Files to create:**
+- `ModularLobotomy/thumb_spider/palermitan_role_passives.dm` — all role passive components
+
+**What to implement:**
+- One component per role, each with 3 tiers tracked by duel count
+- Components register `COMSIG_MOB_ITEM_ATTACK` and/or `COMSIG_MOB_APPLY_DAMGE`
+- Passives: Butcher, Blade Lineage, Thumb, Kurokumo, Index, Insurgence, Middle, N-Corp, Rat, Carnival, Zwei, Seven, Dieci, Cinq, Shi, Liu, Devyat, Hana
+- Each reads its tier from `palermitan_exp.role_duel_counts[role_name]`
+- Auto-grant/upgrade after each duel via `grant_duel_rewards()`
+
+**How to test:**
+- Use debug kit → full setup + "Grant Duel Action"
+- Use debug kit → "Add Role Duel Count → Butcher → 1" — verify "Predator's Instinct" tier 1 is active. Attack a mob below 50% HP, verify 1 Fragile inflicted.
+- Use debug kit → "Add Role Duel Count → Butcher → 3" — verify tier 2 upgrade (2 Fragile).
+- Use debug kit → "Add Role Duel Count → Butcher → 5" — verify tier 3 (2 Fragile + 1 Damage Up).
+- Test at least one passive from each category:
+  - A syndicate passive (e.g. Kurokumo — attack a mob, verify Poise gain)
+  - An association passive (e.g. Zwei — take damage, verify DLU gain)
+  - A roaming passive (e.g. Liu — attack a mob, verify Overheat inflicted)
+  - Hana — equip two different weapons, attack with one then the other, verify OLU on weapon switch
+- Alternatively: duel an actual player with the right role to test the full flow (duel → role count increments → passive granted)
+
+---
+
+## Step 12: Recruitment Integration + DME [CODED]
+**Files to modify:**
+- `code/modules/jobs/job_types/trusted_players/thumb_nursefather.dm` — update recruitment to grant all systems
+- `lobotomy-corp13.dme` — add all new files
+
+**What to implement:**
+- Update `recruit_apprentice()` to:
+  - Add `palermitan_apprentice` component (base passives)
+  - Add `palermitan_exp` component (EXP tracking)
+  - Grant `thumb_duel_challenge` action (duel button)
+  - Grant `palermitan_tree` action (skill tree button)
+- Add all new `.dm` files to the DME
+- Verify full flow: recruit → duel → gain EXP/attrs → open tree → select skills → use skills in combat
+
+**How to test:**
+- **Solo test via debug kit:** Use debug kit → "Full Setup" to simulate what recruitment does. Verify all components, actions, and gear are granted. Run through the full gameplay loop:
+  1. "Force Start Duel vs Dummy" → win → verify attribute + EXP gain
+  2. Open skill tree → verify skill points available, select a skill
+  3. Attack a mob → verify selected skill works
+  4. "Spawn Nursefather Drink" → verify 5 EXP
+  5. "Simulate Duel Loss + Correction" → verify correction animation + attribute gain
+  6. "Simulate Duel Win" repeatedly until gear tiers up → verify weapon/armor stats change
+- **Multiplayer test (if available):** Join as Ex Thumb Sottocapo, recruit another player with the scroll. Verify they get 40 all attributes, tier 1 gear, both action buttons, and base passives active.
+
+---
+
+## Step 13: Polish + Compile
+- Full compile test
+- Line length check on any JS files
+- Verify no runtime errors during duel/skill/passive usage
+- Verify all temp_visuals clean up properly
+- Verify signals are properly unregistered on component removal
+
+---
+
+## Debug Tool — Palermitan Debug Kit
+
+**File:** `ModularLobotomy/thumb_spider/palermitan_debug.dm`
+
+A spawnable item (`/obj/item/palermitan_debug_kit`) that opens a TGUI menu on use-in-hand. Can be spawned from the object spawner panel by searching "palermitan debug". Works on whoever is holding it — no recruitment needed.
+
+**Important:** Local testing has only 1 player. The debug kit must handle both sides of interactions (duels, nursefather interactions, etc.) by spawning dummy mobs or simulating the other participant.
+
+**Menu options:**
+- **Grant Base Passives** — adds `/datum/component/palermitan_apprentice` to the user
+- **Remove Base Passives** — removes the component
+- **Grant EXP Component** — adds `/datum/component/palermitan_exp`
+- **Add EXP** (input amount) — calls `modify_exp(amount)`
+- **Set Attribute Level** (input value) — sets all 4 attributes to the value
+- **Set Weapon Tier** (1-4) — finds apprentice weapons in user's hands/inventory and calls `set_tier()`
+- **Set Armor Tier** (1-4) — finds apprentice armor on user and calls `set_tier()`
+- **Grant Duel Action** — gives the duel challenge action button
+- **Grant Skill Tree Action** — gives the skill tree action button
+- **Spawn Duel Dummy** — spawns a `/mob/living/simple_animal/hostile` dummy mob nearby with configurable attributes (input value, defaults to 100). The dummy stands still, has HP, can enter crit, and counts as a valid duel target. This lets you test duels solo.
+- **Force Start Duel vs Dummy** — spawns a dummy and immediately starts a duel with it (skips challenge/acceptance). The dummy fights back with basic attacks.
+- **Simulate Duel Win** — grants rewards as if you won a duel vs a 100-attr opponent (no actual duel needed)
+- **Simulate Duel Loss** — grants rewards as if you lost a duel vs a 100-attr opponent
+- **Simulate Duel Loss + Correction** — simulates a loss AND immediately performs the nursefather correction (deals damage, grants bonus attrs, escalates correction_count). Tests the full correction flow without needing a second player as nursefather.
+- **Set Correction Eligible** — makes you eligible for nursefather correction right now (in case you want to test correction separately)
+- **Add Role Duel Count** (pick role from list, input count) — sets duel count for a specific role and grants/upgrades the passive
+- **Grant All Skills** — unlocks all tier 1a + 2a + 3a in the first 2 schools (Terremoto + Incendio)
+- **Reset All** — removes all components, actions, resets everything
+- **Spawn Gear Set** — creates tier 1 apprentice armor + katana + greatsword at your feet
+- **Spawn Acceleration Ammo** — creates a stack of 12 acceleration rounds
+- **Spawn Nursefather Drink** — creates an alcoholic drink in your hand + simulates the give/take EXP flow (since you can't give() to yourself normally)
+- **Spawn Glass Bottle + Throw at Self** — spawns a glass bottle and simulates being hit by it from the nursefather, granting the 3 EXP (since you can't throw at yourself)
+- **Full Setup** — one button that does: Grant Base Passives + Grant EXP + Grant Duel Action + Grant Skill Tree + Spawn Gear Set + Set Attribute Level 40
+
+### Duel Dummy Mob
+```dm
+/mob/living/simple_animal/hostile/palermitan_dummy
+    name = "training dummy"
+    desc = "A training dummy for duel practice."
+    maxHealth = 500
+    health = 500
+    stat_attack = CONSCIOUS
+    faction = list("neutral")
+    melee_damage_lower = 10
+    melee_damage_upper = 15
+    attack_verb_continuous = "strikes"
+    attack_verb_simple = "strike"
+    /// Fake attributes for reward calculation
+    var/fake_attributes = 100
+```
+The dummy counts as a valid duel target. When the duel system calculates attribute rewards, it reads `fake_attributes` instead of real attribute datums (since simple_animals don't have them). The dummy can enter crit (triggering duel win) and can be killed normally.
+
+### Nursefather Dummy Mob
+```dm
+/mob/living/simple_animal/hostile/palermitan_nursefather_dummy
+    name = "Ex Thumb Sottocapo"
+    desc = "A stand-in for the nursefather during debug corrections."
+    icon = 'icons/mob/human.dmi'
+    icon_state = "human"
+    maxHealth = 9999
+    health = 9999
+    stat_attack = CONSCIOUS
+    faction = list("neutral")
+    melee_damage_lower = 5
+    melee_damage_upper = 10
+```
+Spawned adjacent to the apprentice by the "Simulate Duel Loss + Correction" button. Faces the apprentice, plays the correction animation as the attacker (including `do_attack_animation`, `face_atom`, cutscene_duel component), then is `qdel()`'d after the animation completes. Has high HP so it doesn't die during the animation.
+
+This debug kit is added in **Step 1** and updated with new options as each step is implemented. That way every step is immediately testable when completed.
+
+---
+
+## File Summary (all new files to create)
+```
+ModularLobotomy/thumb_spider/palermitan_debug.dm          — spawnable debug kit item
+ModularLobotomy/thumb_spider/palermitan_base.dm           — base passives component (Duello + Palermitan Style + nursefather interactions)
+ModularLobotomy/thumb_spider/palermitan_exp.dm            — EXP + skill point + school investment tracking
+ModularLobotomy/thumb_spider/palermitan_duel.dm           — duel system + arena + challenge action + rewards
+ModularLobotomy/thumb_spider/palermitan_tree.dm           — skill tree TGUI datum + 4 school definitions (24 skills)
+ModularLobotomy/thumb_spider/palermitan_skills.dm         — skill node components (4 schools x 3 tiers x 2 choices)
+ModularLobotomy/thumb_spider/palermitan_role_passives.dm  — role-specific passive components (18 roles)
+tgui/packages/tgui/interfaces/PalermitanSkillTree.js      — React skill tree UI (4 school tabs)
+```
+
+## Existing files to modify
+```
+code/datums/status_effects/debuffs.dm                                       — Duel Escalates + Severed Tendon status effects
+ModularLobotomy/ego_weapons/melee/city/thumb_spider.dm                      — weapon dual-wield by tier
+code/modules/jobs/job_types/trusted_players/thumb_nursefather.dm             — recruitment integration
+code/modules/clothing/suits/ego_gear/non_abnormality/thumb.dm               — (already done, set_tier exists)
+lobotomy-corp13.dme                                                          — include new files
+```

--- a/ModularLobotomy/ego_weapons/melee/city/thumb_odin_eye.dm
+++ b/ModularLobotomy/ego_weapons/melee/city/thumb_odin_eye.dm
@@ -27,6 +27,7 @@
 	icon = 'icons/obj/spider_house/thumb/thumb_spider_icon.dmi'
 	icon_state = "odin_eye"
 	eye_color = "FF0000"
+	organ_flags = ORGAN_UNREMOVABLE
 	/// Current precognition stacks
 	var/precognition_stacks = 30
 	/// Maximum precognition stacks

--- a/ModularLobotomy/ego_weapons/melee/city/thumb_odin_eye.dm
+++ b/ModularLobotomy/ego_weapons/melee/city/thumb_odin_eye.dm
@@ -1,4 +1,3 @@
-////////////////////////////////////////////////////////////
 // EYE OF ODIN
 //
 // A cybernetic eye organ for Thumbfathers. Grants precognitive melee evasion.
@@ -19,7 +18,6 @@
 // - Each melee hit deals 5% of incoming damage as clone damage
 // - Eye color changes from bright red to dark red
 // After 30 seconds, stacks fully restore to 30 and eye returns to bright red.
-////////////////////////////////////////////////////////////
 
 /obj/item/organ/eyes/robotic/odin_eye
 	name = "Eye of Odin"

--- a/ModularLobotomy/ego_weapons/melee/city/thumb_odin_eye.dm
+++ b/ModularLobotomy/ego_weapons/melee/city/thumb_odin_eye.dm
@@ -1,1 +1,170 @@
-// Stub - populated by the Thumb sub-PR
+////////////////////////////////////////////////////////////
+// EYE OF ODIN
+//
+// A cybernetic eye organ for Thumbfathers. Grants precognitive melee evasion.
+//
+// === PRECOGNITION STACKS ===
+// Starts at 30/30. When the user would take melee or ranged damage, they have a chance to evade.
+// Evasion chance scales linearly with stacks: 100% at 30, 40% at 1.
+// - Melee: costs max(1, CEILING(damage / 10, 1)) stacks per evade
+// - Ranged: costs max(1, CEILING(damage / 25, 1)) stacks per evade (more efficient vs projectiles)
+// No cooldown on evasion. Creates an afterimage and shifts the user to a random adjacent tile.
+//
+// === REGENERATION ===
+// Regains 10 stacks every 5 seconds, capped at 30. Uses on_life() with world.time tracking.
+//
+// === OVERHEAT ===
+// When stacks reach 0, the eye overheats for 30 seconds:
+// - No evasion, no stack regeneration
+// - Each melee hit deals 5% of incoming damage as clone damage
+// - Eye color changes from bright red to dark red
+// After 30 seconds, stacks fully restore to 30 and eye returns to bright red.
+////////////////////////////////////////////////////////////
+
+/obj/item/organ/eyes/robotic/odin_eye
+	name = "Eye of Odin"
+	desc = "A cybernetic eye implant gifted to a Thumbfather. It replaces the right eye with a glowing red optic that grants precognitive reflexes, allowing the user to evade incoming melee attacks - but overuse burns out the implant temporarily."
+	icon = 'icons/obj/spider_house/thumb/thumb_spider_icon.dmi'
+	icon_state = "odin_eye"
+	eye_color = "FF0000"
+	/// Current precognition stacks
+	var/precognition_stacks = 30
+	/// Maximum precognition stacks
+	var/max_stacks = 30
+	/// Whether the eye is currently overheated
+	var/overheated = FALSE
+	/// World time when the overheat ends
+	var/overheat_end_time = 0
+	/// World time when stacks next regenerate
+	var/next_regen_time = 0
+	/// Eye color when functioning normally
+	var/bright_red = "FF0000"
+	/// Eye color when overheated
+	var/dark_red = "8B0000"
+
+/obj/item/organ/eyes/robotic/odin_eye/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = FALSE, initialising)
+	. = ..()
+	if(!owner)
+		return
+	RegisterSignal(owner, COMSIG_MOB_APPLY_DAMGE, PROC_REF(on_damage_taken))
+	precognition_stacks = max_stacks
+	overheated = FALSE
+	overheat_end_time = 0
+	next_regen_time = world.time + 5 SECONDS
+
+/obj/item/organ/eyes/robotic/odin_eye/Remove(mob/living/carbon/M, special = 0)
+	if(M)
+		UnregisterSignal(M, COMSIG_MOB_APPLY_DAMGE)
+	precognition_stacks = max_stacks
+	overheated = FALSE
+	overheat_end_time = 0
+	eye_color = bright_red
+	return ..()
+
+/obj/item/organ/eyes/robotic/odin_eye/on_life()
+	. = ..()
+	if(!owner || owner.stat == DEAD)
+		return
+
+	// Check overheat expiry
+	if(overheated)
+		if(overheat_end_time > 0 && world.time >= overheat_end_time)
+			end_overheat()
+		return
+
+	// Stack regeneration every 5 seconds
+	if(precognition_stacks < max_stacks && world.time >= next_regen_time)
+		var/old_stacks = precognition_stacks
+		precognition_stacks = min(precognition_stacks + 10, max_stacks)
+		next_regen_time = world.time + 5 SECONDS
+		if(precognition_stacks > old_stacks)
+			to_chat(owner, span_notice("Your Eye of Odin regenerates precognition. Stacks: [precognition_stacks]/[max_stacks]."))
+
+/obj/item/organ/eyes/robotic/odin_eye/examine(mob/user)
+	. = ..()
+	if(ishuman(loc))
+		if(overheated)
+			. += span_danger("The eye is dark and smoldering - it has overheated!")
+		else
+			. += span_notice("The eye glows with a steady red light. Precognition stacks: [precognition_stacks]/[max_stacks].")
+
+/// Signal handler for incoming damage. Evades melee and ranged attacks by consuming precognition stacks.
+/// Melee: costs CEILING(damage / 10, 1) stacks. Ranged: costs CEILING(damage / 25, 1) stacks.
+/obj/item/organ/eyes/robotic/odin_eye/proc/on_damage_taken(datum/source, damage, damagetype, def_zone, attack_source, flags, attack_type)
+	SIGNAL_HANDLER
+	if(!damage || damage <= 0)
+		return
+
+	var/is_melee = (attack_type & ATTACK_TYPE_MELEE)
+	var/is_ranged = (attack_type & ATTACK_TYPE_RANGED)
+	if(!is_melee && !is_ranged)
+		return
+
+	var/mob/living/carbon/human/H = owner
+	if(!istype(H))
+		return
+
+	// Overheated: no evasion, take 5% clone damage on melee hits instead
+	if(overheated)
+		if(is_melee)
+			var/clone_damage = damage * 0.05
+			if(clone_damage > 0)
+				INVOKE_ASYNC(src, PROC_REF(apply_clone_damage), clone_damage)
+		return
+
+	// Evade the attack - chance scales with stacks: 100% at 30, 40% at 1 (linear)
+	if(precognition_stacks > 0)
+		var/evade_chance = 40 + ((precognition_stacks - 1) * 60 / (max_stacks - 1))
+		if(!prob(evade_chance))
+			return
+		// Afterimage at current position, then shift to a random adjacent tile
+		new /obj/effect/temp_visual/decoy/fading(get_turf(H), H)
+		var/turf/T = get_step(H, pick(GLOB.cardinals))
+		if(T && !T.density)
+			H.forceMove(T)
+		playsound(H, 'sound/weapons/black_silence/evasion.ogg', 50, TRUE)
+		// Consume stacks based on attack type (always at least 1)
+		// Melee: damage/10 per stack. Ranged: damage/25 per stack (more efficient vs projectiles)
+		var/stack_divisor = is_melee ? 10 : 25
+		var/stacks_to_lose = max(1, CEILING(damage / stack_divisor, 1))
+		precognition_stacks = max(0, precognition_stacks - stacks_to_lose)
+		if(precognition_stacks <= 0)
+			INVOKE_ASYNC(src, PROC_REF(enter_overheat))
+		return COMPONENT_MOB_DENY_DAMAGE
+
+/// Applies clone damage to the owner
+/obj/item/organ/eyes/robotic/odin_eye/proc/apply_clone_damage(damage)
+	if(QDELETED(owner) || owner.stat == DEAD)
+		return
+	owner.adjustCloneLoss(damage)
+
+/// Enters the overheat state: no evasion for 30 seconds, eye turns dark red
+/obj/item/organ/eyes/robotic/odin_eye/proc/enter_overheat()
+	if(overheated)
+		return
+	overheated = TRUE
+	precognition_stacks = 0
+	overheat_end_time = world.time + 30 SECONDS
+	// Change eye color to dark red
+	eye_color = dark_red
+	if(ishuman(owner))
+		var/mob/living/carbon/human/H = owner
+		H.eye_color = dark_red
+		H.regenerate_icons()
+	to_chat(owner, span_userdanger("Your Eye of Odin overheats! Your precognitive vision fades..."))
+
+/// Ends the overheat state: restores stacks to max, eye returns to bright red
+/obj/item/organ/eyes/robotic/odin_eye/proc/end_overheat()
+	if(!overheated)
+		return
+	overheated = FALSE
+	overheat_end_time = 0
+	precognition_stacks = max_stacks
+	next_regen_time = world.time + 5 SECONDS
+	// Change eye color back to bright red
+	eye_color = bright_red
+	if(ishuman(owner))
+		var/mob/living/carbon/human/H = owner
+		H.eye_color = bright_red
+		H.regenerate_icons()
+	to_chat(owner, span_nicegreen("Your Eye of Odin cools down. Precognitive vision restored. Stacks: [precognition_stacks]/[max_stacks]."))

--- a/ModularLobotomy/ego_weapons/melee/city/thumb_spider.dm
+++ b/ModularLobotomy/ego_weapons/melee/city/thumb_spider.dm
@@ -2,7 +2,6 @@
 // Thumbfather weapons are subtypes of /obj/item/ego_weapon/city (NOT thumb_east)
 // Thumbapprentice weapons are basic city ego weapons
 //
-////////////////////////////////////////////////////////////
 // THUMB NURSEFATHER WEAPON SYSTEM
 //
 // The Thumbfather Rapier and Katana are a dual-wield pair designed around the Poise/Concentration system.
@@ -58,7 +57,6 @@
 // - Detonation (on every ammo spend): weapon's detonation_sound
 // - Combo stages use lunge/sweep/finisher sounds from the Thumb East weapon set.
 // - Reload uses rifle reload start/load/end/fail sounds.
-////////////////////////////////////////////////////////////
 
 // Combo stages
 #define NURSEFATHER_COMBO_NONE 0
@@ -66,7 +64,6 @@
 #define NURSEFATHER_COMBO_ATTACK2 2
 #define NURSEFATHER_COMBO_FINISHER 3
 
-////////////////////////////////////////////////////////////
 // THUMBFATHER SHARED PROCS
 
 /// Helper proc to find the partner thumbfather weapon in the user's other hand
@@ -133,7 +130,7 @@
 	to_chat(user, span_userdanger("\The [weapon] recognizes you as an inferior. It begins to beep ominously!"))
 	user.visible_message(span_warning("\The [weapon] in [user]'s hand starts beeping loudly!"))
 
-	// Three warning beeps over ~2 seconds — dropping the weapon cancels the discipline.
+	// Three warning beeps over ~2 seconds - dropping the weapon cancels the discipline.
 	for(var/i in 1 to 3)
 		if(QDELETED(weapon) || QDELETED(user) || !user.is_holding(weapon))
 			thumbfather_clear_defense_active(weapon)
@@ -438,7 +435,6 @@
 		var/obj/item/ego_weapon/city/thumbfather_katana/K = weapon
 		K.busy = FALSE
 
-////////////////////////////////////////////////////////////
 // THUMBFATHER RAPIER
 /obj/item/ego_weapon/city/thumbfather_rapier
 	name = "thumbfather rapier"
@@ -760,7 +756,6 @@
 		. = span_danger("[user] fires their [src.name], using the exhaust to nonchalantly light [A]. They don't even flinch from the recoil.")
 		playsound(src, 'sound/weapons/ego/thumb_east_rifle_detonation.ogg', 90, FALSE, 10)
 
-////////////////////////////////////////////////////////////
 // THUMBFATHER KATANA
 /obj/item/ego_weapon/city/thumbfather_katana
 	name = "thumbfather katana"
@@ -1082,10 +1077,9 @@
 		. = span_danger("[user] fires their [src.name], using the exhaust to nonchalantly light [A]. They don't even flinch from the recoil.")
 		playsound(src, 'sound/weapons/ego/thumb_east_rifle_detonation.ogg', 90, FALSE, 10)
 
-////////////////////////////////////////////////////////////
 // THUMBAPPRENTICE WEAPONS
 // Both weapons have 4 evolution tiers. Attack speed is fixed; only force changes.
-// Katana: attack_speed = 1.0 | Greatsword: attack_speed = 1.5
+// Katana: attack_speed = 1 | Greatsword: attack_speed = 1.5
 // DPS targets per tier: 22, 32, 44, 65
 
 /// Helper proc to find the partner apprentice weapon in the user's other hand
@@ -1267,7 +1261,6 @@
 			attribute_requirements = list(FORTITUDE_ATTRIBUTE = 100, PRUDENCE_ATTRIBUTE = 100, TEMPERANCE_ATTRIBUTE = 100, JUSTICE_ATTRIBUTE = 100)
 			swing_threshold = 1
 
-////////////////////////////////////////////////////////////
 // ACCELERATION ROUNDS - Unique ammo for thumbfather weapons
 /obj/item/stack/thumb_east_ammo/acceleration
 	name = "acceleration propellant ammunition"
@@ -1304,7 +1297,7 @@
 	max_amount = 12
 	merge_type = /obj/item/stack/thumb_east_ammo/spent/acceleration
 
-// ================== THUMBFATHER EGO DATUMS ==================
+// THUMBFATHER EGO DATUMS
 // Placed here rather than in _cityweapons_datums.dm / _cityarmor_datums.dm
 // to prevent DM merge conflicts with other sub-PRs that modify those shared files.
 

--- a/ModularLobotomy/ego_weapons/melee/city/thumb_spider.dm
+++ b/ModularLobotomy/ego_weapons/melee/city/thumb_spider.dm
@@ -1304,6 +1304,42 @@
 	max_amount = 12
 	merge_type = /obj/item/stack/thumb_east_ammo/spent/acceleration
 
+// ================== THUMBFATHER EGO DATUMS ==================
+// Placed here rather than in _cityweapons_datums.dm / _cityarmor_datums.dm
+// to prevent DM merge conflicts with other sub-PRs that modify those shared files.
+
+// Thumbfather Acceleration Propellant Ammo Box
+// Holds ammo used by Thumbfather dual-wield weapons (rapier/katana).
+/datum/ego_datum/auxiliary/thumb_acceleration_ammobox
+	name = "Acceleration Propellant Ammo Box"
+	origin = "City"
+	item_category = "Ammo"
+	item_path = /obj/item/storage/box/thumb_east_ammo/acceleration
+	cost = 50
+	well_enabled = FALSE
+
+/// Thumbfather Rapier
+/datum/ego_datum/weapon/city/thumbfather_rapier
+	item_path = /obj/item/ego_weapon/city/thumbfather_rapier
+	cost = 90
+	ego_tags = list(EGO_TAG_COMBO, EGO_TAG_MOBILITY, EGO_TAG_DOT, EGO_TAG_DEBUFFER)
+
+/// Thumbfather Katana
+/datum/ego_datum/weapon/city/thumbfather_katana
+	item_path = /obj/item/ego_weapon/city/thumbfather_katana
+	cost = 90
+	ego_tags = list(EGO_TAG_COMBO, EGO_TAG_MOBILITY, EGO_TAG_AOE_RADIAL, EGO_TAG_DEBUFFER)
+
+/// Thumb Ex-Sottocapo Armor (Thumbfather)
+/datum/ego_datum/armor/city/thumb_spider_ex_sottocapo
+	item_path = /obj/item/clothing/suit/armor/ego_gear/city/thumb_spider/ex_sottocapo
+	cost = 100
+
+/// Thumb Apprentice Armor (starts at tier 1, evolves)
+/datum/ego_datum/armor/city/thumb_spider_apprentice
+	item_path = /obj/item/clothing/suit/armor/ego_gear/city/thumb_spider/apprentice
+	cost = 25
+
 #undef NURSEFATHER_COMBO_NONE
 #undef NURSEFATHER_COMBO_LUNGE
 #undef NURSEFATHER_COMBO_ATTACK2

--- a/ModularLobotomy/ego_weapons/melee/city/thumb_spider.dm
+++ b/ModularLobotomy/ego_weapons/melee/city/thumb_spider.dm
@@ -1,1 +1,1310 @@
-// Stub - populated by the Thumb sub-PR
+// Thumb Spider Weapons
+// Thumbfather weapons are subtypes of /obj/item/ego_weapon/city (NOT thumb_east)
+// Thumbapprentice weapons are basic city ego weapons
+//
+////////////////////////////////////////////////////////////
+// THUMB NURSEFATHER WEAPON SYSTEM
+//
+// The Thumbfather Rapier and Katana are a dual-wield pair designed around the Poise/Concentration system.
+// They use a unique ammo type called Acceleration Rounds (stacks to 12, double normal capacity).
+//
+// === CORE LOOP ===
+// Acceleration Rounds are spent by dual-wield follow-ups and combo actions. Basic attacks do not spend ammo.
+// Every time a round is spent, a detonation sound plays and the camera shakes.
+// When a round is spent:
+//   - Rapier: grants 5 Poise to user + applies 4 Overheat to target
+//   - Katana: grants 1 Concentration to user + applies 3 Tremor to target (no burst)
+// Poise crits also passively boost status effects regardless of combo state:
+//   - Rapier crit: +2 Overheat to target
+//   - Katana crit: +2 Tremor to target (no burst)
+//
+// === DUAL-WIELD ===
+// Every 2nd non-combo hit with one weapon triggers the partner weapon at 25% damage.
+// The follow-up spends ammo from the partner and grants its buffs/debuffs.
+// Dual-wield follow-ups do NOT advance, trigger, or interact with the combo in any way.
+// The swing counter only increments on non-combo hits.
+//
+// === COMBO (3 stages, costs 4 rounds total, requires weapon swapping) ===
+// The combo uses a lunge -> AoE sweep -> finisher pattern, similar to Thumb East weapons,
+// but requires swapping between the rapier and katana between each stage.
+//
+// 1. LUNGE: Click a target from range with either weapon (costs 1 round).
+//    Dashes to the target and auto-attacks if in range. 13 second lunge cooldown.
+//    If the lunge falls short, you can still land a melee hit with the SAME weapon to continue.
+// 2. AoE SWEEP: Hit the target in melee with the OTHER weapon (costs 1 round).
+//    Deals the weapon hit + AoE damage (50% of weapon force) in a radius around the user.
+//    Hitting with the same weapon as the lunge BREAKS the combo.
+// 3. FINISHER: Hit the target in melee with the STARTING weapon (costs 2 rounds).
+//    Deals 150% weapon force, then Tremor Bursts the target and deals bonus RED damage
+//    equal to (target's Tremor stacks + Overheat stacks).
+//    Hitting with the wrong weapon BREAKS the combo.
+//
+// The combo resets after 5 seconds of inactivity (7 seconds during the finisher window).
+// Combo state is synced between both weapons so either can be used at the correct stage.
+//
+// Example: Rapier (lunge) -> Katana (AoE sweep) -> Rapier (finisher)
+//      or: Katana (lunge) -> Rapier (AoE sweep) -> Katana (finisher)
+//
+// === RELOAD ===
+// - Channeled reload: 0.6s start + 0.4s per round loaded. Can be interrupted (fumble).
+// - Hit weapon with ammo OR hit ammo with weapon to reload (reverse reload).
+// - Loading Acceleration Rounds into one weapon also loads 1 round into the partner (linked reload).
+// - Reload start resets the combo and plays sound effects.
+// - Alt-click to manually unload a single round.
+//
+// === SOUNDS ===
+// - Rapier hitsound: thumb_east_rifle_attack.ogg
+// - Katana hitsound: thumb_east_podao_attack.ogg
+// - Detonation (on every ammo spend): weapon's detonation_sound
+// - Combo stages use lunge/sweep/finisher sounds from the Thumb East weapon set.
+// - Reload uses rifle reload start/load/end/fail sounds.
+////////////////////////////////////////////////////////////
+
+// Combo stages
+#define NURSEFATHER_COMBO_NONE 0
+#define NURSEFATHER_COMBO_LUNGE 1
+#define NURSEFATHER_COMBO_ATTACK2 2
+#define NURSEFATHER_COMBO_FINISHER 3
+
+////////////////////////////////////////////////////////////
+// THUMBFATHER SHARED PROCS
+
+/// Helper proc to find the partner thumbfather weapon in the user's other hand
+/proc/find_thumbfather_partner(obj/item/ego_weapon/city/source, mob/living/carbon/human/user)
+	if(!istype(user))
+		return null
+	for(var/obj/item/ego_weapon/city/W in user.held_items)
+		if(W == source)
+			continue
+		if(istype(W, /obj/item/ego_weapon/city/thumbfather_rapier) || istype(W, /obj/item/ego_weapon/city/thumbfather_katana))
+			return W
+	return null
+
+/// Returns TRUE if this weapon is the rapier type
+/proc/is_thumbfather_rapier(obj/item/ego_weapon/city/weapon)
+	return istype(weapon, /obj/item/ego_weapon/city/thumbfather_rapier)
+
+/// Returns TRUE if the user is permitted to wield thumbfather weapons without triggering the discipline system.
+/// Only the Ex Thumb Sottocapo and their Apprentice are authorized. Bypassed on non-city maps and the tutorial level.
+/proc/thumbfather_is_authorized(mob/user)
+	if(!ishuman(user))
+		return TRUE
+	var/mob/living/carbon/human/H = user
+	if(H.mind?.assigned_role in list("Ex Thumb Sottocapo", "Thumb Apprentice"))
+		return TRUE
+	if(!(SSmaptype.maptype in SSmaptype.citymaps))
+		return TRUE
+	if(is_tutorial_level(H.z))
+		return TRUE
+	return FALSE
+
+/// Beeps three times, fires an acceleration round into a random limb of the holder,
+/// then force-drops itself. On the 3rd+ offense against the same mob, the limb is dismembered.
+/proc/thumbfather_discipline_sequence(obj/item/ego_weapon/city/weapon, mob/living/carbon/human/user)
+	if(!istype(weapon) || !istype(user))
+		return
+	var/defense_active
+	var/list/defense_strikes
+	var/detonation_sfx
+	if(is_thumbfather_rapier(weapon))
+		var/obj/item/ego_weapon/city/thumbfather_rapier/R = weapon
+		defense_active = R.defense_active
+		defense_strikes = R.defense_strikes
+		detonation_sfx = R.detonation_sound
+	else
+		var/obj/item/ego_weapon/city/thumbfather_katana/K = weapon
+		defense_active = K.defense_active
+		defense_strikes = K.defense_strikes
+		detonation_sfx = K.detonation_sound
+	if(defense_active)
+		return
+	if(is_thumbfather_rapier(weapon))
+		var/obj/item/ego_weapon/city/thumbfather_rapier/R = weapon
+		R.defense_active = TRUE
+	else
+		var/obj/item/ego_weapon/city/thumbfather_katana/K = weapon
+		K.defense_active = TRUE
+
+	var/user_ref = REF(user)
+	var/strikes = defense_strikes[user_ref] || 0
+	strikes++
+	defense_strikes[user_ref] = strikes
+
+	to_chat(user, span_userdanger("\The [weapon] recognizes you as an inferior. It begins to beep ominously!"))
+	user.visible_message(span_warning("\The [weapon] in [user]'s hand starts beeping loudly!"))
+
+	// Three warning beeps over ~2 seconds — dropping the weapon cancels the discipline.
+	for(var/i in 1 to 3)
+		if(QDELETED(weapon) || QDELETED(user) || !user.is_holding(weapon))
+			thumbfather_clear_defense_active(weapon)
+			return
+		playsound(get_turf(weapon), 'sound/machines/triple_beep.ogg', 60, FALSE)
+		sleep(7)
+
+	if(QDELETED(weapon) || QDELETED(user) || !user.is_holding(weapon))
+		thumbfather_clear_defense_active(weapon)
+		return
+
+	// Pick a limb to fire into. Arms and legs are the Thumb's preferred punishment zones.
+	var/list/preferred_zones = list(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
+	var/obj/item/bodypart/BP
+	var/target_zone
+	for(var/zone in shuffle(preferred_zones))
+		var/obj/item/bodypart/candidate = user.get_bodypart(zone)
+		if(candidate)
+			BP = candidate
+			target_zone = zone
+			break
+	if(!BP && length(user.bodyparts))
+		BP = pick(user.bodyparts)
+		target_zone = BP.body_zone
+
+	playsound(get_turf(weapon), detonation_sfx, 90, FALSE, 10)
+	if(BP)
+		user.visible_message(span_danger("\The [weapon] discharges an acceleration round into [user]'s [BP.name]!"),
+			span_userdanger("\The [weapon] fires an acceleration round into your own [BP.name]!"))
+	else
+		user.visible_message(span_danger("\The [weapon] discharges an acceleration round into [user]!"),
+			span_userdanger("\The [weapon] fires an acceleration round into you!"))
+
+	if(strikes >= 3)
+		to_chat(user, span_userdanger("The Thumb does not tolerate repeat disrespect!"))
+		user.deal_damage(60, BRUTE, weapon, flags = DAMAGE_FORCED, def_zone = target_zone)
+		if(BP && !QDELETED(BP))
+			BP.dismember(BRUTE, FALSE)
+	else
+		user.deal_damage(35, BRUTE, weapon, flags = DAMAGE_FORCED, def_zone = target_zone)
+
+	if(!QDELETED(user) && !QDELETED(weapon))
+		user.dropItemToGround(weapon, TRUE)
+	thumbfather_clear_defense_active(weapon)
+
+/// Clears the defense_active flag on a thumbfather weapon regardless of type.
+/proc/thumbfather_clear_defense_active(obj/item/ego_weapon/city/weapon)
+	if(is_thumbfather_rapier(weapon))
+		var/obj/item/ego_weapon/city/thumbfather_rapier/R = weapon
+		R.defense_active = FALSE
+	else
+		var/obj/item/ego_weapon/city/thumbfather_katana/K = weapon
+		K.defense_active = FALSE
+
+/// Spends one acceleration round from the weapon if available. Returns TRUE if spent, FALSE otherwise.
+/// Also creates the spent cartridge, plays a detonation sound, and applies weapon-specific buffs/debuffs.
+/// volume: controls the detonation sound volume (default 90, use lower for dual-wield follow-ups)
+/proc/spend_acceleration_round(obj/item/ego_weapon/city/weapon, mob/living/user, mob/living/target, volume = 90)
+	// Access ammo list via the thumbfather vars
+	var/list/ammo_list
+	if(is_thumbfather_rapier(weapon))
+		var/obj/item/ego_weapon/city/thumbfather_rapier/R = weapon
+		ammo_list = R.current_ammo
+	else
+		var/obj/item/ego_weapon/city/thumbfather_katana/K = weapon
+		ammo_list = K.current_ammo
+	if(!length(ammo_list))
+		return FALSE
+	var/obj/item/stack/thumb_east_ammo/acceleration/accel_round
+	for(var/obj/item/stack/thumb_east_ammo/acceleration/round in ammo_list)
+		accel_round = round
+		break
+	if(!accel_round)
+		return FALSE
+	ammo_list -= accel_round
+	if(!length(ammo_list))
+		if(is_thumbfather_rapier(weapon))
+			var/obj/item/ego_weapon/city/thumbfather_rapier/R = weapon
+			R.current_ammo_type = null
+			R.current_ammo_name = ""
+		else
+			var/obj/item/ego_weapon/city/thumbfather_katana/K = weapon
+			K.current_ammo_type = null
+			K.current_ammo_name = ""
+	var/obj/item/stack/thumb_east_ammo/spent/new_spent = new accel_round.spent_type(weapon)
+	new_spent.forceMove(get_turf(weapon))
+	// Play detonation sound on every ammo spend
+	var/detonation_sfx
+	if(is_thumbfather_rapier(weapon))
+		var/obj/item/ego_weapon/city/thumbfather_rapier/R = weapon
+		detonation_sfx = R.detonation_sound
+	else
+		var/obj/item/ego_weapon/city/thumbfather_katana/K = weapon
+		detonation_sfx = K.detonation_sound
+	playsound(weapon, detonation_sfx, volume, FALSE, 10)
+	if(is_thumbfather_rapier(weapon))
+		user.apply_lc_poise(accel_round.poise_base)
+		if(isliving(target))
+			target.apply_lc_overheat(4)
+	else
+		user.apply_lc_concentration(accel_round.concentration_base)
+		if(isliving(target))
+			target.apply_lc_tremor(3, INFINITY)
+	qdel(accel_round)
+	return TRUE
+
+/// Combo finisher: tremor burst the target and deal bonus RED damage equal to (tremor + overheat stacks)
+/proc/thumbfather_finisher(mob/living/target, mob/living/user)
+	var/tremor_stacks = 0
+	var/overheat_stacks = 0
+	var/datum/status_effect/stacking/lc_tremor/T = target.has_status_effect(/datum/status_effect/stacking/lc_tremor)
+	if(T)
+		tremor_stacks = T.stacks
+	var/datum/status_effect/stacking/lc_burn/B = target.has_status_effect(/datum/status_effect/stacking/lc_burn)
+	if(B)
+		overheat_stacks = B.stacks
+	var/bonus_damage = tremor_stacks + overheat_stacks
+	if(T)
+		T.TremorBurst()
+	if(bonus_damage > 0)
+		target.deal_damage(bonus_damage, RED_DAMAGE, source = user, attack_type = ATTACK_TYPE_MELEE)
+		to_chat(user, span_green("Your finishing strike detonates for [bonus_damage] bonus damage!"))
+	to_chat(target, span_userdanger("[user]'s finishing strike detonates the built-up tremor and heat!"))
+
+/// Hits all living mobs in a radius around the user, excluding user and primary target. Used for the AoE sweep.
+/proc/thumbfather_radius_aoe(obj/item/ego_weapon/city/weapon, mob/living/user, mob/living/target, radius)
+	var/aoe_damage = round(initial(weapon.force) * 0.5)
+	for(var/turf/T in orange(radius, user))
+		new /obj/effect/temp_visual/thumb_east_aoe_impact(T)
+		for(var/mob/living/L in T)
+			if(L == user || L == target)
+				continue
+			L.deal_damage(aoe_damage, weapon.damtype, user, attack_type = (ATTACK_TYPE_MELEE | ATTACK_TYPE_SPECIAL))
+
+/// Syncs combo state to both weapons. Sets combo_stage and combo_starter_is_rapier on each.
+/proc/sync_nursefather_combo(obj/item/ego_weapon/city/weapon, mob/living/user, new_stage, new_starter_is_rapier)
+	var/obj/item/ego_weapon/city/partner = find_thumbfather_partner(weapon, user)
+	var/list/weapons = list(weapon)
+	if(partner)
+		weapons += partner
+	for(var/obj/item/ego_weapon/city/W in weapons)
+		if(is_thumbfather_rapier(W))
+			var/obj/item/ego_weapon/city/thumbfather_rapier/R = W
+			deltimer(R.combo_reset_timer)
+			R.combo_stage = new_stage
+			R.combo_starter_is_rapier = new_starter_is_rapier
+		else
+			var/obj/item/ego_weapon/city/thumbfather_katana/K = W
+			deltimer(K.combo_reset_timer)
+			K.combo_stage = new_stage
+			K.combo_starter_is_rapier = new_starter_is_rapier
+
+/// Resets combo state on both weapons. Shows a warning message if the combo was in progress.
+/proc/reset_nursefather_combo(obj/item/ego_weapon/city/weapon, mob/living/user, show_message = TRUE)
+	// Check if we should show a reset message (only if combo was in progress past lunge)
+	var/was_in_combo = FALSE
+	if(is_thumbfather_rapier(weapon))
+		var/obj/item/ego_weapon/city/thumbfather_rapier/R = weapon
+		was_in_combo = (R.combo_stage != NURSEFATHER_COMBO_NONE && R.combo_stage != NURSEFATHER_COMBO_LUNGE)
+	else
+		var/obj/item/ego_weapon/city/thumbfather_katana/K = weapon
+		was_in_combo = (K.combo_stage != NURSEFATHER_COMBO_NONE && K.combo_stage != NURSEFATHER_COMBO_LUNGE)
+	if(show_message && was_in_combo)
+		to_chat(user, span_warning("Your combo resets!"))
+	sync_nursefather_combo(weapon, user, NURSEFATHER_COMBO_NONE, FALSE)
+
+/// Starts a combo expiry timer on the active weapon. Resets combo on both weapons when it fires.
+/proc/start_nursefather_combo_timer(obj/item/ego_weapon/city/weapon, mob/living/user, extra_time = 0)
+	var/duration
+	if(is_thumbfather_rapier(weapon))
+		var/obj/item/ego_weapon/city/thumbfather_rapier/R = weapon
+		deltimer(R.combo_reset_timer)
+		duration = R.combo_reset_duration + extra_time
+		R.combo_reset_timer = addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(reset_nursefather_combo), weapon, user, TRUE), duration, TIMER_STOPPABLE)
+	else
+		var/obj/item/ego_weapon/city/thumbfather_katana/K = weapon
+		deltimer(K.combo_reset_timer)
+		duration = K.combo_reset_duration + extra_time
+		K.combo_reset_timer = addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(reset_nursefather_combo), weapon, user, TRUE), duration, TIMER_STOPPABLE)
+	// Also cancel any existing timer on the partner so we don't double-reset
+	var/obj/item/ego_weapon/city/partner = find_thumbfather_partner(weapon, user)
+	if(partner)
+		if(is_thumbfather_rapier(partner))
+			var/obj/item/ego_weapon/city/thumbfather_rapier/R = partner
+			deltimer(R.combo_reset_timer)
+		else
+			var/obj/item/ego_weapon/city/thumbfather_katana/K = partner
+			deltimer(K.combo_reset_timer)
+
+/// Channeled reload proc for thumbfather weapons. Loads rounds with do_after, with linked reload for partner.
+/proc/thumbfather_reload(obj/item/ego_weapon/city/weapon, obj/item/stack/thumb_east_ammo/ammo, mob/living/user, list/current_ammo, max_ammo, list/accepted_ammo_table)
+	if(!(ammo.type in accepted_ammo_table))
+		to_chat(user, span_warning("The [ammo.name] are incompatible with the [weapon.name]."))
+		return
+	var/bullets_in_gun = length(current_ammo)
+	if(bullets_in_gun >= max_ammo)
+		to_chat(user, span_warning("The [weapon.name] cannot fit any more ammunition - it is fully loaded."))
+		return
+	var/obj/item/ego_weapon/city/partner = find_thumbfather_partner(weapon, user)
+	var/is_acceleration = istype(ammo, /obj/item/stack/thumb_east_ammo/acceleration)
+	var/remaining_capacity = max_ammo - bullets_in_gun
+	var/amount_to_load = min(ammo.amount, remaining_capacity)
+
+	// Reload start: reset combo and play start sound
+	playsound(weapon, 'sound/weapons/ego/thumb_east_rifle_reload_start.ogg', 90, FALSE, 10)
+	to_chat(user, span_info("You begin loading your [weapon.name]..."))
+
+	// Set busy on the weapon and reset combo
+	if(is_thumbfather_rapier(weapon))
+		var/obj/item/ego_weapon/city/thumbfather_rapier/R = weapon
+		R.busy = TRUE
+	else
+		var/obj/item/ego_weapon/city/thumbfather_katana/K = weapon
+		K.busy = TRUE
+	reset_nursefather_combo(weapon, user)
+
+	// Calculate how many channeling steps we need - we load 2 rounds per step
+	var/load_steps = CEILING(amount_to_load / 2, 1)
+
+	if(do_after(user, 0.6 SECONDS, weapon, progress = TRUE, interaction_key = "thumbfather_reload", max_interact_count = 1))
+		// Load 2 rounds per channeling step
+		for(var/i in 1 to load_steps)
+			if(do_after(user, 0.4 SECONDS, weapon, progress = TRUE, interaction_key = "thumbfather_reload", max_interact_count = 1))
+				var/rounds_this_step = min(2, max_ammo - length(current_ammo))
+				var/loaded_this_step = 0
+				for(var/j in 1 to rounds_this_step)
+					if(!ammo || QDELETED(ammo) || ammo.amount < 1)
+						break
+					var/obj/item/stack/thumb_east_ammo/bullet = ammo.split_stack(user, 1)
+					if(!bullet)
+						break
+					bullet.forceMove(weapon)
+					current_ammo += bullet
+					loaded_this_step++
+				if(!loaded_this_step)
+					break
+				if(is_thumbfather_rapier(weapon))
+					var/obj/item/ego_weapon/city/thumbfather_rapier/R = weapon
+					R.current_ammo_type = ammo.type
+					R.current_ammo_name = ammo.name
+				else
+					var/obj/item/ego_weapon/city/thumbfather_katana/K = weapon
+					K.current_ammo_type = ammo.type
+					K.current_ammo_name = ammo.name
+				playsound(weapon, 'sound/weapons/ego/thumb_east_rifle_reload_load.ogg', 90, FALSE, 8)
+				to_chat(user, span_info("You load [loaded_this_step] round\s into the [weapon.name]."))
+				// Linked reload: also load 2 into partner per step
+				if(is_acceleration && partner)
+					var/list/partner_ammo
+					var/partner_max
+					var/list/partner_accepted
+					if(is_thumbfather_rapier(partner))
+						var/obj/item/ego_weapon/city/thumbfather_rapier/R = partner
+						partner_ammo = R.current_ammo
+						partner_max = R.max_ammo
+						partner_accepted = R.accepted_ammo_table
+					else
+						var/obj/item/ego_weapon/city/thumbfather_katana/K = partner
+						partner_ammo = K.current_ammo
+						partner_max = K.max_ammo
+						partner_accepted = K.accepted_ammo_table
+					var/partner_loaded = 0
+					for(var/k in 1 to 2)
+						if(!((ammo.type in partner_accepted) && length(partner_ammo) < partner_max && ammo && !QDELETED(ammo) && ammo.amount >= 1))
+							break
+						var/obj/item/stack/thumb_east_ammo/partner_bullet = ammo.split_stack(user, 1)
+						if(partner_bullet)
+							partner_bullet.forceMove(partner)
+							partner_ammo += partner_bullet
+							partner_loaded++
+					if(partner_loaded)
+						if(is_thumbfather_rapier(partner))
+							var/obj/item/ego_weapon/city/thumbfather_rapier/R = partner
+							R.current_ammo_type = ammo.type
+							R.current_ammo_name = ammo.name
+						else
+							var/obj/item/ego_weapon/city/thumbfather_katana/K = partner
+							K.current_ammo_type = ammo.type
+							K.current_ammo_name = ammo.name
+						to_chat(user, span_info("[partner_loaded] round\s also loaded into your [partner.name]."))
+			else
+				// Reload interrupted mid-loading
+				playsound(weapon, 'sound/weapons/ego/thumb_east_rifle_reload_fail.ogg', 100, FALSE, 6)
+				user.visible_message(span_danger("[user] fumbles while reloading!"), span_danger("Your reload is interrupted!"))
+				if(is_thumbfather_rapier(weapon))
+					var/obj/item/ego_weapon/city/thumbfather_rapier/R = weapon
+					R.busy = FALSE
+				else
+					var/obj/item/ego_weapon/city/thumbfather_katana/K = weapon
+					K.busy = FALSE
+				return
+		// Reload complete
+		addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound), weapon, 'sound/weapons/ego/thumb_east_rifle_reload_end.ogg', 90, FALSE, 10), 0.2 SECONDS)
+	else
+		to_chat(user, span_danger("You abort your reload!"))
+
+	// Clear busy
+	if(is_thumbfather_rapier(weapon))
+		var/obj/item/ego_weapon/city/thumbfather_rapier/R = weapon
+		R.busy = FALSE
+	else
+		var/obj/item/ego_weapon/city/thumbfather_katana/K = weapon
+		K.busy = FALSE
+
+////////////////////////////////////////////////////////////
+// THUMBFATHER RAPIER
+/obj/item/ego_weapon/city/thumbfather_rapier
+	name = "thumbfather rapier"
+	desc = "A slender, elegant rapier favored by a thumbfather. Its reach is deceptively long."
+	icon = 'icons/obj/spider_house/thumb/thumb_weapon_icon.dmi'
+	lefthand_file = 'icons/obj/spider_house/thumb/thumb_weapon_left.dmi'
+	righthand_file = 'icons/obj/spider_house/thumb/thumb_weapon_right.dmi'
+	inhand_x_dimension = 48
+	inhand_y_dimension = 48
+	icon_state = "thumbfather_rapier"
+	inhand_icon_state = "thumbfather_rapier"
+	hitsound = 'sound/weapons/ego/thumb_east_rifle_attack.ogg'
+	base_pixel_x = 8
+	base_pixel_y = 8
+	force = 45
+	damtype = RED_DAMAGE
+	attack_speed = 0.8
+	attack_verb_continuous = list("thrusts", "pierces", "lunges")
+	attack_verb_simple = list("thrust", "pierce", "lunge")
+	attribute_requirements = list(
+							FORTITUDE_ATTRIBUTE = 100,
+							PRUDENCE_ATTRIBUTE = 80,
+							TEMPERANCE_ATTRIBUTE = 80,
+							JUSTICE_ATTRIBUTE = 80
+							)
+	special = "This is a Thumbfather dual-wield weapon. <b>Load it with acceleration propellant ammunition</b> and dual-wield it with its partner to unlock its full potential."
+	/// Detailed combo description shown on examine
+	var/combo_description = "This weapon's combo consists of a <b>long-range lunge</b>, followed by an <b>AoE sweep with the other weapon</b>, and ends with a powerful <b>finisher that detonates Tremor and Overheat</b>.\n"+\
+	"<b>Lunge</b>: Attack a target from range to dash at them (costs 1 round).\n"+\
+	"<b>AoE Sweep</b>: Swap to your other weapon and hit the target (costs 1 round). Deals AoE damage around you.\n"+\
+	"<b>Finisher</b>: Swap back to your starting weapon and hit the target (costs 2 rounds). Tremor Bursts and deals bonus RED damage equal to built-up Tremor + Overheat stacks.\n"+\
+	"Hitting with the wrong weapon at any stage <b>breaks the combo</b>. The combo expires after 5 seconds of inactivity."
+	/// Ammo types this weapon can load
+	var/list/accepted_ammo_table = list(
+		/obj/item/stack/thumb_east_ammo/acceleration,
+	)
+	/// Maximum ammo capacity
+	var/max_ammo = 6
+	/// Loaded rounds
+	var/list/current_ammo = list()
+	/// Type path of currently loaded ammo
+	var/current_ammo_type
+	/// Display name of currently loaded ammo
+	var/current_ammo_name = ""
+	/// Whether this weapon is currently performing a dual-wield follow-up attack
+	var/busy_dual_strike = FALSE
+	/// Tracks hits for dual-wield (triggers on every 2nd hit)
+	var/swing_count = 0
+	/// Current combo stage (synced between both weapons)
+	var/combo_stage = NURSEFATHER_COMBO_NONE
+	/// Whether the combo was started by the rapier (TRUE) or katana (FALSE) (synced between both weapons)
+	var/combo_starter_is_rapier = FALSE
+	/// Timer for combo reset
+	var/combo_reset_timer
+	/// Duration before combo resets from inactivity
+	var/combo_reset_duration = 5 SECONDS
+	/// Whether we can lunge
+	var/lunge_ready = TRUE
+	/// Lunge distance in tiles
+	var/lunge_range = 3
+	/// Cooldown between lunges
+	var/lunge_cooldown_duration = 13 SECONDS
+	/// Timer for lunge cooldown
+	var/lunge_cooldown_timer
+	/// Base radius for AoE sweep
+	var/attack2_aoe_radius = 1
+	/// Are we currently performing a channeled action (reloading)?
+	var/busy = FALSE
+	/// Cooldown for balloon alerts
+	var/balloon_alert_cooldown
+	/// TRUE while the discipline sequence is running on an unauthorized holder
+	var/defense_active = FALSE
+	/// Tracks how many times each unauthorized mob has picked this weapon up, by REF
+	var/list/defense_strikes = list()
+
+	// Sound variables
+	var/lunge_sound = 'sound/weapons/ego/thumb_east_rifle_boostedlunge.ogg'
+	var/sweep_sound = 'sound/weapons/ego/thumb_east_rifle_boostedsweep.ogg'
+	var/finisher_sound = 'sound/weapons/ego/thumb_east_rifle_boostedfinisher.ogg'
+	var/detonation_sound = 'sound/weapons/ego/thumb_east_rifle_detonation.ogg'
+	var/dryfire_sound = 'sound/weapons/gun/general/dry_fire.ogg'
+
+/obj/item/ego_weapon/city/thumbfather_rapier/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/item_scaling, 1, 0.8, -12, -12)
+
+/obj/item/ego_weapon/city/thumbfather_rapier/Destroy(force)
+	for(var/obj/item/stack/thumb_east_ammo/leftover in current_ammo)
+		leftover.forceMove(get_turf(src))
+	current_ammo = null
+	deltimer(combo_reset_timer)
+	deltimer(lunge_cooldown_timer)
+	return ..()
+
+/obj/item/ego_weapon/city/thumbfather_rapier/equipped(mob/user, slot)
+	. = ..()
+	RegisterSignal(user, COMSIG_POISE_CRIT_ATTACKER, PROC_REF(on_poise_crit), override = TRUE)
+	if(slot == ITEM_SLOT_HANDS && !thumbfather_is_authorized(user))
+		INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(thumbfather_discipline_sequence), src, user)
+
+/obj/item/ego_weapon/city/thumbfather_rapier/dropped(mob/user)
+	UnregisterSignal(user, COMSIG_POISE_CRIT_ATTACKER)
+	return ..()
+
+/obj/item/ego_weapon/city/thumbfather_rapier/examine(mob/user)
+	. = ..()
+	. += span_danger("There are [length(current_ammo)]/[max_ammo] rounds of [length(current_ammo) > 0 ? current_ammo_name : "ammunition"] currently loaded.")
+	. += span_info(combo_description)
+	. += span_notice("Every 2nd non-combo hit triggers a <b>dual-wield follow-up</b> from your partner weapon at 25% damage, spending a round from it.")
+	. += span_notice("Spending a round from this rapier grants <b>5 Poise</b> to you and applies <b>4 Overheat</b> to the target. Poise crits also apply +2 Overheat.")
+	. += span_notice("<b>Hit the weapon with ammunition</b> to reload (channeled). <b>Alt-click</b> to unload a round.")
+	if(combo_stage == NURSEFATHER_COMBO_LUNGE)
+		. += span_green("Combo active: lunge landed! [combo_starter_is_rapier ? "Switch to katana" : "Hit with rapier"] for the AoE sweep!")
+	else if(combo_stage == NURSEFATHER_COMBO_ATTACK2)
+		. += span_green("Combo active: AoE sweep ready! [combo_starter_is_rapier != is_thumbfather_rapier(src) ? "Hit with this weapon!" : "Switch to your other weapon!"]")
+	else if(combo_stage == NURSEFATHER_COMBO_FINISHER)
+		. += span_green("Combo active: finisher ready! [combo_starter_is_rapier == is_thumbfather_rapier(src) ? "Hit with this weapon!" : "Switch to your other weapon!"]")
+	. += span_danger("This weapon's AoE is indiscriminate. <b>Watch out for friendly fire</b>.")
+
+/// On Poise crit: boost overheat by 2
+/obj/item/ego_weapon/city/thumbfather_rapier/proc/on_poise_crit(datum/source, mob/living/target, bonus_damage)
+	SIGNAL_HANDLER
+	if(!isliving(target))
+		return
+	target.apply_lc_overheat(2)
+
+/// Called when the lunge cooldown expires
+/obj/item/ego_weapon/city/thumbfather_rapier/proc/ReadyToLunge(mob/user)
+	lunge_ready = TRUE
+	lunge_cooldown_timer = null
+	if(combo_stage == NURSEFATHER_COMBO_NONE)
+		to_chat(user, span_nicegreen("You're ready to lunge and begin a new combo again."))
+		user.balloon_alert(user, "You're ready to lunge again.")
+	else
+		to_chat(user, span_nicegreen("You're ready to lunge again, once your current combo is finished."))
+		user.balloon_alert(user, "You're ready to lunge again.")
+
+/// Lunge opener: dash towards the target from range and auto-attack if we reach them
+/obj/item/ego_weapon/city/thumbfather_rapier/proc/Lunge(mob/living/target, mob/living/user)
+	if(!can_see(user, target, lunge_range))
+		to_chat(user, span_warning("You can't reach your target!"))
+		if(balloon_alert_cooldown < world.time)
+			user.balloon_alert(user, "You can't reach your target!")
+			balloon_alert_cooldown = world.time + 0.4 SECONDS
+		return FALSE
+	if(!lunge_ready)
+		to_chat(user, span_warning("You're not ready to lunge yet!"))
+		if(balloon_alert_cooldown < world.time)
+			user.balloon_alert(user, "You're not ready to lunge yet!")
+			balloon_alert_cooldown = world.time + 0.4 SECONDS
+		return FALSE
+
+	// Set combo stage on both weapons
+	sync_nursefather_combo(src, user, NURSEFATHER_COMBO_LUNGE, TRUE)
+	if(spend_acceleration_round(src, user, target))
+		lunge_ready = FALSE
+		lunge_cooldown_timer = addtimer(CALLBACK(src, PROC_REF(ReadyToLunge), user), lunge_cooldown_duration)
+		shake_camera(user, 1.5, 3)
+		to_chat(user, span_danger("You lunge at [target] using the propulsion from your [src.name]!"))
+		var/turf/takeoff_turf = get_turf(user)
+		new /obj/effect/temp_visual/thumb_east_aoe_impact(takeoff_turf)
+		for(var/i in 2 to get_dist(user, target))
+			step_towards(user, target)
+		if(get_dist(user, target) < 2)
+			hitsound = lunge_sound
+			target.attackby(src, user)
+		else
+			to_chat(user, span_warning("Your lunge falls short of hitting your target!"))
+		start_nursefather_combo_timer(src, user)
+		return TRUE
+	else
+		to_chat(user, span_warning("You pull the trigger to lunge at [target], but you have no ammo left."))
+		playsound(src, dryfire_sound, 65)
+		sync_nursefather_combo(src, user, NURSEFATHER_COMBO_NONE, FALSE)
+		return FALSE
+
+/// Main attack proc with combo handling and weapon-swap enforcement
+/obj/item/ego_weapon/city/thumbfather_rapier/attack(mob/living/target, mob/living/carbon/human/user)
+	if(busy)
+		return
+	var/weapon_is_rapier = TRUE
+	switch(combo_stage)
+		if(NURSEFATHER_COMBO_NONE)
+			. = ..()
+		if(NURSEFATHER_COMBO_LUNGE)
+			// Lunge hit must be with the starting weapon
+			if(weapon_is_rapier != combo_starter_is_rapier)
+				to_chat(user, span_warning("Combo broken! You needed to land the lunge hit with your starting weapon."))
+				reset_nursefather_combo(src, user, FALSE)
+				. = ..()
+			else
+				. = ..()
+				hitsound = initial(hitsound)
+				user.changeNext_move(CLICK_CD_MELEE * attack_speed * 1.1)
+				sync_nursefather_combo(src, user, NURSEFATHER_COMBO_ATTACK2, combo_starter_is_rapier)
+				start_nursefather_combo_timer(src, user)
+				to_chat(user, span_info("Combo: switch to your [combo_starter_is_rapier ? "katana" : "rapier"] and hit!"))
+		if(NURSEFATHER_COMBO_ATTACK2)
+			// AoE sweep must be with the OTHER weapon from the starter
+			if(weapon_is_rapier == combo_starter_is_rapier)
+				to_chat(user, span_warning("Combo broken! You needed to switch weapons."))
+				reset_nursefather_combo(src, user, FALSE)
+				. = ..()
+			else
+				if(spend_acceleration_round(src, user, target))
+					shake_camera(user, 1.5, 3)
+					hitsound = null
+					. = ..()
+					playsound(src, sweep_sound, 90, FALSE, 10)
+					hitsound = initial(hitsound)
+					user.changeNext_move(CLICK_CD_MELEE * attack_speed * 1.3)
+					thumbfather_radius_aoe(src, user, target, attack2_aoe_radius)
+					sync_nursefather_combo(src, user, NURSEFATHER_COMBO_FINISHER, combo_starter_is_rapier)
+					start_nursefather_combo_timer(src, user, 2 SECONDS)
+					to_chat(user, span_info("Combo: switch back to your [combo_starter_is_rapier ? "rapier" : "katana"] for the finisher!"))
+				else
+					reset_nursefather_combo(src, user)
+					playsound(src, dryfire_sound, 65)
+					. = ..()
+		if(NURSEFATHER_COMBO_FINISHER)
+			// Finisher must be with the STARTING weapon
+			if(weapon_is_rapier != combo_starter_is_rapier)
+				to_chat(user, span_warning("Combo broken! You needed to finish with your starting weapon."))
+				reset_nursefather_combo(src, user, FALSE)
+				. = ..()
+			else
+				var/spent1 = spend_acceleration_round(src, user, target)
+				var/spent2 = spend_acceleration_round(src, user, target)
+				if(spent1 || spent2)
+					shake_camera(user, 2, 4)
+					var/original_force = force
+					force = round(force * 1.5)
+					hitsound = null
+					. = ..()
+					playsound(src, finisher_sound, 90, FALSE, 10)
+					hitsound = initial(hitsound)
+					force = original_force
+					user.changeNext_move(CLICK_CD_MELEE * attack_speed * 1.2)
+					thumbfather_finisher(target, user)
+				else
+					playsound(src, dryfire_sound, 65)
+					. = ..()
+				reset_nursefather_combo(src, user, FALSE)
+	// Dual-wield: trigger partner every 2nd hit, spending ammo for poise/concentration/effects
+	// Only triggers on non-combo hits - combo attacks do NOT count towards or trigger dual-wield follow-ups
+	if(!busy_dual_strike && combo_stage == NURSEFATHER_COMBO_NONE)
+		swing_count++
+		if(swing_count >= 2)
+			swing_count = 0
+			var/obj/item/ego_weapon/city/thumbfather_katana/partner = find_thumbfather_partner(src, user)
+			if(partner && !partner.busy_dual_strike && (target in view(partner.reach, user)))
+				INVOKE_ASYNC(src, PROC_REF(DualWieldFollowUp), partner, user, target)
+
+/// Delayed dual-wield follow-up attack with the partner weapon
+/obj/item/ego_weapon/city/thumbfather_rapier/proc/DualWieldFollowUp(obj/item/ego_weapon/city/thumbfather_katana/partner, mob/living/carbon/human/user, mob/living/target)
+	sleep(0.2 SECONDS)
+	if(QDELETED(partner) || QDELETED(user) || QDELETED(target))
+		return
+	if(!(target in view(partner.reach, user)))
+		return
+	spend_acceleration_round(partner, user, target, 50)
+	partner.busy_dual_strike = TRUE
+	var/original_force = partner.force
+	partner.force = round(original_force * 0.25)
+	user.do_attack_animation(target, null, partner)
+	target.attacked_by(partner, user)
+	partner.force = original_force
+	partner.busy_dual_strike = FALSE
+
+/// Lunge from range + reverse reload
+/obj/item/ego_weapon/city/thumbfather_rapier/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+	// Reverse reload: clicking ammo with the weapon
+	if(istype(target, /obj/item/stack/thumb_east_ammo))
+		var/obj/item/stack/thumb_east_ammo/ammo = target
+		INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(thumbfather_reload), src, ammo, user, current_ammo, max_ammo, accepted_ammo_table)
+		return TRUE
+	if(!isliving(target))
+		return TRUE
+	if(busy)
+		return TRUE
+	// Lunge from range
+	if(!proximity_flag && combo_stage == NURSEFATHER_COMBO_NONE)
+		Lunge(target, user)
+		return TRUE
+
+/// Load ammo by hitting the weapon with it
+/obj/item/ego_weapon/city/thumbfather_rapier/attackby(obj/item/stack/thumb_east_ammo/I, mob/living/user, params)
+	if(!istype(I))
+		return ..()
+	if(busy)
+		return
+	if(!(I.type in accepted_ammo_table))
+		to_chat(user, span_warning("The [I.name] are incompatible with the [src.name]."))
+		return
+	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(thumbfather_reload), src, I, user, current_ammo, max_ammo, accepted_ammo_table)
+
+/// Unload a round by alt-clicking
+/obj/item/ego_weapon/city/thumbfather_rapier/AltClick(mob/user)
+	. = ..()
+	if(busy)
+		return
+	if(length(current_ammo))
+		var/obj/item/stack/thumb_east_ammo/round = current_ammo[length(current_ammo)]
+		current_ammo -= round
+		round.forceMove(get_turf(src))
+		to_chat(user, span_info("You unload a round from the [src.name]."))
+		playsound(src, 'sound/weapons/gun/pistol/drop_small.ogg', 90, FALSE)
+		reset_nursefather_combo(src, user)
+		if(!length(current_ammo))
+			current_ammo_type = null
+			current_ammo_name = ""
+	else
+		to_chat(user, span_warning("The [src.name] is empty."))
+
+/// Light cigars with the rapier by spending a round
+/obj/item/ego_weapon/city/thumbfather_rapier/ignition_effect(atom/A, mob/user)
+	. = ""
+	if(spend_acceleration_round(src, user, null))
+		. = span_danger("[user] fires their [src.name], using the exhaust to nonchalantly light [A]. They don't even flinch from the recoil.")
+		playsound(src, 'sound/weapons/ego/thumb_east_rifle_detonation.ogg', 90, FALSE, 10)
+
+////////////////////////////////////////////////////////////
+// THUMBFATHER KATANA
+/obj/item/ego_weapon/city/thumbfather_katana
+	name = "thumbfather katana"
+	desc = "A finely crafted katana carried by a thumbfather. Each swing carries the weight of authority."
+	icon = 'icons/obj/spider_house/thumb/thumb_weapon_icon.dmi'
+	lefthand_file = 'icons/obj/spider_house/thumb/thumb_weapon_left.dmi'
+	righthand_file = 'icons/obj/spider_house/thumb/thumb_weapon_right.dmi'
+	inhand_x_dimension = 48
+	inhand_y_dimension = 48
+	icon_state = "thumbfather_katana"
+	inhand_icon_state = "thumbfather_katana"
+	hitsound = 'sound/weapons/ego/thumb_east_podao_attack.ogg'
+	base_pixel_x = 8
+	base_pixel_y = 8
+	force = 55
+	damtype = RED_DAMAGE
+	attack_speed = 1.1
+	attack_verb_continuous = list("slashes", "cleaves", "cuts")
+	attack_verb_simple = list("slash", "cleave", "cut")
+	attribute_requirements = list(
+							FORTITUDE_ATTRIBUTE = 100,
+							PRUDENCE_ATTRIBUTE = 100,
+							TEMPERANCE_ATTRIBUTE = 80,
+							JUSTICE_ATTRIBUTE = 80
+							)
+	special = "This is a Thumbfather dual-wield weapon. <b>Load it with acceleration propellant ammunition</b> and dual-wield it with its partner to unlock its full potential."
+	/// Detailed combo description shown on examine
+	var/combo_description = "This weapon's combo consists of a <b>long-range lunge</b>, followed by an <b>AoE sweep with the other weapon</b>, and ends with a powerful <b>finisher that detonates Tremor and Overheat</b>.\n"+\
+	"<b>Lunge</b>: Attack a target from range to dash at them (costs 1 round).\n"+\
+	"<b>AoE Sweep</b>: Swap to your other weapon and hit the target (costs 1 round). Deals AoE damage around you.\n"+\
+	"<b>Finisher</b>: Swap back to your starting weapon and hit the target (costs 2 rounds). Tremor Bursts and deals bonus RED damage equal to built-up Tremor + Overheat stacks.\n"+\
+	"Hitting with the wrong weapon at any stage <b>breaks the combo</b>. The combo expires after 5 seconds of inactivity."
+	/// Ammo types this weapon can load
+	var/list/accepted_ammo_table = list(
+		/obj/item/stack/thumb_east_ammo/acceleration,
+	)
+	/// Maximum ammo capacity
+	var/max_ammo = 6
+	/// Loaded rounds
+	var/list/current_ammo = list()
+	/// Type path of currently loaded ammo
+	var/current_ammo_type
+	/// Display name of currently loaded ammo
+	var/current_ammo_name = ""
+	/// Whether this weapon is currently performing a dual-wield follow-up attack
+	var/busy_dual_strike = FALSE
+	/// Tracks hits for dual-wield (triggers on every 2nd hit)
+	var/swing_count = 0
+	/// Current combo stage (synced between both weapons)
+	var/combo_stage = NURSEFATHER_COMBO_NONE
+	/// Whether the combo was started by the rapier (TRUE) or katana (FALSE) (synced between both weapons)
+	var/combo_starter_is_rapier = FALSE
+	/// Timer for combo reset
+	var/combo_reset_timer
+	/// Duration before combo resets from inactivity
+	var/combo_reset_duration = 5 SECONDS
+	/// Whether we can lunge
+	var/lunge_ready = TRUE
+	/// Lunge distance in tiles
+	var/lunge_range = 3
+	/// Cooldown between lunges
+	var/lunge_cooldown_duration = 13 SECONDS
+	/// Timer for lunge cooldown
+	var/lunge_cooldown_timer
+	/// Base radius for AoE sweep
+	var/attack2_aoe_radius = 1
+	/// Are we currently performing a channeled action (reloading)?
+	var/busy = FALSE
+	/// Cooldown for balloon alerts
+	var/balloon_alert_cooldown
+	/// TRUE while the discipline sequence is running on an unauthorized holder
+	var/defense_active = FALSE
+	/// Tracks how many times each unauthorized mob has picked this weapon up, by REF
+	var/list/defense_strikes = list()
+
+	// Sound variables
+	var/lunge_sound = 'sound/weapons/ego/thumb_east_podao_boostedlunge.ogg'
+	var/sweep_sound = 'sound/weapons/ego/thumb_east_podao_boostedsweep.ogg'
+	var/finisher_sound = 'sound/weapons/ego/thumb_east_rifle_boostedfinisher.ogg'
+	var/detonation_sound = 'sound/weapons/ego/thumb_east_podao_detonation.ogg'
+	var/dryfire_sound = 'sound/weapons/gun/general/dry_fire.ogg'
+
+/obj/item/ego_weapon/city/thumbfather_katana/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/item_scaling, 1, 0.8, -12, -12)
+
+/obj/item/ego_weapon/city/thumbfather_katana/Destroy(force)
+	for(var/obj/item/stack/thumb_east_ammo/leftover in current_ammo)
+		leftover.forceMove(get_turf(src))
+	current_ammo = null
+	deltimer(combo_reset_timer)
+	deltimer(lunge_cooldown_timer)
+	return ..()
+
+/obj/item/ego_weapon/city/thumbfather_katana/equipped(mob/user, slot)
+	. = ..()
+	RegisterSignal(user, COMSIG_POISE_CRIT_ATTACKER, PROC_REF(on_poise_crit), override = TRUE)
+	if(slot == ITEM_SLOT_HANDS && !thumbfather_is_authorized(user))
+		INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(thumbfather_discipline_sequence), src, user)
+
+/obj/item/ego_weapon/city/thumbfather_katana/dropped(mob/user)
+	UnregisterSignal(user, COMSIG_POISE_CRIT_ATTACKER)
+	return ..()
+
+/obj/item/ego_weapon/city/thumbfather_katana/examine(mob/user)
+	. = ..()
+	. += span_danger("There are [length(current_ammo)]/[max_ammo] rounds of [length(current_ammo) > 0 ? current_ammo_name : "ammunition"] currently loaded.")
+	. += span_info(combo_description)
+	. += span_notice("Every 2nd non-combo hit triggers a <b>dual-wield follow-up</b> from your partner weapon at 25% damage, spending a round from it.")
+	. += span_notice("Spending a round from this katana grants <b>1 Concentration</b> to you and applies <b>3 Tremor</b> to the target. Poise crits also apply +2 Tremor.")
+	. += span_notice("<b>Hit the weapon with ammunition</b> to reload (channeled). <b>Alt-click</b> to unload a round.")
+	if(combo_stage == NURSEFATHER_COMBO_LUNGE)
+		. += span_green("Combo active: lunge landed! [combo_starter_is_rapier ? "Switch to katana" : "Hit with rapier"] for the AoE sweep!")
+	else if(combo_stage == NURSEFATHER_COMBO_ATTACK2)
+		. += span_green("Combo active: AoE sweep ready! [combo_starter_is_rapier != is_thumbfather_rapier(src) ? "Hit with this weapon!" : "Switch to your other weapon!"]")
+	else if(combo_stage == NURSEFATHER_COMBO_FINISHER)
+		. += span_green("Combo active: finisher ready! [combo_starter_is_rapier == is_thumbfather_rapier(src) ? "Hit with this weapon!" : "Switch to your other weapon!"]")
+	. += span_danger("This weapon's AoE is indiscriminate. <b>Watch out for friendly fire</b>.")
+
+/// On Poise crit: boost tremor by 2
+/obj/item/ego_weapon/city/thumbfather_katana/proc/on_poise_crit(datum/source, mob/living/target, bonus_damage)
+	SIGNAL_HANDLER
+	if(!isliving(target))
+		return
+	target.apply_lc_tremor(2, INFINITY)
+
+/// Called when the lunge cooldown expires
+/obj/item/ego_weapon/city/thumbfather_katana/proc/ReadyToLunge(mob/user)
+	lunge_ready = TRUE
+	lunge_cooldown_timer = null
+	if(combo_stage == NURSEFATHER_COMBO_NONE)
+		to_chat(user, span_nicegreen("You're ready to lunge and begin a new combo again."))
+		user.balloon_alert(user, "You're ready to lunge again.")
+	else
+		to_chat(user, span_nicegreen("You're ready to lunge again, once your current combo is finished."))
+		user.balloon_alert(user, "You're ready to lunge again.")
+
+/// Lunge opener: dash towards the target from range and auto-attack if we reach them
+/obj/item/ego_weapon/city/thumbfather_katana/proc/Lunge(mob/living/target, mob/living/user)
+	if(!can_see(user, target, lunge_range))
+		to_chat(user, span_warning("You can't reach your target!"))
+		if(balloon_alert_cooldown < world.time)
+			user.balloon_alert(user, "You can't reach your target!")
+			balloon_alert_cooldown = world.time + 0.4 SECONDS
+		return FALSE
+	if(!lunge_ready)
+		to_chat(user, span_warning("You're not ready to lunge yet!"))
+		if(balloon_alert_cooldown < world.time)
+			user.balloon_alert(user, "You're not ready to lunge yet!")
+			balloon_alert_cooldown = world.time + 0.4 SECONDS
+		return FALSE
+
+	// Set combo stage on both weapons - katana is the starter
+	sync_nursefather_combo(src, user, NURSEFATHER_COMBO_LUNGE, FALSE)
+	if(spend_acceleration_round(src, user, target))
+		lunge_ready = FALSE
+		lunge_cooldown_timer = addtimer(CALLBACK(src, PROC_REF(ReadyToLunge), user), lunge_cooldown_duration)
+		shake_camera(user, 1.5, 3)
+		to_chat(user, span_danger("You lunge at [target] using the propulsion from your [src.name]!"))
+		var/turf/takeoff_turf = get_turf(user)
+		new /obj/effect/temp_visual/thumb_east_aoe_impact(takeoff_turf)
+		for(var/i in 2 to get_dist(user, target))
+			step_towards(user, target)
+		if(get_dist(user, target) < 2)
+			hitsound = lunge_sound
+			target.attackby(src, user)
+		else
+			to_chat(user, span_warning("Your lunge falls short of hitting your target!"))
+		start_nursefather_combo_timer(src, user)
+		return TRUE
+	else
+		to_chat(user, span_warning("You pull the trigger to lunge at [target], but you have no ammo left."))
+		playsound(src, dryfire_sound, 65)
+		sync_nursefather_combo(src, user, NURSEFATHER_COMBO_NONE, FALSE)
+		return FALSE
+
+/// Main attack proc with combo handling and weapon-swap enforcement
+/obj/item/ego_weapon/city/thumbfather_katana/attack(mob/living/target, mob/living/carbon/human/user)
+	if(busy)
+		return
+	var/weapon_is_rapier = FALSE
+	switch(combo_stage)
+		if(NURSEFATHER_COMBO_NONE)
+			. = ..()
+		if(NURSEFATHER_COMBO_LUNGE)
+			// Lunge hit must be with the starting weapon
+			if(weapon_is_rapier != combo_starter_is_rapier)
+				to_chat(user, span_warning("Combo broken! You needed to land the lunge hit with your starting weapon."))
+				reset_nursefather_combo(src, user, FALSE)
+				. = ..()
+			else
+				. = ..()
+				hitsound = initial(hitsound)
+				user.changeNext_move(CLICK_CD_MELEE * attack_speed * 1.1)
+				sync_nursefather_combo(src, user, NURSEFATHER_COMBO_ATTACK2, combo_starter_is_rapier)
+				start_nursefather_combo_timer(src, user)
+				to_chat(user, span_info("Combo: switch to your [combo_starter_is_rapier ? "katana" : "rapier"] and hit!"))
+		if(NURSEFATHER_COMBO_ATTACK2)
+			// AoE sweep must be with the OTHER weapon from the starter
+			if(weapon_is_rapier == combo_starter_is_rapier)
+				to_chat(user, span_warning("Combo broken! You needed to switch weapons."))
+				reset_nursefather_combo(src, user, FALSE)
+				. = ..()
+			else
+				if(spend_acceleration_round(src, user, target))
+					shake_camera(user, 1.5, 3)
+					hitsound = null
+					. = ..()
+					playsound(src, sweep_sound, 90, FALSE, 10)
+					hitsound = initial(hitsound)
+					user.changeNext_move(CLICK_CD_MELEE * attack_speed * 1.3)
+					thumbfather_radius_aoe(src, user, target, attack2_aoe_radius)
+					sync_nursefather_combo(src, user, NURSEFATHER_COMBO_FINISHER, combo_starter_is_rapier)
+					start_nursefather_combo_timer(src, user, 2 SECONDS)
+					to_chat(user, span_info("Combo: switch back to your [combo_starter_is_rapier ? "rapier" : "katana"] for the finisher!"))
+				else
+					reset_nursefather_combo(src, user)
+					playsound(src, dryfire_sound, 65)
+					. = ..()
+		if(NURSEFATHER_COMBO_FINISHER)
+			// Finisher must be with the STARTING weapon
+			if(weapon_is_rapier != combo_starter_is_rapier)
+				to_chat(user, span_warning("Combo broken! You needed to finish with your starting weapon."))
+				reset_nursefather_combo(src, user, FALSE)
+				. = ..()
+			else
+				var/spent1 = spend_acceleration_round(src, user, target)
+				var/spent2 = spend_acceleration_round(src, user, target)
+				if(spent1 || spent2)
+					shake_camera(user, 2, 4)
+					var/original_force = force
+					force = round(force * 1.5)
+					hitsound = null
+					. = ..()
+					playsound(src, finisher_sound, 90, FALSE, 10)
+					hitsound = initial(hitsound)
+					force = original_force
+					user.changeNext_move(CLICK_CD_MELEE * attack_speed * 1.2)
+					thumbfather_finisher(target, user)
+				else
+					playsound(src, dryfire_sound, 65)
+					. = ..()
+				reset_nursefather_combo(src, user, FALSE)
+	// Dual-wield: trigger partner every 2nd hit, spending ammo for poise/concentration/effects
+	// Only triggers on non-combo hits - combo attacks do NOT count towards or trigger dual-wield follow-ups
+	if(!busy_dual_strike && combo_stage == NURSEFATHER_COMBO_NONE)
+		swing_count++
+		if(swing_count >= 2)
+			swing_count = 0
+			var/obj/item/ego_weapon/city/thumbfather_rapier/partner = find_thumbfather_partner(src, user)
+			if(partner && !partner.busy_dual_strike && (target in view(partner.reach, user)))
+				INVOKE_ASYNC(src, PROC_REF(DualWieldFollowUp), partner, user, target)
+
+/// Delayed dual-wield follow-up attack with the partner weapon
+/obj/item/ego_weapon/city/thumbfather_katana/proc/DualWieldFollowUp(obj/item/ego_weapon/city/thumbfather_rapier/partner, mob/living/carbon/human/user, mob/living/target)
+	sleep(0.2 SECONDS)
+	if(QDELETED(partner) || QDELETED(user) || QDELETED(target))
+		return
+	if(!(target in view(partner.reach, user)))
+		return
+	spend_acceleration_round(partner, user, target, 50)
+	partner.busy_dual_strike = TRUE
+	var/original_force = partner.force
+	partner.force = round(original_force * 0.25)
+	user.do_attack_animation(target, null, partner)
+	target.attacked_by(partner, user)
+	partner.force = original_force
+	partner.busy_dual_strike = FALSE
+
+/// Lunge from range + reverse reload
+/obj/item/ego_weapon/city/thumbfather_katana/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+	// Reverse reload: clicking ammo with the weapon
+	if(istype(target, /obj/item/stack/thumb_east_ammo))
+		var/obj/item/stack/thumb_east_ammo/ammo = target
+		INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(thumbfather_reload), src, ammo, user, current_ammo, max_ammo, accepted_ammo_table)
+		return TRUE
+	if(!isliving(target))
+		return TRUE
+	if(busy)
+		return TRUE
+	// Lunge from range
+	if(!proximity_flag && combo_stage == NURSEFATHER_COMBO_NONE)
+		Lunge(target, user)
+		return TRUE
+
+/// Load ammo by hitting the weapon with it
+/obj/item/ego_weapon/city/thumbfather_katana/attackby(obj/item/stack/thumb_east_ammo/I, mob/living/user, params)
+	if(!istype(I))
+		return ..()
+	if(busy)
+		return
+	if(!(I.type in accepted_ammo_table))
+		to_chat(user, span_warning("The [I.name] are incompatible with the [src.name]."))
+		return
+	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(thumbfather_reload), src, I, user, current_ammo, max_ammo, accepted_ammo_table)
+
+/// Unload a round by alt-clicking
+/obj/item/ego_weapon/city/thumbfather_katana/AltClick(mob/user)
+	. = ..()
+	if(busy)
+		return
+	if(length(current_ammo))
+		var/obj/item/stack/thumb_east_ammo/round = current_ammo[length(current_ammo)]
+		current_ammo -= round
+		round.forceMove(get_turf(src))
+		to_chat(user, span_info("You unload a round from the [src.name]."))
+		playsound(src, 'sound/weapons/gun/pistol/drop_small.ogg', 90, FALSE)
+		reset_nursefather_combo(src, user)
+		if(!length(current_ammo))
+			current_ammo_type = null
+			current_ammo_name = ""
+	else
+		to_chat(user, span_warning("The [src.name] is empty."))
+
+/// Light cigars with the katana by spending a round
+/obj/item/ego_weapon/city/thumbfather_katana/ignition_effect(atom/A, mob/user)
+	. = ""
+	if(spend_acceleration_round(src, user, null))
+		. = span_danger("[user] fires their [src.name], using the exhaust to nonchalantly light [A]. They don't even flinch from the recoil.")
+		playsound(src, 'sound/weapons/ego/thumb_east_rifle_detonation.ogg', 90, FALSE, 10)
+
+////////////////////////////////////////////////////////////
+// THUMBAPPRENTICE WEAPONS
+// Both weapons have 4 evolution tiers. Attack speed is fixed; only force changes.
+// Katana: attack_speed = 1.0 | Greatsword: attack_speed = 1.5
+// DPS targets per tier: 22, 32, 44, 65
+
+/// Helper proc to find the partner apprentice weapon in the user's other hand
+/proc/find_apprentice_partner(obj/item/ego_weapon/city/source, mob/living/carbon/human/user)
+	if(!istype(user))
+		return null
+	for(var/obj/item/ego_weapon/city/W in user.held_items)
+		if(W == source)
+			continue
+		if(istype(W, /obj/item/ego_weapon/city/thumbapprentice_katana) || istype(W, /obj/item/ego_weapon/city/thumbapprentice_greatsword))
+			return W
+	return null
+
+/obj/item/ego_weapon/city/thumbapprentice_katana
+	name = "thumb apprentice katana"
+	desc = "A standard-issue katana given to apprentices of the Thumb. Simple but effective."
+	icon = 'icons/obj/spider_house/thumb/thumb_weapon_icon.dmi'
+	lefthand_file = 'icons/obj/spider_house/thumb/thumb_weapon_left.dmi'
+	righthand_file = 'icons/obj/spider_house/thumb/thumb_weapon_right.dmi'
+	inhand_x_dimension = 48
+	inhand_y_dimension = 48
+	icon_state = "thumbapprentice_katana"
+	inhand_icon_state = "thumbapprentice_katana"
+	base_pixel_x = 8
+	base_pixel_y = 8
+	force = 22
+	damtype = RED_DAMAGE
+	attack_speed = 1
+	attack_verb_continuous = list("slashes", "cuts", "strikes")
+	attack_verb_simple = list("slash", "cut", "strike")
+	attribute_requirements = list(
+							FORTITUDE_ATTRIBUTE = 40,
+							PRUDENCE_ATTRIBUTE = 40,
+							TEMPERANCE_ATTRIBUTE = 40,
+							JUSTICE_ATTRIBUTE = 40
+							)
+	/// Current evolution tier (1-4)
+	var/tier = 1
+	/// Dual-wield: 0 = disabled, 1 = every hit, 2 = every 2nd hit
+	var/swing_threshold = 0
+	/// Tracks hits for dual-wield trigger
+	var/swing_count = 0
+	/// Whether this weapon is currently performing a dual-wield follow-up
+	var/busy_dual_strike = FALSE
+
+/obj/item/ego_weapon/city/thumbapprentice_katana/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/item_scaling, 1, 0.8, -12, -12)
+
+/obj/item/ego_weapon/city/thumbapprentice_katana/attack(mob/living/target, mob/living/carbon/human/user)
+	. = ..()
+	// Dual-wield follow-up
+	if(busy_dual_strike || !swing_threshold)
+		return
+	swing_count++
+	if(swing_count >= swing_threshold)
+		swing_count = 0
+		var/obj/item/ego_weapon/city/partner = find_apprentice_partner(src, user)
+		if(partner)
+			var/obj/item/ego_weapon/city/thumbapprentice_greatsword/gs = partner
+			if(istype(gs) && !gs.busy_dual_strike && (target in view(partner.reach, user)))
+				gs.busy_dual_strike = TRUE
+				var/original_force = gs.force
+				gs.force = round(original_force * 0.25)
+				playsound(gs.loc, gs.hitsound, 50, FALSE)
+				user.do_attack_animation(target, null, gs)
+				target.attacked_by(gs, user)
+				gs.force = original_force
+				gs.busy_dual_strike = FALSE
+				// Inflict 1 Duel Escalates on the follow-up hit
+				target.apply_duel_escalates(1, user)
+
+/// Sets the katana to a specific evolution tier. Updates force, requirements, and dual-wield threshold.
+/obj/item/ego_weapon/city/thumbapprentice_katana/proc/set_tier(new_tier)
+	tier = clamp(new_tier, 1, 4)
+	switch(tier)
+		if(1)
+			force = 22
+			desc = "A standard-issue katana given to apprentices of the Thumb. Simple but effective."
+			attribute_requirements = list(FORTITUDE_ATTRIBUTE = 40, PRUDENCE_ATTRIBUTE = 40, TEMPERANCE_ATTRIBUTE = 40, JUSTICE_ATTRIBUTE = 40)
+			swing_threshold = 0
+		if(2)
+			force = 32
+			desc = "A katana that has been honed through combat. Its edge grows sharper."
+			attribute_requirements = list(FORTITUDE_ATTRIBUTE = 60, PRUDENCE_ATTRIBUTE = 60, TEMPERANCE_ATTRIBUTE = 60, JUSTICE_ATTRIBUTE = 60)
+			swing_threshold = 2
+		if(3)
+			force = 44
+			desc = "A battle-tested katana. Its blade carries the weight of experience."
+			attribute_requirements = list(FORTITUDE_ATTRIBUTE = 80, PRUDENCE_ATTRIBUTE = 80, TEMPERANCE_ATTRIBUTE = 80, JUSTICE_ATTRIBUTE = 80)
+			swing_threshold = 2
+		if(4)
+			force = 65
+			desc = "A katana that has reached its full potential. A weapon worthy of the Thumb."
+			attribute_requirements = list(FORTITUDE_ATTRIBUTE = 100, PRUDENCE_ATTRIBUTE = 100, TEMPERANCE_ATTRIBUTE = 100, JUSTICE_ATTRIBUTE = 100)
+			swing_threshold = 1
+
+/obj/item/ego_weapon/city/thumbapprentice_greatsword
+	name = "thumb apprentice greatsword"
+	desc = "A heavy greatsword entrusted to apprentices of the Thumb. What it lacks in speed, it makes up for in raw power."
+	icon = 'icons/obj/spider_house/thumb/thumb_weapon_icon.dmi'
+	lefthand_file = 'icons/obj/spider_house/thumb/thumb_weapon_left.dmi'
+	righthand_file = 'icons/obj/spider_house/thumb/thumb_weapon_right.dmi'
+	inhand_x_dimension = 48
+	inhand_y_dimension = 48
+	icon_state = "thumbapprentice_greatsword"
+	inhand_icon_state = "thumbapprentice_greatsword"
+	base_pixel_x = 8
+	base_pixel_y = 8
+	force = 33
+	damtype = RED_DAMAGE
+	attack_speed = 1.5
+	attack_verb_continuous = list("cleaves", "smashes", "crushes")
+	attack_verb_simple = list("cleave", "smash", "crush")
+	attribute_requirements = list(
+							FORTITUDE_ATTRIBUTE = 40,
+							PRUDENCE_ATTRIBUTE = 40,
+							TEMPERANCE_ATTRIBUTE = 40,
+							JUSTICE_ATTRIBUTE = 40
+							)
+	/// Current evolution tier (1-4)
+	var/tier = 1
+	/// Dual-wield: 0 = disabled, 1 = every hit, 2 = every 2nd hit
+	var/swing_threshold = 0
+	/// Tracks hits for dual-wield trigger
+	var/swing_count = 0
+	/// Whether this weapon is currently performing a dual-wield follow-up
+	var/busy_dual_strike = FALSE
+
+/obj/item/ego_weapon/city/thumbapprentice_greatsword/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/item_scaling, 1, 0.8, -12, -12)
+
+/obj/item/ego_weapon/city/thumbapprentice_greatsword/attack(mob/living/target, mob/living/carbon/human/user)
+	. = ..()
+	// Dual-wield follow-up
+	if(busy_dual_strike || !swing_threshold)
+		return
+	swing_count++
+	if(swing_count >= swing_threshold)
+		swing_count = 0
+		var/obj/item/ego_weapon/city/partner = find_apprentice_partner(src, user)
+		if(partner)
+			var/obj/item/ego_weapon/city/thumbapprentice_katana/kat = partner
+			if(istype(kat) && !kat.busy_dual_strike && (target in view(partner.reach, user)))
+				kat.busy_dual_strike = TRUE
+				var/original_force = kat.force
+				kat.force = round(original_force * 0.25)
+				playsound(kat.loc, kat.hitsound, 50, FALSE)
+				user.do_attack_animation(target, null, kat)
+				target.attacked_by(kat, user)
+				kat.force = original_force
+				kat.busy_dual_strike = FALSE
+				// Inflict 1 Duel Escalates on the follow-up hit
+				target.apply_duel_escalates(1, user)
+
+/// Sets the greatsword to a specific evolution tier. Updates force, requirements, and dual-wield threshold.
+/obj/item/ego_weapon/city/thumbapprentice_greatsword/proc/set_tier(new_tier)
+	tier = clamp(new_tier, 1, 4)
+	switch(tier)
+		if(1)
+			force = 33
+			desc = "A heavy greatsword entrusted to apprentices of the Thumb. What it lacks in speed, it makes up for in raw power."
+			attribute_requirements = list(FORTITUDE_ATTRIBUTE = 40, PRUDENCE_ATTRIBUTE = 40, TEMPERANCE_ATTRIBUTE = 40, JUSTICE_ATTRIBUTE = 40)
+			swing_threshold = 0
+		if(2)
+			force = 48
+			desc = "A greatsword that has been tempered through combat. Its weight feels more natural."
+			attribute_requirements = list(FORTITUDE_ATTRIBUTE = 60, PRUDENCE_ATTRIBUTE = 60, TEMPERANCE_ATTRIBUTE = 60, JUSTICE_ATTRIBUTE = 60)
+			swing_threshold = 2
+		if(3)
+			force = 66
+			desc = "A battle-tested greatsword. Each swing carries devastating force."
+			attribute_requirements = list(FORTITUDE_ATTRIBUTE = 80, PRUDENCE_ATTRIBUTE = 80, TEMPERANCE_ATTRIBUTE = 80, JUSTICE_ATTRIBUTE = 80)
+			swing_threshold = 2
+		if(4)
+			force = 98
+			desc = "A greatsword that has reached its full potential. A weapon worthy of the Thumb."
+			attribute_requirements = list(FORTITUDE_ATTRIBUTE = 100, PRUDENCE_ATTRIBUTE = 100, TEMPERANCE_ATTRIBUTE = 100, JUSTICE_ATTRIBUTE = 100)
+			swing_threshold = 1
+
+////////////////////////////////////////////////////////////
+// ACCELERATION ROUNDS - Unique ammo for thumbfather weapons
+/obj/item/stack/thumb_east_ammo/acceleration
+	name = "acceleration propellant ammunition"
+	desc = "Specialized propellant ammunition designed for dual-wielded thumbfather weapons. These rounds accelerate the wielder's reflexes, granting heightened focus and poise.\n\
+	When loaded into a thumbfather rapier, spending a round grants Poise. When loaded into a thumbfather katana, spending a round grants Concentration.\n\
+	Loading one thumbfather weapon will also load a round into the partner weapon in your other hand."
+	singular_name = "acceleration propellant round"
+	max_amount = 12
+	merge_type = /obj/item/stack/thumb_east_ammo/acceleration
+	icon_state = "thumb_east_acceleration"
+	w_class = WEIGHT_CLASS_SMALL
+	slot_flags = ITEM_SLOT_POCKETS
+	spent_type = /obj/item/stack/thumb_east_ammo/spent/acceleration
+	tremor_base = 0
+	burn_base = 0
+	flat_force_base = 6
+	heat_generation = 1
+	/// Poise stacks granted to the user when spent by a rapier
+	var/poise_base = 5
+	/// Concentration stacks granted to the user when spent by a katana
+	var/concentration_base = 1
+
+/obj/item/stack/thumb_east_ammo/acceleration/examine(mob/user)
+	. = ..()
+	. += span_notice("Grants [poise_base] Poise when spent by a thumbfather rapier.")
+	. += span_notice("Grants [concentration_base] Concentration when spent by a thumbfather katana.")
+	. += span_notice("Loading one thumbfather weapon will also load a round into the partner weapon.")
+
+/obj/item/stack/thumb_east_ammo/spent/acceleration
+	name = "spent acceleration propellant casings"
+	desc = "A spent cartridge of acceleration propellant ammunition. The residual energy has been fully expended."
+	singular_name = "spent acceleration propellant casing"
+	icon_state = "thumb_east_acceleration_spent"
+	max_amount = 12
+	merge_type = /obj/item/stack/thumb_east_ammo/spent/acceleration
+
+#undef NURSEFATHER_COMBO_NONE
+#undef NURSEFATHER_COMBO_LUNGE
+#undef NURSEFATHER_COMBO_ATTACK2
+#undef NURSEFATHER_COMBO_FINISHER

--- a/ModularLobotomy/lc13_effects.dm
+++ b/ModularLobotomy/lc13_effects.dm
@@ -363,3 +363,108 @@
 /obj/effect/bloodspawner/nogibs/silent
 	sound_to_play = null
 	sound_vol = 0
+
+// Middle Nursefather combat effects — 48x48 (directional, centered on user for wide attacks)
+/obj/effect/temp_visual/dir_setting/middle_basic_slash
+	name = "middle slash"
+	icon = 'icons/effects/BDragon1727_effects/48x48.dmi'
+	icon_state = "middle_basic_slash"
+	pixel_x = -8
+	pixel_y = -8
+	duration = 5
+	layer = ABOVE_MOB_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+/obj/effect/temp_visual/dir_setting/laevateinn_basic_slash
+	name = "laevateinn slash"
+	icon = 'icons/effects/BDragon1727_effects/48x48.dmi'
+	icon_state = "laevateinn_basic_slash"
+	pixel_x = -8
+	pixel_y = -8
+	duration = 5
+	layer = ABOVE_MOB_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+// Middle Nursefather combat effects — 64x64
+/// Ground slam AoE — non-directional purple particle burst, centered on impact
+/obj/effect/temp_visual/middle_slam
+	name = "middle slam"
+	icon = 'icons/effects/BDragon1727_effects/64x64.dmi'
+	icon_state = "middle_slam"
+	pixel_x = -16
+	pixel_y = -16
+	duration = 4.5
+	layer = ABOVE_MOB_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+/// Smoke trail on tiles crossed during dash — directional, faces dash direction
+/obj/effect/temp_visual/dir_setting/smoke_dash
+	name = "smoke dash"
+	icon = 'icons/effects/BDragon1727_effects/64x64.dmi'
+	icon_state = "smoke_dash"
+	pixel_x = -16
+	pixel_y = -16
+	duration = 8
+	layer = ABOVE_MOB_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+/// Smoke cloud at dash origin — directional, faces dash direction
+/obj/effect/temp_visual/dir_setting/smoke_afterdash
+	name = "smoke afterdash"
+	icon = 'icons/effects/BDragon1727_effects/64x64.dmi'
+	icon_state = "smoke_afterdash"
+	pixel_x = -16
+	pixel_y = -16
+	duration = 7.5
+	layer = ABOVE_MOB_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+/// Small purple directional pierce/stab line — for precise stabs
+/obj/effect/temp_visual/dir_setting/middle_slash
+	name = "middle slash"
+	icon = 'icons/effects/BDragon1727_effects/64x64.dmi'
+	icon_state = "middle_slash"
+	pixel_x = -16
+	pixel_y = -16
+	duration = 4
+	layer = ABOVE_MOB_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+/// Small orange/red directional pierce/stab line — for Laevateinn stabs
+/obj/effect/temp_visual/dir_setting/laevateinn_stab
+	name = "laevateinn stab"
+	icon = 'icons/effects/BDragon1727_effects/64x64.dmi'
+	icon_state = "laevateinn_stab"
+	pixel_x = -16
+	pixel_y = -16
+	duration = 4
+	layer = ABOVE_MOB_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+/// Purple energy burst — used when punching/inflicting Weakened. Picks a random dir for visual variety.
+/obj/effect/temp_visual/dir_setting/middle_blast
+	name = "middle blast"
+	icon = 'icons/effects/BDragon1727_effects/64x64.dmi'
+	icon_state = "middle_blast"
+	pixel_x = -16
+	pixel_y = -16
+	duration = 4
+	layer = ABOVE_MOB_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+/obj/effect/temp_visual/dir_setting/middle_blast/Initialize(mapload, set_dir)
+	return ..(mapload, pick(GLOB.cardinals))
+
+/// Orange/red energy burst — used when grabbing a target. Picks a random dir for visual variety.
+/obj/effect/temp_visual/dir_setting/laevateinn_blast
+	name = "laevateinn blast"
+	icon = 'icons/effects/BDragon1727_effects/64x64.dmi'
+	icon_state = "laevateinn_blast"
+	pixel_x = -16
+	pixel_y = -16
+	duration = 4
+	layer = ABOVE_MOB_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+/obj/effect/temp_visual/dir_setting/laevateinn_blast/Initialize(mapload, set_dir)
+	return ..(mapload, pick(GLOB.cardinals))

--- a/ModularLobotomy/refinery/boxes.dm
+++ b/ModularLobotomy/refinery/boxes.dm
@@ -174,3 +174,20 @@
 /obj/item/storage/box/thumb_east_ammo/tigermark/PopulateContents()
 	for(var/i = 1 to 6)
 		new /obj/item/stack/thumb_east_ammo/tigermark(src)
+
+// Storage datum for acceleration propellant ammo boxes
+/datum/component/storage/concrete/thumb_east_acceleration
+	can_hold = list(/obj/item/stack/thumb_east_ammo/acceleration = TRUE)
+	exception_hold = list(/obj/item/stack/thumb_east_ammo/acceleration = TRUE)
+
+/// Acceleration propellant ammo box for Thumbfather weapons. 12x Acceleration Rounds.
+/obj/item/storage/box/thumb_east_ammo/acceleration
+	name = "acceleration propellant ammo box (x12)"
+	desc = "A compact box containing twelve acceleration propellant rounds designed for Thumbfather dual-wield weapons. When spent, these rounds grant Poise from a rapier or Concentration from a katana."
+	icon_state = "thumb_east_box_acceleration"
+	w_class = WEIGHT_CLASS_BULKY
+	component_type = /datum/component/storage/concrete/thumb_east_acceleration
+
+/obj/item/storage/box/thumb_east_ammo/acceleration/PopulateContents()
+	for(var/i = 1 to 12)
+		new /obj/item/stack/thumb_east_ammo/acceleration(src)

--- a/ModularLobotomy/thumb_spider/palermitan_base.dm
+++ b/ModularLobotomy/thumb_spider/palermitan_base.dm
@@ -17,7 +17,7 @@
 	var/last_drink_exp_time = 0
 	/// world.time of last glass bottle EXP grant (30 sec cooldown)
 	var/last_glass_exp_time = 0
-	/// Tremor burst threshold — INFINITY by default (no bursting). Set by Terremoto T2 skills.
+	/// Tremor burst threshold - INFINITY by default (no bursting). Set by Terremoto T2 skills.
 	var/tremor_burst_threshold = INFINITY
 	/// world.time of last food offering EXP grant (2 min cooldown)
 	var/last_food_exp_time = 0
@@ -31,6 +31,17 @@
 		return COMPONENT_INCOMPATIBLE
 	if(_nursefather)
 		nursefather_ref = _nursefather
+		RegisterSignal(nursefather_ref, COMSIG_PARENT_QDELETING, PROC_REF(on_nursefather_deleted))
+
+/datum/component/palermitan_apprentice/Destroy()
+	if(nursefather_ref)
+		UnregisterSignal(nursefather_ref, COMSIG_PARENT_QDELETING)
+		nursefather_ref = null
+	return ..()
+
+/datum/component/palermitan_apprentice/proc/on_nursefather_deleted(datum/source)
+	SIGNAL_HANDLER
+	nursefather_ref = null
 
 /datum/component/palermitan_apprentice/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_MOB_ITEM_ATTACK, PROC_REF(on_attack))
@@ -48,10 +59,9 @@
 		COMSIG_MOB_EMOTE,
 	))
 
-////////////////////////////////////////////////////////////
 // DUELLO + PALERMITAN STYLE (base passives)
 
-/// Core attack handler — applies Duello and Palermitan Style passives + food offering check
+/// Core attack handler - applies Duello and Palermitan Style passives + food offering check
 /datum/component/palermitan_apprentice/proc/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
 	SIGNAL_HANDLER
 	if(!isliving(target) || target == user)
@@ -94,7 +104,6 @@
 	if(!QDELETED(weapon))
 		weapon.force -= bonus
 
-////////////////////////////////////////////////////////////
 // EXP FROM EMOTES AND TRAINING
 
 /// Showing Respect: Bow emote near higher-ranked players grants EXP
@@ -134,7 +143,6 @@
 			to_chat(apprentice, span_notice("You show respect to your betters. (+3 EXP)"))
 			return
 
-////////////////////////////////////////////////////////////
 // NURSEFATHER INTERACTIONS
 
 /// Helper to check if a mob is the nursefather
@@ -146,7 +154,7 @@
 		return TRUE
 	return FALSE
 
-/// Thrown item impact — check for glass bottle from nursefather
+/// Thrown item impact - check for glass bottle from nursefather
 /datum/component/palermitan_apprentice/proc/on_hitby(datum/source, atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
 	SIGNAL_HANDLER
 	if(!istype(AM, /obj/item/reagent_containers/food/drinks))
@@ -167,7 +175,7 @@
 		exp_comp.modify_exp(3)
 	to_chat(apprentice, span_notice("The glass shattering against you sharpens your resolve. (+3 EXP)"))
 
-/// Melee attack on the apprentice — check for nursefather unarmed correction OR glass bottle hit
+/// Melee attack on the apprentice - check for nursefather unarmed correction OR glass bottle hit
 /datum/component/palermitan_apprentice/proc/on_attackby(datum/source, obj/item/W, mob/living/user, params)
 	SIGNAL_HANDLER
 	// Check for glass bottle melee hit from nursefather
@@ -181,7 +189,7 @@
 				if(exp_comp)
 					exp_comp.modify_exp(3)
 				to_chat(apprentice, span_notice("The bottle impact sharpens your resolve. (+3 EXP)"))
-	// Daily Training: nursefather hits apprentice with a weapon — grants EXP
+	// Daily Training: nursefather hits apprentice with a weapon - grants EXP
 	if(W && is_nursefather(user))
 		if(world.time >= last_training_exp_time + 3 MINUTES)
 			last_training_exp_time = world.time
@@ -191,7 +199,7 @@
 				exp_comp.modify_exp(2)
 			to_chat(apprentice, span_notice("Your mentor's training strike sharpens your resolve. (+2 EXP)"))
 
-/// Unarmed attack on the apprentice — nursefather harm-intent hand triggers correction.
+/// Unarmed attack on the apprentice - nursefather harm-intent hand triggers correction.
 /// COMSIG_PARENT_ATTACKBY only fires for item attacks, so unarmed punches need this signal instead.
 /datum/component/palermitan_apprentice/proc/on_attack_hand(datum/source, mob/living/user)
 	SIGNAL_HANDLER
@@ -219,7 +227,6 @@
 	to_chat(apprentice, span_notice("Offering a drink to your mentor strengthens your bond. (+5 EXP)"))
 	return TRUE
 
-////////////////////////////////////////////////////////////
 // POST-DUEL CORRECTION
 
 /// Performs the nursefather correction animation and grants rewards

--- a/ModularLobotomy/thumb_spider/palermitan_base.dm
+++ b/ModularLobotomy/thumb_spider/palermitan_base.dm
@@ -1,1 +1,386 @@
-// Stub - populated by the Thumb sub-PR
+/// Palermitan Apprentice Base Component
+/// Grants the "Duello" and "Palermitan Style" base passives.
+/// Also handles nursefather interactions (drinks, glass bottles, post-duel correction).
+/// Attached to the apprentice mob on recruitment.
+/datum/component/palermitan_apprentice
+	/// Reference to the nursefather mentor
+	var/mob/living/nursefather_ref
+	/// How many times the nursefather has corrected the apprentice after a duel loss
+	var/correction_count = 0
+	/// Whether the apprentice is currently eligible for a post-duel correction
+	var/correction_eligible = FALSE
+	/// world.time deadline for correction eligibility
+	var/correction_deadline = 0
+	/// Attribute gain that would be granted by a correction (0.25x of the lost duel's win value)
+	var/potential_correction_attrs = 0
+	/// world.time of last drink EXP grant (2 min cooldown)
+	var/last_drink_exp_time = 0
+	/// world.time of last glass bottle EXP grant (30 sec cooldown)
+	var/last_glass_exp_time = 0
+	/// Tremor burst threshold — INFINITY by default (no bursting). Set by Terremoto T2 skills.
+	var/tremor_burst_threshold = INFINITY
+	/// world.time of last food offering EXP grant (2 min cooldown)
+	var/last_food_exp_time = 0
+	/// world.time of last bow emote EXP grant (2 min cooldown)
+	var/last_bow_exp_time = 0
+	/// world.time of last daily training EXP grant (3 min cooldown)
+	var/last_training_exp_time = 0
+
+/datum/component/palermitan_apprentice/Initialize(mob/living/_nursefather)
+	if(!ishuman(parent))
+		return COMPONENT_INCOMPATIBLE
+	if(_nursefather)
+		nursefather_ref = _nursefather
+
+/datum/component/palermitan_apprentice/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_MOB_ITEM_ATTACK, PROC_REF(on_attack))
+	RegisterSignal(parent, COMSIG_ATOM_HITBY, PROC_REF(on_hitby))
+	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, PROC_REF(on_attackby))
+	RegisterSignal(parent, COMSIG_ATOM_ATTACK_HAND, PROC_REF(on_attack_hand))
+	RegisterSignal(parent, COMSIG_MOB_EMOTE, PROC_REF(on_emote))
+
+/datum/component/palermitan_apprentice/UnregisterFromParent()
+	UnregisterSignal(parent, list(
+		COMSIG_MOB_ITEM_ATTACK,
+		COMSIG_ATOM_HITBY,
+		COMSIG_PARENT_ATTACKBY,
+		COMSIG_ATOM_ATTACK_HAND,
+		COMSIG_MOB_EMOTE,
+	))
+
+////////////////////////////////////////////////////////////
+// DUELLO + PALERMITAN STYLE (base passives)
+
+/// Core attack handler — applies Duello and Palermitan Style passives + food offering check
+/datum/component/palermitan_apprentice/proc/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	SIGNAL_HANDLER
+	if(!isliving(target) || target == user)
+		return
+
+	// === SHARING A MEAL: Offering food to nursefather grants EXP ===
+	if(weapon && is_nursefather(target) && istype(weapon, /obj/item/reagent_containers/food))
+		if(world.time >= last_food_exp_time + 2 MINUTES)
+			last_food_exp_time = world.time
+			var/datum/component/palermitan_exp/exp_comp = user.GetComponent(/datum/component/palermitan_exp)
+			if(exp_comp)
+				exp_comp.modify_exp(3)
+			to_chat(user, span_notice("You offer a meal to your mentor. (+3 EXP)"))
+
+	// === DUELLO: Inflict 1 Duel Escalates on target ===
+	target.apply_duel_escalates(1, user)
+
+	// === DUELLO: Heal sanity if target has Duel Escalates ===
+	var/datum/status_effect/stacking/duel_escalates/D = target.has_status_effect(/datum/status_effect/stacking/duel_escalates)
+	if(D && D.stacks > 0 && ishuman(user))
+		var/sanity_heal = min(D.stacks * 3, 15)
+		var/mob/living/carbon/human/H = user
+		H.adjustSanityLoss(-sanity_heal)
+
+	// === PALERMITAN STYLE: Bonus damage based on Duel Escalates stacks ===
+	if(D && D.stacks > 0 && weapon)
+		var/stacks = D.stacks
+		var/percent_bonus = stacks * 0.02
+		var/force_bonus = round(weapon.force * percent_bonus)
+		if(stacks >= 10)
+			force_bonus += 10
+		else if(stacks >= 5)
+			force_bonus += 5
+		if(force_bonus > 0)
+			weapon.force += force_bonus
+			INVOKE_ASYNC(src, PROC_REF(restore_force), weapon, force_bonus)
+
+/// Restores the temporary force bonus after a brief delay
+/datum/component/palermitan_apprentice/proc/restore_force(obj/item/weapon, bonus)
+	if(!QDELETED(weapon))
+		weapon.force -= bonus
+
+////////////////////////////////////////////////////////////
+// EXP FROM EMOTES AND TRAINING
+
+/// Showing Respect: Bow emote near higher-ranked players grants EXP
+/datum/component/palermitan_apprentice/proc/on_emote(datum/source, emote_key)
+	SIGNAL_HANDLER
+	if(emote_key != "bow" && emote_key != "salute")
+		return
+	if(world.time < last_bow_exp_time + 2 MINUTES)
+		return
+	var/mob/living/carbon/human/apprentice = parent
+	if(!istype(apprentice))
+		return
+	// Check for nearby players with higher average attributes
+	for(var/mob/living/carbon/human/H in view(3, get_turf(apprentice)))
+		if(H == apprentice)
+			continue
+		if(!H.client)
+			continue
+		// Check if they have higher avg attributes or are the nursefather
+		var/target_higher = is_nursefather(H)
+		if(!target_higher)
+			var/app_avg = 0
+			var/target_avg = 0
+			for(var/attr_name in list(FORTITUDE_ATTRIBUTE, PRUDENCE_ATTRIBUTE, TEMPERANCE_ATTRIBUTE, JUSTICE_ATTRIBUTE))
+				var/datum/attribute/A1 = apprentice.attributes[attr_name]
+				var/datum/attribute/A2 = H.attributes[attr_name]
+				if(A1)
+					app_avg += A1.level
+				if(A2)
+					target_avg += A2.level
+			target_higher = (target_avg > app_avg)
+		if(target_higher)
+			last_bow_exp_time = world.time
+			var/datum/component/palermitan_exp/exp_comp = apprentice.GetComponent(/datum/component/palermitan_exp)
+			if(exp_comp)
+				exp_comp.modify_exp(3)
+			to_chat(apprentice, span_notice("You show respect to your betters. (+3 EXP)"))
+			return
+
+////////////////////////////////////////////////////////////
+// NURSEFATHER INTERACTIONS
+
+/// Helper to check if a mob is the nursefather
+/datum/component/palermitan_apprentice/proc/is_nursefather(mob/living/M)
+	if(nursefather_ref && M == nursefather_ref)
+		return TRUE
+	// Fallback: check assigned role
+	if(M?.mind?.assigned_role == "Ex Thumb Sottocapo")
+		return TRUE
+	return FALSE
+
+/// Thrown item impact — check for glass bottle from nursefather
+/datum/component/palermitan_apprentice/proc/on_hitby(datum/source, atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
+	SIGNAL_HANDLER
+	if(!istype(AM, /obj/item/reagent_containers/food/drinks))
+		return
+	var/obj/item/reagent_containers/food/drinks/D = AM
+	if(!D.isGlass)
+		return
+	if(!throwingdatum?.thrower || !is_nursefather(throwingdatum.thrower))
+		return
+	// Cooldown check
+	if(world.time < last_glass_exp_time + 30 SECONDS)
+		return
+	last_glass_exp_time = world.time
+	// Grant EXP
+	var/mob/living/carbon/human/apprentice = parent
+	var/datum/component/palermitan_exp/exp_comp = apprentice.GetComponent(/datum/component/palermitan_exp)
+	if(exp_comp)
+		exp_comp.modify_exp(3)
+	to_chat(apprentice, span_notice("The glass shattering against you sharpens your resolve. (+3 EXP)"))
+
+/// Melee attack on the apprentice — check for nursefather unarmed correction OR glass bottle hit
+/datum/component/palermitan_apprentice/proc/on_attackby(datum/source, obj/item/W, mob/living/user, params)
+	SIGNAL_HANDLER
+	// Check for glass bottle melee hit from nursefather
+	if(istype(W, /obj/item/reagent_containers/food/drinks))
+		var/obj/item/reagent_containers/food/drinks/D = W
+		if(D.isGlass && is_nursefather(user))
+			if(world.time >= last_glass_exp_time + 30 SECONDS)
+				last_glass_exp_time = world.time
+				var/mob/living/carbon/human/apprentice = parent
+				var/datum/component/palermitan_exp/exp_comp = apprentice.GetComponent(/datum/component/palermitan_exp)
+				if(exp_comp)
+					exp_comp.modify_exp(3)
+				to_chat(apprentice, span_notice("The bottle impact sharpens your resolve. (+3 EXP)"))
+	// Daily Training: nursefather hits apprentice with a weapon — grants EXP
+	if(W && is_nursefather(user))
+		if(world.time >= last_training_exp_time + 3 MINUTES)
+			last_training_exp_time = world.time
+			var/mob/living/carbon/human/apprentice = parent
+			var/datum/component/palermitan_exp/exp_comp = apprentice.GetComponent(/datum/component/palermitan_exp)
+			if(exp_comp)
+				exp_comp.modify_exp(2)
+			to_chat(apprentice, span_notice("Your mentor's training strike sharpens your resolve. (+2 EXP)"))
+
+/// Unarmed attack on the apprentice — nursefather harm-intent hand triggers correction.
+/// COMSIG_PARENT_ATTACKBY only fires for item attacks, so unarmed punches need this signal instead.
+/datum/component/palermitan_apprentice/proc/on_attack_hand(datum/source, mob/living/user)
+	SIGNAL_HANDLER
+	if(!isliving(user))
+		return
+	if(!is_nursefather(user))
+		return
+	if(user.a_intent != INTENT_HARM)
+		return
+	if(!correction_eligible || world.time >= correction_deadline)
+		return
+	INVOKE_ASYNC(src, PROC_REF(perform_correction), user)
+
+/// Grants drink-sharing EXP. Called externally (from debug kit or give/take signal).
+/datum/component/palermitan_apprentice/proc/grant_drink_exp()
+	if(world.time < last_drink_exp_time + 2 MINUTES)
+		var/mob/living/apprentice = parent
+		to_chat(apprentice, span_warning("You've shared a drink too recently. (Cooldown: 2 minutes)"))
+		return FALSE
+	last_drink_exp_time = world.time
+	var/mob/living/carbon/human/apprentice = parent
+	var/datum/component/palermitan_exp/exp_comp = apprentice.GetComponent(/datum/component/palermitan_exp)
+	if(exp_comp)
+		exp_comp.modify_exp(5)
+	to_chat(apprentice, span_notice("Offering a drink to your mentor strengthens your bond. (+5 EXP)"))
+	return TRUE
+
+////////////////////////////////////////////////////////////
+// POST-DUEL CORRECTION
+
+/// Performs the nursefather correction animation and grants rewards
+/datum/component/palermitan_apprentice/proc/perform_correction(mob/living/nursefather)
+	var/mob/living/carbon/human/apprentice = parent
+	if(!istype(apprentice) || QDELETED(apprentice) || QDELETED(nursefather))
+		return
+
+	correction_eligible = FALSE
+
+	// Calculate animation tier (upgrades every 2 corrections)
+	var/anim_tier = clamp(round(correction_count / 2) + 1, 1, 5)
+	var/list/damage_percents = list(0.05, 0.10, 0.20, 0.30, 0.50)
+	var/damage = apprentice.health * damage_percents[anim_tier]
+
+	switch(anim_tier)
+		if(1)
+			nursefather.visible_message(
+				span_warning("[nursefather] lightly slaps [apprentice]."),
+				span_warning("You correct [apprentice] with a light slap."))
+			playsound(apprentice, 'sound/weapons/punch1.ogg', 25)
+			nursefather.do_attack_animation(apprentice)
+			apprentice.deal_damage(damage, RED_DAMAGE, nursefather)
+		if(2)
+			nursefather.visible_message(
+				span_warning("[nursefather] backhands [apprentice] across the face."),
+				span_warning("You backhand [apprentice]."))
+			playsound(apprentice, 'sound/weapons/punch2.ogg', 35)
+			nursefather.do_attack_animation(apprentice)
+			animate(apprentice, pixel_x = apprentice.base_pixel_x + 4, time = 1)
+			animate(pixel_x = apprentice.base_pixel_x, time = 2)
+			apprentice.deal_damage(damage, RED_DAMAGE, nursefather)
+		if(3)
+			// Cutscene: 2-hit combo
+			var/combo_duration = 1.5 SECONDS
+			nursefather.Immobilize(combo_duration)
+			nursefather.changeNext_move(combo_duration)
+			apprentice.Immobilize(combo_duration)
+			apprentice.AddComponent(/datum/component/cutscene_duel, nursefather)
+			nursefather.face_atom(apprentice)
+
+			nursefather.do_attack_animation(apprentice)
+			playsound(apprentice, 'sound/weapons/punch3.ogg', 45)
+			animate(apprentice, pixel_x = apprentice.base_pixel_x + 8, time = 1)
+			apprentice.deal_damage(damage * 0.5, RED_DAMAGE, nursefather, DAMAGE_FORCED)
+			sleep(0.4 SECONDS)
+
+			nursefather.do_attack_animation(apprentice)
+			playsound(apprentice, 'sound/weapons/punch4.ogg', 50)
+			animate(apprentice, pixel_x = apprentice.base_pixel_x - 6, time = 1)
+			apprentice.deal_damage(damage * 0.5, RED_DAMAGE, nursefather, DAMAGE_FORCED)
+			shake_camera(apprentice, 1, 2)
+			sleep(0.4 SECONDS)
+
+			animate(apprentice, pixel_x = apprentice.base_pixel_x, pixel_y = apprentice.base_pixel_y, time = 2)
+			qdel(apprentice.GetComponent(/datum/component/cutscene_duel))
+
+			nursefather.visible_message(
+				span_danger("[nursefather] strikes [apprentice] twice in quick succession."),
+				span_danger("You discipline [apprentice] with two hard strikes."))
+		if(4)
+			// Cutscene: 3-hit combo
+			var/combo_duration = 2.5 SECONDS
+			nursefather.Immobilize(combo_duration)
+			nursefather.changeNext_move(combo_duration)
+			apprentice.Immobilize(combo_duration)
+			apprentice.AddComponent(/datum/component/cutscene_duel, nursefather)
+			nursefather.face_atom(apprentice)
+
+			nursefather.do_attack_animation(apprentice)
+			playsound(apprentice, 'sound/weapons/punch3.ogg', 50)
+			animate(apprentice, pixel_y = apprentice.base_pixel_y - 4, pixel_x = apprentice.base_pixel_x + 2, time = 1)
+			apprentice.deal_damage(damage * 0.33, RED_DAMAGE, nursefather, DAMAGE_FORCED)
+			sleep(0.5 SECONDS)
+
+			nursefather.do_attack_animation(apprentice)
+			playsound(apprentice, 'sound/weapons/punch4.ogg', 55)
+			animate(apprentice, pixel_y = apprentice.base_pixel_y + 6, pixel_x = apprentice.base_pixel_x - 4, time = 1)
+			apprentice.deal_damage(damage * 0.33, RED_DAMAGE, nursefather, DAMAGE_FORCED)
+			shake_camera(apprentice, 2, 2)
+			sleep(0.5 SECONDS)
+
+			nursefather.do_attack_animation(apprentice)
+			playsound(apprentice, 'sound/weapons/punch4.ogg', 65)
+			animate(apprentice, pixel_y = apprentice.base_pixel_y - 8, pixel_x = apprentice.base_pixel_x, time = 1)
+			apprentice.deal_damage(damage * 0.34, RED_DAMAGE, nursefather, DAMAGE_FORCED)
+			shake_camera(apprentice, 3, 3)
+			apprentice.Knockdown(10)
+			sleep(0.5 SECONDS)
+
+			animate(apprentice, pixel_x = apprentice.base_pixel_x, pixel_y = apprentice.base_pixel_y, time = 3)
+			qdel(apprentice.GetComponent(/datum/component/cutscene_duel))
+
+			nursefather.visible_message(
+				span_danger("[nursefather] beats [apprentice] with a brutal three-hit combination."),
+				span_danger("You beat some sense into [apprentice]."))
+		if(5)
+			// Cutscene: 5-hit full beating
+			var/combo_duration = 4 SECONDS
+			nursefather.Immobilize(combo_duration)
+			nursefather.changeNext_move(combo_duration)
+			apprentice.Immobilize(combo_duration)
+			apprentice.AddComponent(/datum/component/cutscene_duel, nursefather)
+			nursefather.face_atom(apprentice)
+
+			var/hit_damage = damage / 5
+
+			playsound(apprentice, 'sound/weapons/thudswoosh.ogg', 40)
+			animate(apprentice, pixel_x = apprentice.base_pixel_x + 10, time = 1)
+			sleep(0.3 SECONDS)
+
+			nursefather.do_attack_animation(apprentice)
+			playsound(apprentice, 'sound/weapons/punch3.ogg', 55)
+			animate(apprentice, pixel_y = apprentice.base_pixel_y - 6, pixel_x = apprentice.base_pixel_x + 4, time = 1)
+			apprentice.deal_damage(hit_damage, RED_DAMAGE, nursefather, DAMAGE_FORCED)
+			sleep(0.4 SECONDS)
+
+			nursefather.do_attack_animation(apprentice)
+			playsound(apprentice, 'sound/weapons/punch4.ogg', 60)
+			animate(apprentice, pixel_x = apprentice.base_pixel_x - 10, pixel_y = apprentice.base_pixel_y, time = 1)
+			apprentice.deal_damage(hit_damage, RED_DAMAGE, nursefather, DAMAGE_FORCED)
+			shake_camera(apprentice, 2, 3)
+			sleep(0.4 SECONDS)
+
+			nursefather.do_attack_animation(apprentice)
+			playsound(apprentice, 'sound/weapons/punch4.ogg', 65)
+			animate(apprentice, pixel_y = apprentice.base_pixel_y - 10, pixel_x = apprentice.base_pixel_x - 2, time = 1)
+			apprentice.deal_damage(hit_damage, RED_DAMAGE, nursefather, DAMAGE_FORCED)
+			shake_camera(apprentice, 3, 3)
+			sleep(0.5 SECONDS)
+
+			nursefather.do_attack_animation(apprentice)
+			playsound(apprentice, 'sound/weapons/punch4.ogg', 75)
+			animate(apprentice, pixel_y = apprentice.base_pixel_y - 14, pixel_x = apprentice.base_pixel_x, time = 1)
+			apprentice.deal_damage(hit_damage * 2, RED_DAMAGE, nursefather, DAMAGE_FORCED)
+			shake_camera(apprentice, 4, 4)
+			apprentice.Knockdown(20)
+			sleep(0.6 SECONDS)
+
+			animate(apprentice, pixel_x = apprentice.base_pixel_x, pixel_y = apprentice.base_pixel_y, time = 5, easing = QUAD_EASING)
+			qdel(apprentice.GetComponent(/datum/component/cutscene_duel))
+
+			nursefather.visible_message(
+				span_userdanger("[nursefather] gives [apprentice] a thorough, brutal beating."),
+				span_userdanger("You give [apprentice] the correction they deserve."))
+
+	// Grant correction rewards
+	correction_count++
+	if(potential_correction_attrs > 0)
+		for(var/attr_name in list(FORTITUDE_ATTRIBUTE, PRUDENCE_ATTRIBUTE, TEMPERANCE_ATTRIBUTE, JUSTICE_ATTRIBUTE))
+			var/datum/attribute/A = apprentice.attributes[attr_name]
+			if(A)
+				A.level = min(200, A.level + potential_correction_attrs)
+				A.on_update(apprentice)
+		to_chat(apprentice, span_notice("The correction grants you [potential_correction_attrs] to each attribute."))
+		potential_correction_attrs = 0
+
+	// Grant EXP
+	var/datum/component/palermitan_exp/exp_comp = apprentice.GetComponent(/datum/component/palermitan_exp)
+	if(exp_comp)
+		exp_comp.modify_exp(5)
+
+	// Check gear tier-up
+	check_gear_tierup(apprentice)

--- a/ModularLobotomy/thumb_spider/palermitan_debug.dm
+++ b/ModularLobotomy/thumb_spider/palermitan_debug.dm
@@ -1,1 +1,406 @@
-// Stub - populated by the Thumb sub-PR
+/// Palermitan Debug Kit — spawnable item for testing the apprentice system.
+/// Spawn from object spawner by searching "palermitan debug".
+/// Use in-hand OR alt-click from pocket/belt/backpack to open the menu.
+/obj/item/palermitan_debug_kit
+	name = "palermitan debug kit"
+	desc = "A debug tool for testing the Thumb Apprentice Palermitan Style system. Use in-hand or alt-click to open the menu."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "hypertool"
+	w_class = WEIGHT_CLASS_TINY
+	slot_flags = ITEM_SLOT_LPOCKET | ITEM_SLOT_RPOCKET | ITEM_SLOT_BELT
+	/// Reference to an active duel started by this debug kit
+	var/datum/thumb_duel/active_debug_duel
+
+/obj/item/palermitan_debug_kit/attack_self(mob/living/user)
+	. = ..()
+	open_debug_menu(user)
+
+/obj/item/palermitan_debug_kit/AltClick(mob/user)
+	. = ..()
+	open_debug_menu(user)
+
+/obj/item/palermitan_debug_kit/proc/open_debug_menu(mob/user)
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+
+	var/list/options = list(
+		"Full Setup",
+		"Grant Base Passives",
+		"Remove Base Passives",
+		"Grant EXP Component",
+		"Add EXP",
+		"Grant Duel Action",
+		"Grant Skill Tree Action",
+		"Spawn Gear Set",
+		"Set Weapon Tier",
+		"Set Armor Tier",
+		"Set Attribute Level",
+		"--- Duel Testing ---",
+		"Spawn Duel Dummy",
+		"Force Start Duel vs Dummy",
+		"Simulate Duel Win",
+		"Simulate Duel Loss",
+		"Simulate Loss + Correction",
+		"--- Role Passives ---",
+		"Add Role Passive",
+		"--- Nursefather ---",
+		"Simulate Drink EXP",
+		"Simulate Glass Bottle EXP",
+		"--- Reset ---",
+		"Reset All",
+	)
+
+	var/choice = tgui_input_list(H, "Palermitan Debug Kit", "Debug Menu", options)
+	if(!choice || findtext(choice, "---"))
+		return
+
+	switch(choice)
+		if("Full Setup")
+			debug_full_setup(H)
+		if("Grant Base Passives")
+			debug_grant_passives(H)
+		if("Remove Base Passives")
+			debug_remove_passives(H)
+		if("Grant EXP Component")
+			debug_grant_exp(H)
+		if("Add EXP")
+			debug_add_exp(H)
+		if("Grant Duel Action")
+			debug_grant_duel_action(H)
+		if("Grant Skill Tree Action")
+			debug_grant_tree_action(H)
+		if("Spawn Gear Set")
+			debug_spawn_gear(H)
+		if("Set Weapon Tier")
+			debug_set_weapon_tier(H)
+		if("Set Armor Tier")
+			debug_set_armor_tier(H)
+		if("Set Attribute Level")
+			debug_set_attributes(H)
+		if("Spawn Duel Dummy")
+			debug_spawn_dummy(H)
+		if("Force Start Duel vs Dummy")
+			debug_force_duel(H)
+		if("Simulate Duel Win")
+			debug_simulate_duel(H, TRUE)
+		if("Simulate Duel Loss")
+			debug_simulate_duel(H, FALSE)
+		if("Add Role Passive")
+			debug_add_role_passive(H)
+		if("Simulate Loss + Correction")
+			debug_simulate_correction(H)
+		if("Simulate Drink EXP")
+			debug_simulate_drink(H)
+		if("Simulate Glass Bottle EXP")
+			debug_simulate_glass(H)
+		if("Reset All")
+			debug_reset_all(H)
+
+/obj/item/palermitan_debug_kit/proc/debug_full_setup(mob/living/carbon/human/H)
+	debug_grant_passives(H)
+	debug_grant_exp(H)
+	debug_grant_duel_action(H)
+	debug_grant_tree_action(H)
+	debug_set_attributes_value(H, 40)
+	debug_spawn_gear(H)
+	to_chat(H, span_boldnotice("Palermitan Debug: Full setup complete. Passives, EXP, duel action, skill tree, gear, and 40 attributes."))
+
+/obj/item/palermitan_debug_kit/proc/debug_grant_passives(mob/living/carbon/human/H)
+	if(H.GetComponent(/datum/component/palermitan_apprentice))
+		to_chat(H, span_warning("Already has base passives."))
+		return
+	H.AddComponent(/datum/component/palermitan_apprentice)
+	to_chat(H, span_notice("Palermitan Debug: Base passives (Duello + Palermitan Style) granted."))
+
+/obj/item/palermitan_debug_kit/proc/debug_remove_passives(mob/living/carbon/human/H)
+	var/datum/component/palermitan_apprentice/comp = H.GetComponent(/datum/component/palermitan_apprentice)
+	if(!comp)
+		to_chat(H, span_warning("No base passives to remove."))
+		return
+	qdel(comp)
+	to_chat(H, span_notice("Palermitan Debug: Base passives removed."))
+
+/obj/item/palermitan_debug_kit/proc/debug_spawn_gear(mob/living/carbon/human/H)
+	var/turf/T = get_turf(H)
+	new /obj/item/clothing/suit/armor/ego_gear/city/thumb_spider/apprentice(T)
+	new /obj/item/ego_weapon/city/thumbapprentice_katana(T)
+	new /obj/item/ego_weapon/city/thumbapprentice_greatsword(T)
+	to_chat(H, span_notice("Palermitan Debug: Tier 1 armor + katana + greatsword spawned at your feet."))
+
+/obj/item/palermitan_debug_kit/proc/debug_set_weapon_tier(mob/living/carbon/human/H)
+	var/new_tier = tgui_input_list(H, "Set weapon tier", "Weapon Tier", list("1", "2", "3", "4"))
+	if(!new_tier)
+		return
+	new_tier = text2num(new_tier)
+	// GetAllContents() covers held items, backpack, pockets, belt, etc.
+	for(var/obj/item/ego_weapon/city/thumbapprentice_katana/K in H.GetAllContents())
+		K.set_tier(new_tier)
+	for(var/obj/item/ego_weapon/city/thumbapprentice_greatsword/G in H.GetAllContents())
+		G.set_tier(new_tier)
+	to_chat(H, span_notice("Palermitan Debug: Weapon tier set to [new_tier]. Dual-wield threshold: [new_tier >= 4 ? "every hit" : (new_tier >= 2 ? "every 2nd hit" : "disabled")]"))
+
+/obj/item/palermitan_debug_kit/proc/debug_set_armor_tier(mob/living/carbon/human/H)
+	var/new_tier = tgui_input_list(H, "Set armor tier", "Armor Tier", list("1", "2", "3", "4"))
+	if(!new_tier)
+		return
+	new_tier = text2num(new_tier)
+	// Check worn armor
+	var/obj/item/clothing/suit/armor/ego_gear/city/thumb_spider/apprentice/worn = H.get_item_by_slot(ITEM_SLOT_OCLOTHING)
+	if(istype(worn))
+		worn.set_tier(new_tier)
+	// Check held/inventory
+	for(var/obj/item/clothing/suit/armor/ego_gear/city/thumb_spider/apprentice/A in H.GetAllContents())
+		A.set_tier(new_tier)
+	to_chat(H, span_notice("Palermitan Debug: Armor tier set to [new_tier]."))
+
+/obj/item/palermitan_debug_kit/proc/debug_set_attributes(mob/living/carbon/human/H)
+	var/new_level = tgui_input_list(H, "Set all attributes to:", "Attribute Level", list("40", "60", "80", "100", "120", "150", "200"))
+	if(!new_level)
+		return
+	new_level = text2num(new_level)
+	debug_set_attributes_value(H, new_level)
+	to_chat(H, span_notice("Palermitan Debug: All attributes set to [new_level]."))
+
+/obj/item/palermitan_debug_kit/proc/debug_set_attributes_value(mob/living/carbon/human/H, value)
+	H.set_attribute_limit(200)
+	var/datum/attribute/fort = H.attributes[FORTITUDE_ATTRIBUTE]
+	var/datum/attribute/prud = H.attributes[PRUDENCE_ATTRIBUTE]
+	var/datum/attribute/temp = H.attributes[TEMPERANCE_ATTRIBUTE]
+	var/datum/attribute/just = H.attributes[JUSTICE_ATTRIBUTE]
+	if(fort)
+		fort.level = value
+		fort.on_update(H)
+	if(prud)
+		prud.level = value
+		prud.on_update(H)
+	if(temp)
+		temp.level = value
+		temp.on_update(H)
+	if(just)
+		just.level = value
+		just.on_update(H)
+
+/obj/item/palermitan_debug_kit/proc/debug_grant_exp(mob/living/carbon/human/H)
+	if(H.GetComponent(/datum/component/palermitan_exp))
+		to_chat(H, span_warning("Already has EXP component."))
+		return
+	H.AddComponent(/datum/component/palermitan_exp)
+	to_chat(H, span_notice("Palermitan Debug: EXP component granted."))
+
+/obj/item/palermitan_debug_kit/proc/debug_add_exp(mob/living/carbon/human/H)
+	var/datum/component/palermitan_exp/exp_comp = H.GetComponent(/datum/component/palermitan_exp)
+	if(!exp_comp)
+		to_chat(H, span_warning("No EXP component. Grant it first."))
+		return
+	var/amount = tgui_input_list(H, "Add how much EXP?", "Add EXP", list("10", "20", "50", "100", "200", "500", "900"))
+	if(!amount)
+		return
+	exp_comp.modify_exp(text2num(amount))
+
+/obj/item/palermitan_debug_kit/proc/debug_grant_duel_action(mob/living/carbon/human/H)
+	// Check if already has the action
+	for(var/datum/action/innate/thumb_duel_challenge/existing in H.actions)
+		to_chat(H, span_warning("Already has duel action."))
+		return
+	var/datum/action/innate/thumb_duel_challenge/duel_action = new()
+	duel_action.Grant(H)
+	to_chat(H, span_notice("Palermitan Debug: Duel challenge action granted."))
+
+/obj/item/palermitan_debug_kit/proc/debug_spawn_dummy(mob/living/carbon/human/H)
+	var/turf/T = get_step(H, H.dir)
+	if(!T)
+		T = get_turf(H)
+	var/mob/living/simple_animal/hostile/palermitan_dummy/D = new(T)
+	var/attr_str = tgui_input_list(H, "Dummy attribute level?", "Dummy Attributes", list("40", "60", "80", "100", "150", "200"))
+	if(attr_str)
+		D.fake_attributes = text2num(attr_str)
+	to_chat(H, span_notice("Palermitan Debug: Duel dummy spawned with [D.fake_attributes] fake attributes."))
+
+/obj/item/palermitan_debug_kit/proc/debug_force_duel(mob/living/carbon/human/H)
+	// End any existing active duel first
+	if(active_debug_duel?.active)
+		active_debug_duel.end_duel(null, null, "cancelled by debug kit")
+		active_debug_duel = null
+	// Spawn a dummy and immediately start a duel
+	var/turf/T = get_step(H, H.dir)
+	if(!T)
+		T = get_turf(H)
+	var/mob/living/simple_animal/hostile/palermitan_dummy/D = new(T)
+	// Make sure the apprentice has the base component
+	if(!H.GetComponent(/datum/component/palermitan_apprentice))
+		H.AddComponent(/datum/component/palermitan_apprentice)
+	if(!H.GetComponent(/datum/component/palermitan_exp))
+		H.AddComponent(/datum/component/palermitan_exp)
+	active_debug_duel = new /datum/thumb_duel(H, D)
+	active_debug_duel.start_duel()
+	to_chat(H, span_notice("Palermitan Debug: Duel started vs dummy (attrs: [D.fake_attributes])."))
+
+/obj/item/palermitan_debug_kit/proc/debug_simulate_duel(mob/living/carbon/human/H, won)
+	// End any existing active duel first (cleans up walls, signals, etc.)
+	if(active_debug_duel?.active)
+		active_debug_duel.cleanup()
+		QDEL_NULL(active_debug_duel)
+	// Make sure the apprentice has components
+	if(!H.GetComponent(/datum/component/palermitan_apprentice))
+		H.AddComponent(/datum/component/palermitan_apprentice)
+	if(!H.GetComponent(/datum/component/palermitan_exp))
+		H.AddComponent(/datum/component/palermitan_exp)
+	// Create a temporary dummy for reward calculation (doesn't start a real duel)
+	var/turf/T = get_turf(H)
+	var/mob/living/simple_animal/hostile/palermitan_dummy/D = new(T)
+	// Use the reward proc directly without starting a duel
+	var/datum/thumb_duel/temp_duel = new(H, D)
+	if(won)
+		temp_duel.grant_duel_rewards(H, D)
+		to_chat(H, span_boldnotice("Palermitan Debug: Simulated duel WIN vs [D.fake_attributes]-attr opponent."))
+	else
+		temp_duel.grant_duel_rewards(D, H)
+		to_chat(H, span_boldwarning("Palermitan Debug: Simulated duel LOSS vs [D.fake_attributes]-attr opponent."))
+	// Clean up temp objects (temp_duel was never started so no walls/signals to clean)
+	qdel(temp_duel)
+	qdel(D)
+
+/obj/item/palermitan_debug_kit/proc/debug_grant_tree_action(mob/living/carbon/human/H)
+	for(var/datum/action/innate/palermitan_tree/existing in H.actions)
+		to_chat(H, span_warning("Already has skill tree action."))
+		return
+	var/datum/action/innate/palermitan_tree/tree_action = new()
+	tree_action.Grant(H)
+	to_chat(H, span_notice("Palermitan Debug: Skill tree action granted."))
+
+/obj/item/palermitan_debug_kit/proc/debug_simulate_correction(mob/living/carbon/human/H)
+	// Ensure components exist
+	if(!H.GetComponent(/datum/component/palermitan_apprentice))
+		H.AddComponent(/datum/component/palermitan_apprentice)
+	if(!H.GetComponent(/datum/component/palermitan_exp))
+		H.AddComponent(/datum/component/palermitan_exp)
+	// Simulate a duel loss first (for attribute calculation)
+	var/turf/T = get_turf(H)
+	var/mob/living/simple_animal/hostile/palermitan_dummy/D = new(T)
+	var/datum/thumb_duel/temp_duel = new(H, D)
+	temp_duel.grant_duel_rewards(D, H)
+	qdel(temp_duel)
+	qdel(D)
+	// Now spawn a nursefather dummy and perform the correction
+	var/datum/component/palermitan_apprentice/pal = H.GetComponent(/datum/component/palermitan_apprentice)
+	if(!pal)
+		return
+	// Force correction eligibility
+	pal.correction_eligible = TRUE
+	pal.correction_deadline = world.time + 5 MINUTES
+	if(pal.potential_correction_attrs <= 0)
+		pal.potential_correction_attrs = 3
+	// Spawn nursefather dummy adjacent
+	var/turf/nurse_turf = get_step(H, H.dir)
+	if(!nurse_turf)
+		nurse_turf = get_turf(H)
+	var/mob/living/simple_animal/hostile/palermitan_dummy/nurse = new(nurse_turf)
+	nurse.name = "Ex Thumb Sottocapo"
+	nurse.maxHealth = 9999
+	nurse.health = 9999
+	// Run correction animation
+	pal.perform_correction(nurse)
+	// Clean up dummy after animation
+	QDEL_IN(nurse, 6 SECONDS)
+	to_chat(H, span_boldwarning("Palermitan Debug: Simulated duel loss + correction (count: [pal.correction_count])."))
+
+/obj/item/palermitan_debug_kit/proc/debug_simulate_drink(mob/living/carbon/human/H)
+	var/datum/component/palermitan_apprentice/pal = H.GetComponent(/datum/component/palermitan_apprentice)
+	if(!pal)
+		to_chat(H, span_warning("No base passives component. Grant it first."))
+		return
+	pal.grant_drink_exp()
+
+/obj/item/palermitan_debug_kit/proc/debug_simulate_glass(mob/living/carbon/human/H)
+	var/datum/component/palermitan_apprentice/pal = H.GetComponent(/datum/component/palermitan_apprentice)
+	if(!pal)
+		to_chat(H, span_warning("No base passives component. Grant it first."))
+		return
+	if(!H.GetComponent(/datum/component/palermitan_exp))
+		H.AddComponent(/datum/component/palermitan_exp)
+	if(world.time < pal.last_glass_exp_time + 30 SECONDS)
+		to_chat(H, span_warning("Glass bottle EXP is on cooldown."))
+		return
+	pal.last_glass_exp_time = world.time
+	var/datum/component/palermitan_exp/exp_comp = H.GetComponent(/datum/component/palermitan_exp)
+	if(exp_comp)
+		exp_comp.modify_exp(3)
+	to_chat(H, span_notice("Palermitan Debug: Simulated glass bottle impact. (+3 EXP)"))
+
+/// Role name -> passive component type path mapping
+/obj/item/palermitan_debug_kit/proc/get_role_passive_types()
+	return list(
+		"Butcher" = /datum/component/palermitan_role_passive/butcher,
+		"Blade Lineage" = /datum/component/palermitan_role_passive/blade_lineage,
+		"Thumb" = /datum/component/palermitan_role_passive/thumb,
+		"Kurokumo" = /datum/component/palermitan_role_passive/kurokumo,
+		"Index" = /datum/component/palermitan_role_passive/index,
+		"Insurgence" = /datum/component/palermitan_role_passive/insurgence,
+		"Middle" = /datum/component/palermitan_role_passive/middle,
+		"N-Corp" = /datum/component/palermitan_role_passive/ncorp,
+		"Rat" = /datum/component/palermitan_role_passive/rat,
+		"Carnival" = /datum/component/palermitan_role_passive/carnival,
+		"Zwei" = /datum/component/palermitan_role_passive/zwei,
+		"Seven" = /datum/component/palermitan_role_passive/seven,
+		"Dieci" = /datum/component/palermitan_role_passive/dieci,
+		"Cinq" = /datum/component/palermitan_role_passive/cinq,
+		"Shi" = /datum/component/palermitan_role_passive/shi,
+		"Liu" = /datum/component/palermitan_role_passive/liu,
+		"Devyat" = /datum/component/palermitan_role_passive/devyat,
+		"Hana" = /datum/component/palermitan_role_passive/hana,
+	)
+
+/obj/item/palermitan_debug_kit/proc/debug_add_role_passive(mob/living/carbon/human/H)
+	var/list/role_types = get_role_passive_types()
+	var/role_name = tgui_input_list(H, "Which role passive?", "Role Passive", role_types)
+	if(!role_name)
+		return
+	var/tier_str = tgui_input_list(H, "Set tier:", "Passive Tier", list("1", "2", "3"))
+	if(!tier_str)
+		return
+	var/new_tier = text2num(tier_str)
+	var/passive_type = role_types[role_name]
+	// Remove existing passive of this type if any
+	var/datum/component/palermitan_role_passive/existing = locate(passive_type) in H.GetComponents(/datum/component/palermitan_role_passive)
+	if(existing)
+		qdel(existing)
+	// Add new passive at the selected tier
+	H.AddComponent(passive_type, new_tier)
+	// Also update the EXP component's duel count to match
+	var/datum/component/palermitan_exp/exp_comp = H.GetComponent(/datum/component/palermitan_exp)
+	if(exp_comp)
+		var/required_duels = 1
+		if(new_tier >= 3)
+			required_duels = 5
+		else if(new_tier >= 2)
+			required_duels = 3
+		exp_comp.role_duel_counts[role_name] = required_duels
+	to_chat(H, span_notice("Palermitan Debug: [role_name] passive granted at tier [new_tier]."))
+
+/obj/item/palermitan_debug_kit/proc/debug_reset_all(mob/living/carbon/human/H)
+	// Remove components
+	var/datum/component/palermitan_apprentice/pal = H.GetComponent(/datum/component/palermitan_apprentice)
+	if(pal)
+		qdel(pal)
+	var/datum/component/palermitan_exp/exp = H.GetComponent(/datum/component/palermitan_exp)
+	if(exp)
+		qdel(exp)
+	// Remove all palermitan skill components
+	for(var/datum/component/palermitan_skill/skill in H.GetComponents(/datum/component/palermitan_skill))
+		qdel(skill)
+	// Remove all role passive components
+	for(var/datum/component/palermitan_role_passive/passive in H.GetComponents(/datum/component/palermitan_role_passive))
+		qdel(passive)
+	// Remove actions
+	for(var/datum/action/innate/thumb_duel_challenge/act in H.actions)
+		qdel(act)
+	for(var/datum/action/innate/palermitan_tree/act in H.actions)
+		qdel(act)
+	for(var/datum/action/innate/sezionatura_activate/act in H.actions)
+		qdel(act)
+	// End any active debug duel
+	if(active_debug_duel?.active)
+		active_debug_duel.cleanup()
+		QDEL_NULL(active_debug_duel)
+	to_chat(H, span_notice("Palermitan Debug: All components, skills, passives, and actions removed."))

--- a/ModularLobotomy/thumb_spider/palermitan_debug.dm
+++ b/ModularLobotomy/thumb_spider/palermitan_debug.dm
@@ -1,4 +1,4 @@
-/// Palermitan Debug Kit — spawnable item for testing the apprentice system.
+/// Palermitan Debug Kit - spawnable item for testing the apprentice system.
 /// Spawn from object spawner by searching "palermitan debug".
 /// Use in-hand OR alt-click from pocket/belt/backpack to open the menu.
 /obj/item/palermitan_debug_kit

--- a/ModularLobotomy/thumb_spider/palermitan_duel.dm
+++ b/ModularLobotomy/thumb_spider/palermitan_duel.dm
@@ -245,9 +245,16 @@ GLOBAL_LIST_INIT(duel_fort_rewards, list())
 	// linearly down to 1.0x at 200 attrs.
 	var/underleveled_mult = clamp(1 + (200 - apprentice_avg) / 80, 1.0, 1.75)
 
+	// Dueling the nursefather gives severely reduced rewards (training, not real combat)
+	var/is_nursefather_duel = FALSE
+	if(opponent_mob?.mind?.assigned_role == "Ex Thumb Sottocapo")
+		is_nursefather_duel = TRUE
+
 	// === ATTRIBUTE GROWTH ===
 	var/base_gain = 16
 	var/gain_per_attr = round(base_gain * ratio * underleveled_mult * win_modifier)
+	if(is_nursefather_duel)
+		gain_per_attr = round(gain_per_attr * 0.2)
 	if(gain_per_attr > 0)
 		for(var/attr_name in list(FORTITUDE_ATTRIBUTE, PRUDENCE_ATTRIBUTE, TEMPERANCE_ATTRIBUTE, JUSTICE_ATTRIBUTE))
 			var/datum/attribute/A = apprentice.attributes[attr_name]
@@ -297,6 +304,9 @@ GLOBAL_LIST_INIT(duel_fort_rewards, list())
 			to_chat(apprentice, span_info("Your mentor can correct you within 1.5 minutes for additional attribute growth."))
 
 	// === OPPONENT REWARDS ===
+	// Nursefather gets no rewards for dueling their own apprentice
+	if(is_nursefather_duel)
+		return
 	// Non-apprentice opponent gets Ahn + Fortitude for participating
 	if(ishuman(opponent_mob) && !istype(opponent_mob, /mob/living/simple_animal/hostile/palermitan_dummy))
 		var/mob/living/carbon/human/opp = opponent_mob
@@ -385,14 +395,13 @@ GLOBAL_LIST_INIT(duel_fort_rewards, list())
 	if(min_attr == INFINITY)
 		return
 
-	// Determine what tier the attributes support: (attrs / 2) >= requirement
-	var/effective = round(min_attr / 2)
+	// Determine what tier the attributes support (raw values, matching armor requirements)
 	var/new_tier = 1
-	if(effective >= 100)
+	if(min_attr >= 100)
 		new_tier = 4
-	else if(effective >= 80)
+	else if(min_attr >= 80)
 		new_tier = 3
-	else if(effective >= 60)
+	else if(min_attr >= 60)
 		new_tier = 2
 
 	// Update weapons (inventory or dropped nearby)
@@ -412,12 +421,6 @@ GLOBAL_LIST_INIT(duel_fort_rewards, list())
 			if(!armor_announced)
 				to_chat(apprentice, span_boldnotice("Your armor has evolved to tier [new_tier]!"))
 				armor_announced = TRUE
-
-	// At 150+ attributes: grant Nursefather Passive (evasion from endured pain)
-	if(min_attr >= 150 && !apprentice.GetComponent(/datum/component/nursefather_passive))
-		apprentice.AddComponent(/datum/component/nursefather_passive)
-		to_chat(apprentice, span_boldnotice("The pain you've endured has sharpened your instincts. You gain precognitive evasion!"))
-		to_chat(apprentice, span_notice("You now automatically dodge the first attack every 30 seconds, and have a 50% chance to dodge when unarmed. However, all damage you take inflicts 5% unhealable damage."))
 
 ////////////////////////////////////////////////////////////
 // ROLE PASSIVE GRANTING

--- a/ModularLobotomy/thumb_spider/palermitan_duel.dm
+++ b/ModularLobotomy/thumb_spider/palermitan_duel.dm
@@ -1,1 +1,594 @@
-// Stub - populated by the Thumb sub-PR
+////////////////////////////////////////////////////////////
+// PALERMITAN DUEL SYSTEM
+// PvP duel system for Thumb Apprentice progression.
+// Creates an arena ring, detects win/loss, grants rewards.
+////////////////////////////////////////////////////////////
+
+/// Tracks total Fortitude gained from dueling, keyed by ckey. Caps at 20.
+GLOBAL_LIST_INIT(duel_fort_rewards, list())
+
+/// Training dummy for solo duel testing
+/mob/living/simple_animal/hostile/palermitan_dummy
+	name = "training dummy"
+	desc = "A training dummy for duel practice."
+	icon = 'icons/mob/simple_human.dmi'
+	icon_state = "psycho_knife"
+	icon_living = "psycho_knife"
+	maxHealth = 500
+	health = 500
+	stat_attack = CONSCIOUS
+	faction = list("neutral")
+	melee_damage_lower = 10
+	melee_damage_upper = 15
+	attack_verb_continuous = "strikes"
+	attack_verb_simple = "strike"
+	/// Fake attributes for reward calculation (simple_animals don't have real attributes)
+	var/fake_attributes = 100
+
+////////////////////////////////////////////////////////////
+// DUEL DATUM
+/datum/thumb_duel
+	/// The player who initiated the duel (usually the apprentice)
+	var/mob/living/challenger
+	/// The player/mob who accepted the duel
+	var/mob/living/opponent
+	/// Center turf of the arena
+	var/turf/arena_center
+	/// Radius of the arena in tiles
+	var/arena_radius = 7
+	/// Whether the duel is currently active
+	var/active = FALSE
+	/// Timer for periodic arena checks
+	var/check_timer
+	/// List of spawned wall effects (for cleanup)
+	var/list/arena_walls = list()
+
+/datum/thumb_duel/New(mob/living/init_challenger, mob/living/init_opponent)
+	challenger = init_challenger
+	opponent = init_opponent
+
+/datum/thumb_duel/Destroy()
+	if(active)
+		cleanup()
+	challenger = null
+	opponent = null
+	arena_center = null
+	return ..()
+
+/// Starts the duel after both participants are ready
+/datum/thumb_duel/proc/start_duel()
+	if(active)
+		return
+	if(QDELETED(challenger) || QDELETED(opponent))
+		qdel(src)
+		return
+
+	// Calculate arena center as midpoint between the two participants
+	var/turf/t1 = get_turf(challenger)
+	var/turf/t2 = get_turf(opponent)
+	if(!t1 || !t2 || t1.z != t2.z)
+		qdel(src)
+		return
+	var/mid_x = round((t1.x + t2.x) / 2)
+	var/mid_y = round((t1.y + t2.y) / 2)
+	arena_center = locate(mid_x, mid_y, t1.z)
+	if(!arena_center)
+		qdel(src)
+		return
+
+	active = TRUE
+
+	// Register signals for win/loss detection
+	RegisterSignal(challenger, COMSIG_MOB_STATCHANGE, PROC_REF(on_challenger_stat_change))
+	RegisterSignal(opponent, COMSIG_MOB_STATCHANGE, PROC_REF(on_opponent_stat_change))
+
+	// Spawn arena walls and start check loop
+	spawn_arena_walls()
+	check_timer = addtimer(CALLBACK(src, PROC_REF(arena_check_loop)), 5 SECONDS, TIMER_STOPPABLE)
+
+	to_chat(challenger, span_boldwarning("The duel begins!"))
+	to_chat(opponent, span_boldwarning("The duel begins!"))
+	playsound(arena_center, 'sound/effects/alert.ogg', 50, FALSE, 8)
+
+/// Spawns visual barrier markers on the border ring (non-dense, trigger on Crossed)
+/datum/thumb_duel/proc/spawn_arena_walls()
+	// Clean up old walls first
+	for(var/obj/effect/temp_visual/duel_wall/W in arena_walls)
+		if(!QDELETED(W))
+			qdel(W)
+	arena_walls.Cut()
+	// Spawn new walls on the border ring
+	if(!arena_center)
+		return
+	for(var/turf/T in RANGE_TURFS(arena_radius, arena_center))
+		if(get_dist(T, arena_center) == arena_radius)
+			var/obj/effect/temp_visual/duel_wall/wall = new(T)
+			wall.duel_ref = src
+			arena_walls += wall
+
+/// Periodic check loop — refreshes walls (they're temp_visuals and expire)
+/datum/thumb_duel/proc/arena_check_loop()
+	if(!active)
+		return
+	spawn_arena_walls()
+	check_timer = addtimer(CALLBACK(src, PROC_REF(arena_check_loop)), 5 SECONDS, TIMER_STOPPABLE)
+
+/// Signal handler: challenger entered crit
+/datum/thumb_duel/proc/on_challenger_stat_change(datum/source, new_stat, old_stat)
+	SIGNAL_HANDLER
+	if(new_stat >= SOFT_CRIT)
+		INVOKE_ASYNC(src, PROC_REF(end_duel), opponent, challenger, "was defeated")
+
+/// Signal handler: opponent entered crit
+/datum/thumb_duel/proc/on_opponent_stat_change(datum/source, new_stat, old_stat)
+	SIGNAL_HANDLER
+	if(new_stat >= SOFT_CRIT)
+		INVOKE_ASYNC(src, PROC_REF(end_duel), challenger, opponent, "was defeated")
+
+/// Called by duel_wall when a participant steps on the barrier
+/datum/thumb_duel/proc/on_barrier_crossed(mob/living/crosser)
+	if(!active)
+		return
+	if(crosser == challenger)
+		INVOKE_ASYNC(src, PROC_REF(end_duel), opponent, challenger, "left the ring")
+	else if(crosser == opponent)
+		INVOKE_ASYNC(src, PROC_REF(end_duel), challenger, opponent, "left the ring")
+
+/// Ends the duel, heals players, grants rewards
+/datum/thumb_duel/proc/end_duel(mob/living/winner, mob/living/loser, reason = "")
+	if(!active)
+		return
+	active = FALSE
+
+	// Announce result
+	if(winner && !QDELETED(winner))
+		to_chat(winner, span_boldnotice("You won the duel! [loser] [reason]."))
+	if(loser && !QDELETED(loser))
+		to_chat(loser, span_boldwarning("You lost the duel."))
+
+	// Heal winner 50% of missing HP, loser 25%
+	if(winner && !QDELETED(winner))
+		var/winner_missing = winner.maxHealth - winner.health
+		if(winner_missing > 0)
+			winner.adjustBruteLoss(-(winner_missing * 0.5))
+	if(loser && !QDELETED(loser))
+		var/loser_missing = loser.maxHealth - loser.health
+		if(loser_missing > 0)
+			loser.adjustBruteLoss(-(loser_missing * 0.25))
+
+	// Grant rewards
+	grant_duel_rewards(winner, loser)
+
+	// Cleanup and self-delete
+	cleanup()
+	qdel(src)
+
+/// Cleans up signals, timers, and arena walls
+/datum/thumb_duel/proc/cleanup()
+	if(challenger && !QDELETED(challenger))
+		UnregisterSignal(challenger, COMSIG_MOB_STATCHANGE)
+	if(opponent && !QDELETED(opponent))
+		UnregisterSignal(opponent, COMSIG_MOB_STATCHANGE)
+	deltimer(check_timer)
+	for(var/obj/effect/temp_visual/duel_wall/W in arena_walls)
+		if(!QDELETED(W))
+			qdel(W)
+	arena_walls.Cut()
+
+////////////////////////////////////////////////////////////
+// DUEL REWARDS (Step 6)
+
+/// Grants attribute growth, EXP, and role tracking after a duel
+/datum/thumb_duel/proc/grant_duel_rewards(mob/living/winner, mob/living/loser)
+	if(!winner || !loser)
+		return
+
+	// Determine which participant is the apprentice
+	var/mob/living/carbon/human/apprentice
+	var/mob/living/opponent_mob
+	var/player_won = FALSE
+
+	if(ishuman(winner))
+		var/mob/living/carbon/human/HW = winner
+		if(HW.GetComponent(/datum/component/palermitan_apprentice))
+			apprentice = HW
+			opponent_mob = loser
+			player_won = TRUE
+	if(!apprentice && ishuman(loser))
+		var/mob/living/carbon/human/HL = loser
+		if(HL.GetComponent(/datum/component/palermitan_apprentice))
+			apprentice = HL
+			opponent_mob = winner
+			player_won = FALSE
+
+	if(!apprentice)
+		return
+
+	// Get opponent's average attributes
+	var/opponent_avg = 100
+	if(istype(opponent_mob, /mob/living/simple_animal/hostile/palermitan_dummy))
+		var/mob/living/simple_animal/hostile/palermitan_dummy/D = opponent_mob
+		opponent_avg = D.fake_attributes
+	else if(ishuman(opponent_mob))
+		var/mob/living/carbon/human/HO = opponent_mob
+		var/total = 0
+		var/count = 0
+		for(var/attr_name in list(FORTITUDE_ATTRIBUTE, PRUDENCE_ATTRIBUTE, TEMPERANCE_ATTRIBUTE, JUSTICE_ATTRIBUTE))
+			var/datum/attribute/A = HO.attributes[attr_name]
+			if(A)
+				total += A.level
+				count++
+		if(count > 0)
+			opponent_avg = total / count
+
+	// Get apprentice's average attributes
+	var/apprentice_avg = 40
+	var/total_app = 0
+	var/count_app = 0
+	for(var/attr_name in list(FORTITUDE_ATTRIBUTE, PRUDENCE_ATTRIBUTE, TEMPERANCE_ATTRIBUTE, JUSTICE_ATTRIBUTE))
+		var/datum/attribute/A = apprentice.attributes[attr_name]
+		if(A)
+			total_app += A.level
+			count_app++
+	if(count_app > 0)
+		apprentice_avg = total_app / count_app
+
+	// Calculate ratio and modifiers
+	var/ratio = 1.0
+	if(apprentice_avg > 0)
+		ratio = clamp(opponent_avg / apprentice_avg, 0.5, 2.5)
+	// Losses still give a meaningful chunk — early apprentices are expected to
+	// lose, so half-rewards keep progression flowing instead of stalling.
+	var/win_modifier = player_won ? 1.0 : 0.5
+	// Underleveled catch-up multiplier: stays active all the way to the 200
+	// cap so late stages still feel rewarding. 1.75x at 40 attrs, scales
+	// linearly down to 1.0x at 200 attrs.
+	var/underleveled_mult = clamp(1 + (200 - apprentice_avg) / 80, 1.0, 1.75)
+
+	// === ATTRIBUTE GROWTH ===
+	var/base_gain = 16
+	var/gain_per_attr = round(base_gain * ratio * underleveled_mult * win_modifier)
+	if(gain_per_attr > 0)
+		for(var/attr_name in list(FORTITUDE_ATTRIBUTE, PRUDENCE_ATTRIBUTE, TEMPERANCE_ATTRIBUTE, JUSTICE_ATTRIBUTE))
+			var/datum/attribute/A = apprentice.attributes[attr_name]
+			if(A)
+				A.level = min(200, A.level + gain_per_attr)
+				A.on_update(apprentice)
+		to_chat(apprentice, span_notice("You gained [gain_per_attr] to each attribute from the duel."))
+
+	// === EXP GROWTH ===
+	var/base_exp = 40
+	var/exp_gained = round(base_exp * ratio * underleveled_mult * win_modifier)
+	var/datum/component/palermitan_exp/exp_comp = apprentice.GetComponent(/datum/component/palermitan_exp)
+	if(exp_comp && exp_gained > 0)
+		exp_comp.modify_exp(exp_gained)
+
+	// === ROLE TRACKING + PASSIVE GRANTING ===
+	if(exp_comp)
+		var/role_name
+		// Check for association component first (regular association members have generic assigned_role)
+		if(ishuman(opponent_mob))
+			var/mob/living/carbon/human/HO = opponent_mob
+			var/datum/component/association_exp_comp = HO.GetComponent(/datum/component/association_exp)
+			if(association_exp_comp)
+				var/asso_type = association_exp_comp.vars["association_type"]
+				if(asso_type)
+					role_name = asso_type
+		// Fall back to assigned_role (works for roaming fixers with variant in name, and all other roles)
+		if(!role_name && opponent_mob?.mind)
+			role_name = opponent_mob.mind.assigned_role
+		if(role_name)
+			exp_comp.increment_role_duel(role_name)
+			grant_role_passive(apprentice, role_name, exp_comp.get_role_duel_count(role_name))
+
+	// === GEAR TIER-UP CHECK ===
+	check_gear_tierup(apprentice)
+
+	// === CORRECTION ELIGIBILITY (on loss) ===
+	if(!player_won)
+		var/datum/component/palermitan_apprentice/pal = apprentice.GetComponent(/datum/component/palermitan_apprentice)
+		if(pal)
+			pal.correction_eligible = TRUE
+			pal.correction_deadline = world.time + 1.5 MINUTES
+			// Store what a correction would grant (0.25x of win value, also
+			// benefits from the underleveled catch-up multiplier)
+			var/correction_gain = round(base_gain * ratio * underleveled_mult * 0.25)
+			pal.potential_correction_attrs = correction_gain
+			to_chat(apprentice, span_info("Your mentor can correct you within 1.5 minutes for additional attribute growth."))
+
+	// === OPPONENT REWARDS ===
+	// Non-apprentice opponent gets Ahn + Fortitude for participating
+	if(ishuman(opponent_mob) && !istype(opponent_mob, /mob/living/simple_animal/hostile/palermitan_dummy))
+		var/mob/living/carbon/human/opp = opponent_mob
+		var/opponent_won = (winner == opponent_mob)
+
+		// Determine apprentice gear tier for scaling
+		var/app_tier = 1
+		var/list/found_katanas = _find_apprentice_gear(apprentice, /obj/item/ego_weapon/city/thumbapprentice_katana)
+		for(var/obj/item/ego_weapon/city/thumbapprentice_katana/K in found_katanas)
+			app_tier = K.tier
+			break
+
+		// Ahn reward
+		var/ahn_reward = 0
+		if(opponent_won)
+			ahn_reward = 500 + (app_tier * 125)
+		else
+			ahn_reward = 100 + (app_tier * 37)
+		if(ahn_reward > 0)
+			var/obj/item/card/id/C = opp.get_idcard(TRUE)
+			if(C?.registered_account)
+				C.registered_account.adjust_money(ahn_reward)
+				to_chat(opp, span_notice("You earned [ahn_reward] ahn from the duel."))
+
+		// Fortitude reward (capped at +20 total from dueling)
+		var/fort_gain = opponent_won ? 3 : 1
+		var/opp_ckey = opp.ckey
+		if(opp_ckey)
+			if(!(opp_ckey in GLOB.duel_fort_rewards))
+				GLOB.duel_fort_rewards[opp_ckey] = 0
+			var/current_total = GLOB.duel_fort_rewards[opp_ckey]
+			if(current_total < 20)
+				fort_gain = min(fort_gain, 20 - current_total)
+				if(fort_gain > 0)
+					// Check if opponent is a civilian — if so, boost all 4 attributes
+					var/is_civilian = FALSE
+					if(opp.mind?.assigned_role && findtext(opp.mind.assigned_role, "Civilian"))
+						is_civilian = TRUE
+					if(is_civilian)
+						for(var/attr_name in list(FORTITUDE_ATTRIBUTE, PRUDENCE_ATTRIBUTE, TEMPERANCE_ATTRIBUTE, JUSTICE_ATTRIBUTE))
+							var/datum/attribute/A = opp.attributes[attr_name]
+							if(A)
+								A.level += fort_gain
+								A.on_update(opp)
+						to_chat(opp, span_boldnotice("The duel sharpened all of your abilities! (+[fort_gain] to all attributes)"))
+					else
+						var/datum/attribute/fort_attr = opp.attributes[FORTITUDE_ATTRIBUTE]
+						if(fort_attr)
+							fort_attr.level += fort_gain
+							fort_attr.on_update(opp)
+						to_chat(opp, span_boldnotice("The duel toughened you up! (+[fort_gain] Fortitude)"))
+					GLOB.duel_fort_rewards[opp_ckey] += fort_gain
+
+		// Association EXP reward — mirrors apprentice's EXP gain
+		var/datum/component/association_exp/asso_exp = opp.GetComponent(/datum/component/association_exp)
+		if(asso_exp && exp_gained > 0)
+			asso_exp.modify_exp(exp_gained)
+			to_chat(opp, span_notice("The duel honed your skills! (+[exp_gained] Association EXP)"))
+
+/// Finds apprentice gear of the given type in the apprentice's inventory or
+/// dropped on nearby turfs (range 3). Dropped-on-crit gear would otherwise be
+/// missed by a plain GetAllContents() walk.
+/proc/_find_apprentice_gear(mob/living/carbon/human/apprentice, gear_type)
+	. = list()
+	if(!istype(apprentice))
+		return
+	for(var/obj/item/I in apprentice.GetAllContents())
+		if(istype(I, gear_type))
+			. += I
+	var/turf/T = get_turf(apprentice)
+	if(T)
+		for(var/obj/item/I in range(3, T))
+			if(istype(I, gear_type) && !(I in .))
+				. += I
+
+/// Checks if the apprentice's attributes warrant a gear tier-up
+/proc/check_gear_tierup(mob/living/carbon/human/apprentice)
+	if(!istype(apprentice))
+		return
+	// Get the minimum attribute level (all 4 must meet the threshold)
+	var/min_attr = INFINITY
+	for(var/attr_name in list(FORTITUDE_ATTRIBUTE, PRUDENCE_ATTRIBUTE, TEMPERANCE_ATTRIBUTE, JUSTICE_ATTRIBUTE))
+		var/datum/attribute/A = apprentice.attributes[attr_name]
+		if(A)
+			min_attr = min(min_attr, A.level)
+	if(min_attr == INFINITY)
+		return
+
+	// Determine what tier the attributes support: (attrs / 2) >= requirement
+	var/effective = round(min_attr / 2)
+	var/new_tier = 1
+	if(effective >= 100)
+		new_tier = 4
+	else if(effective >= 80)
+		new_tier = 3
+	else if(effective >= 60)
+		new_tier = 2
+
+	// Update weapons (inventory or dropped nearby)
+	for(var/obj/item/ego_weapon/city/thumbapprentice_katana/K in _find_apprentice_gear(apprentice, /obj/item/ego_weapon/city/thumbapprentice_katana))
+		if(K.tier < new_tier)
+			K.set_tier(new_tier)
+			to_chat(apprentice, span_boldnotice("Your katana has evolved to tier [new_tier]!"))
+	for(var/obj/item/ego_weapon/city/thumbapprentice_greatsword/G in _find_apprentice_gear(apprentice, /obj/item/ego_weapon/city/thumbapprentice_greatsword))
+		if(G.tier < new_tier)
+			G.set_tier(new_tier)
+			to_chat(apprentice, span_boldnotice("Your greatsword has evolved to tier [new_tier]!"))
+	// Update armor (worn, carried, or dropped nearby)
+	var/armor_announced = FALSE
+	for(var/obj/item/clothing/suit/armor/ego_gear/city/thumb_spider/apprentice/A in _find_apprentice_gear(apprentice, /obj/item/clothing/suit/armor/ego_gear/city/thumb_spider/apprentice))
+		if(A.tier < new_tier)
+			A.set_tier(new_tier)
+			if(!armor_announced)
+				to_chat(apprentice, span_boldnotice("Your armor has evolved to tier [new_tier]!"))
+				armor_announced = TRUE
+
+	// At 150+ attributes: grant Nursefather Passive (evasion from endured pain)
+	if(min_attr >= 150 && !apprentice.GetComponent(/datum/component/nursefather_passive))
+		apprentice.AddComponent(/datum/component/nursefather_passive)
+		to_chat(apprentice, span_boldnotice("The pain you've endured has sharpened your instincts. You gain precognitive evasion!"))
+		to_chat(apprentice, span_notice("You now automatically dodge the first attack every 30 seconds, and have a 50% chance to dodge when unarmed. However, all damage you take inflicts 5% unhealable damage."))
+
+////////////////////////////////////////////////////////////
+// ROLE PASSIVE GRANTING
+
+/// Maps role names to passive component type paths
+/proc/get_role_passive_type(role_name)
+	// Map common role names/variants to passive types
+	// Syndicate factions
+	if(findtext(role_name, "Thumb") || findtext(role_name, "Soldato") || findtext(role_name, "Capo") || findtext(role_name, "Sottocapo"))
+		return /datum/component/palermitan_role_passive/thumb
+	if(findtext(role_name, "Kurokumo") || findtext(role_name, "Wakashu") || findtext(role_name, "Hosa") || findtext(role_name, "Kashira"))
+		return /datum/component/palermitan_role_passive/kurokumo
+	if(findtext(role_name, "Index") || findtext(role_name, "Proxy") || findtext(role_name, "Proselyte") || findtext(role_name, "Messenger"))
+		return /datum/component/palermitan_role_passive/index
+	if(findtext(role_name, "Insurgence") || findtext(role_name, "Nightwatch") || findtext(role_name, "Transport"))
+		return /datum/component/palermitan_role_passive/insurgence
+	if(findtext(role_name, "Brother") || findtext(role_name, "Middle"))
+		return /datum/component/palermitan_role_passive/middle
+	if(findtext(role_name, "N-Corp") || findtext(role_name, "Hammer") || findtext(role_name, "Inquisitor") || findtext(role_name, "Nagel"))
+		return /datum/component/palermitan_role_passive/ncorp
+	if(findtext(role_name, "Blade Lineage") || findtext(role_name, "Salsu") || findtext(role_name, "Cutthroat"))
+		return /datum/component/palermitan_role_passive/blade_lineage
+	// City roles
+	if(findtext(role_name, "Butcher"))
+		return /datum/component/palermitan_role_passive/butcher
+	if(findtext(role_name, "Rat"))
+		return /datum/component/palermitan_role_passive/rat
+	if(findtext(role_name, "Carnival"))
+		return /datum/component/palermitan_role_passive/carnival
+	// Association roles
+	if(findtext(role_name, "Zwei"))
+		return /datum/component/palermitan_role_passive/zwei
+	if(findtext(role_name, "Seven"))
+		return /datum/component/palermitan_role_passive/seven
+	if(findtext(role_name, "Dieci"))
+		return /datum/component/palermitan_role_passive/dieci
+	if(findtext(role_name, "Cinq"))
+		return /datum/component/palermitan_role_passive/cinq
+	if(findtext(role_name, "Shi"))
+		return /datum/component/palermitan_role_passive/shi
+	if(findtext(role_name, "Liu"))
+		return /datum/component/palermitan_role_passive/liu
+	if(findtext(role_name, "Devyat"))
+		return /datum/component/palermitan_role_passive/devyat
+	if(findtext(role_name, "Hana"))
+		return /datum/component/palermitan_role_passive/hana
+	return null
+
+/// Grants or upgrades a role passive based on duel count
+/proc/grant_role_passive(mob/living/carbon/human/apprentice, role_name, duel_count)
+	var/passive_type = get_role_passive_type(role_name)
+	if(!passive_type)
+		return
+	// Determine tier from duel count
+	var/new_tier = 1
+	if(duel_count >= 5)
+		new_tier = 3
+	else if(duel_count >= 3)
+		new_tier = 2
+	// Check if we already have this passive
+	var/datum/component/palermitan_role_passive/existing = locate(passive_type) in apprentice.GetComponents(/datum/component/palermitan_role_passive)
+	if(existing)
+		if(existing.tier >= new_tier)
+			return
+		// Upgrade: remove old, add new at higher tier
+		qdel(existing)
+	apprentice.AddComponent(passive_type, new_tier)
+	to_chat(apprentice, span_boldnotice("Role passive unlocked/upgraded! (Tier [new_tier])"))
+
+////////////////////////////////////////////////////////////
+// DUEL WALL EFFECT
+
+/// Visual barrier for the duel arena border — NOT dense, ends duel on contact
+/obj/effect/temp_visual/duel_wall
+	name = "duel barrier"
+	desc = "A shimmering barrier marking the edge of a duel."
+	icon = 'icons/turf/walls/hierophant_wall_temp.dmi'
+	icon_state = "hierophant_wall_temp-0"
+	base_icon_state = "hierophant_wall_temp"
+	smoothing_flags = SMOOTH_BITMASK
+	smoothing_groups = list(SMOOTH_GROUP_HIERO_WALL)
+	canSmoothWith = list(SMOOTH_GROUP_HIERO_WALL)
+	duration = 6 SECONDS
+	layer = BELOW_MOB_LAYER
+	density = FALSE
+	anchored = TRUE
+	color = "#c4a000"
+	light_range = MINIMUM_USEFUL_LIGHT_RANGE
+	light_color = "#c4a000"
+	/// Reference to the duel datum
+	var/datum/thumb_duel/duel_ref
+
+/obj/effect/temp_visual/duel_wall/Initialize(mapload)
+	. = ..()
+	if(smoothing_flags & (SMOOTH_CORNERS|SMOOTH_BITMASK))
+		QUEUE_SMOOTH_NEIGHBORS(src)
+		QUEUE_SMOOTH(src)
+
+/obj/effect/temp_visual/duel_wall/Destroy()
+	if(smoothing_flags & (SMOOTH_CORNERS|SMOOTH_BITMASK))
+		QUEUE_SMOOTH_NEIGHBORS(src)
+	duel_ref = null
+	return ..()
+
+/// When a duel participant steps on the barrier, they lose
+/obj/effect/temp_visual/duel_wall/Crossed(atom/movable/crossing)
+	. = ..()
+	if(!duel_ref || !duel_ref.active)
+		return
+	if(!isliving(crossing))
+		return
+	var/mob/living/crosser = crossing
+	if(crosser == duel_ref.challenger || crosser == duel_ref.opponent)
+		duel_ref.on_barrier_crossed(crosser)
+
+////////////////////////////////////////////////////////////
+// DUEL CHALLENGE ACTION
+
+/// Action button granted to Thumb Apprentices to challenge players/dummies to duels
+/datum/action/innate/thumb_duel_challenge
+	name = "Challenge to Duel"
+	desc = "Challenge a nearby player or dummy to a duel."
+	button_icon_state = "yourswordinhand"
+	/// Active duel (only one at a time)
+	var/datum/thumb_duel/current_duel
+
+/datum/action/innate/thumb_duel_challenge/Activate()
+	var/mob/living/carbon/human/user = owner
+	if(!istype(user))
+		return
+	if(current_duel?.active)
+		to_chat(user, span_warning("You are already in a duel!"))
+		return
+
+	// Find nearby valid targets (humans + dummies)
+	var/list/nearby = list()
+	for(var/mob/living/carbon/human/H in view(7, user))
+		if(H != user && H.stat == CONSCIOUS)
+			nearby += H
+	for(var/mob/living/simple_animal/hostile/palermitan_dummy/D in view(7, user))
+		if(D.stat == CONSCIOUS)
+			nearby += D
+	if(!length(nearby))
+		to_chat(user, span_warning("No valid targets nearby."))
+		return
+
+	var/mob/living/target = tgui_input_list(user, "Who do you challenge?", "Duel Challenge", nearby)
+	if(!target || QDELETED(target) || QDELETED(user))
+		return
+	if(get_dist(user, target) > 7)
+		to_chat(user, span_warning("[target] is too far away."))
+		return
+
+	// Dummies auto-accept
+	if(istype(target, /mob/living/simple_animal/hostile/palermitan_dummy))
+		current_duel = new /datum/thumb_duel(user, target)
+		current_duel.start_duel()
+		return
+
+	// Challenge a human player
+	to_chat(target, span_boldnotice("[user] challenges you to a duel!"))
+	var/response = tgui_alert(target, "[user] challenges you to a duel. Accept?", "Duel Challenge", list("Accept", "Decline"))
+	if(response != "Accept")
+		to_chat(user, span_warning("[target] declined your challenge."))
+		return
+	// Validate both still ok
+	if(QDELETED(user) || QDELETED(target) || user.stat != CONSCIOUS || target.stat != CONSCIOUS)
+		return
+	if(get_dist(user, target) > 12)
+		to_chat(user, span_warning("[target] is too far away now."))
+		return
+
+	current_duel = new /datum/thumb_duel(user, target)
+	current_duel.start_duel()

--- a/ModularLobotomy/thumb_spider/palermitan_duel.dm
+++ b/ModularLobotomy/thumb_spider/palermitan_duel.dm
@@ -1,8 +1,6 @@
-////////////////////////////////////////////////////////////
 // PALERMITAN DUEL SYSTEM
 // PvP duel system for Thumb Apprentice progression.
 // Creates an arena ring, detects win/loss, grants rewards.
-////////////////////////////////////////////////////////////
 
 /// Tracks total Fortitude gained from dueling, keyed by ckey. Caps at 20.
 GLOBAL_LIST_INIT(duel_fort_rewards, list())
@@ -25,7 +23,6 @@ GLOBAL_LIST_INIT(duel_fort_rewards, list())
 	/// Fake attributes for reward calculation (simple_animals don't have real attributes)
 	var/fake_attributes = 100
 
-////////////////////////////////////////////////////////////
 // DUEL DATUM
 /datum/thumb_duel
 	/// The player who initiated the duel (usually the apprentice)
@@ -81,6 +78,8 @@ GLOBAL_LIST_INIT(duel_fort_rewards, list())
 	// Register signals for win/loss detection
 	RegisterSignal(challenger, COMSIG_MOB_STATCHANGE, PROC_REF(on_challenger_stat_change))
 	RegisterSignal(opponent, COMSIG_MOB_STATCHANGE, PROC_REF(on_opponent_stat_change))
+	RegisterSignal(challenger, COMSIG_PARENT_QDELETING, PROC_REF(on_challenger_deleted))
+	RegisterSignal(opponent, COMSIG_PARENT_QDELETING, PROC_REF(on_opponent_deleted))
 
 	// Spawn arena walls and start check loop
 	spawn_arena_walls()
@@ -106,7 +105,7 @@ GLOBAL_LIST_INIT(duel_fort_rewards, list())
 			wall.duel_ref = src
 			arena_walls += wall
 
-/// Periodic check loop — refreshes walls (they're temp_visuals and expire)
+/// Periodic check loop - refreshes walls (they're temp_visuals and expire)
 /datum/thumb_duel/proc/arena_check_loop()
 	if(!active)
 		return
@@ -125,6 +124,18 @@ GLOBAL_LIST_INIT(duel_fort_rewards, list())
 	if(new_stat >= SOFT_CRIT)
 		INVOKE_ASYNC(src, PROC_REF(end_duel), challenger, opponent, "was defeated")
 
+/// Signal handler: challenger was deleted, so the opponent takes the win
+/datum/thumb_duel/proc/on_challenger_deleted(datum/source)
+	SIGNAL_HANDLER
+	challenger = null
+	INVOKE_ASYNC(src, PROC_REF(end_duel), opponent, null, "vanished")
+
+/// Signal handler: opponent was deleted, so the challenger takes the win
+/datum/thumb_duel/proc/on_opponent_deleted(datum/source)
+	SIGNAL_HANDLER
+	opponent = null
+	INVOKE_ASYNC(src, PROC_REF(end_duel), challenger, null, "vanished")
+
 /// Called by duel_wall when a participant steps on the barrier
 /datum/thumb_duel/proc/on_barrier_crossed(mob/living/crosser)
 	if(!active)
@@ -142,7 +153,7 @@ GLOBAL_LIST_INIT(duel_fort_rewards, list())
 
 	// Announce result
 	if(winner && !QDELETED(winner))
-		to_chat(winner, span_boldnotice("You won the duel! [loser] [reason]."))
+		to_chat(winner, span_boldnotice("You won the duel! [loser ? "[loser]" : "Your opponent"] [reason]."))
 	if(loser && !QDELETED(loser))
 		to_chat(loser, span_boldwarning("You lost the duel."))
 
@@ -165,17 +176,16 @@ GLOBAL_LIST_INIT(duel_fort_rewards, list())
 
 /// Cleans up signals, timers, and arena walls
 /datum/thumb_duel/proc/cleanup()
-	if(challenger && !QDELETED(challenger))
-		UnregisterSignal(challenger, COMSIG_MOB_STATCHANGE)
-	if(opponent && !QDELETED(opponent))
-		UnregisterSignal(opponent, COMSIG_MOB_STATCHANGE)
+	if(challenger)
+		UnregisterSignal(challenger, list(COMSIG_MOB_STATCHANGE, COMSIG_PARENT_QDELETING))
+	if(opponent)
+		UnregisterSignal(opponent, list(COMSIG_MOB_STATCHANGE, COMSIG_PARENT_QDELETING))
 	deltimer(check_timer)
 	for(var/obj/effect/temp_visual/duel_wall/W in arena_walls)
 		if(!QDELETED(W))
 			qdel(W)
 	arena_walls.Cut()
 
-////////////////////////////////////////////////////////////
 // DUEL REWARDS (Step 6)
 
 /// Grants attribute growth, EXP, and role tracking after a duel
@@ -234,16 +244,13 @@ GLOBAL_LIST_INIT(duel_fort_rewards, list())
 		apprentice_avg = total_app / count_app
 
 	// Calculate ratio and modifiers
-	var/ratio = 1.0
+	var/ratio = 1
 	if(apprentice_avg > 0)
 		ratio = clamp(opponent_avg / apprentice_avg, 0.5, 2.5)
-	// Losses still give a meaningful chunk — early apprentices are expected to
-	// lose, so half-rewards keep progression flowing instead of stalling.
-	var/win_modifier = player_won ? 1.0 : 0.5
-	// Underleveled catch-up multiplier: stays active all the way to the 200
-	// cap so late stages still feel rewarding. 1.75x at 40 attrs, scales
-	// linearly down to 1.0x at 200 attrs.
-	var/underleveled_mult = clamp(1 + (200 - apprentice_avg) / 80, 1.0, 1.75)
+	// Half-rewards on a loss keep early progression from stalling
+	var/win_modifier = player_won ? 1 : 0.5
+	// Catch-up multiplier: 1.75x at 40 attrs, scaling to 1x at the 200 cap
+	var/underleveled_mult = clamp(1 + (200 - apprentice_avg) / 80, 1, 1.75)
 
 	// Dueling the nursefather gives severely reduced rewards (training, not real combat)
 	var/is_nursefather_duel = FALSE
@@ -341,7 +348,7 @@ GLOBAL_LIST_INIT(duel_fort_rewards, list())
 			if(current_total < 20)
 				fort_gain = min(fort_gain, 20 - current_total)
 				if(fort_gain > 0)
-					// Check if opponent is a civilian — if so, boost all 4 attributes
+					// Check if opponent is a civilian - if so, boost all 4 attributes
 					var/is_civilian = FALSE
 					if(opp.mind?.assigned_role && findtext(opp.mind.assigned_role, "Civilian"))
 						is_civilian = TRUE
@@ -360,7 +367,7 @@ GLOBAL_LIST_INIT(duel_fort_rewards, list())
 						to_chat(opp, span_boldnotice("The duel toughened you up! (+[fort_gain] Fortitude)"))
 					GLOB.duel_fort_rewards[opp_ckey] += fort_gain
 
-		// Association EXP reward — mirrors apprentice's EXP gain
+		// Association EXP reward - mirrors apprentice's EXP gain
 		var/datum/component/association_exp/asso_exp = opp.GetComponent(/datum/component/association_exp)
 		if(asso_exp && exp_gained > 0)
 			asso_exp.modify_exp(exp_gained)
@@ -422,7 +429,6 @@ GLOBAL_LIST_INIT(duel_fort_rewards, list())
 				to_chat(apprentice, span_boldnotice("Your armor has evolved to tier [new_tier]!"))
 				armor_announced = TRUE
 
-////////////////////////////////////////////////////////////
 // ROLE PASSIVE GRANTING
 
 /// Maps role names to passive component type paths
@@ -490,10 +496,9 @@ GLOBAL_LIST_INIT(duel_fort_rewards, list())
 	apprentice.AddComponent(passive_type, new_tier)
 	to_chat(apprentice, span_boldnotice("Role passive unlocked/upgraded! (Tier [new_tier])"))
 
-////////////////////////////////////////////////////////////
 // DUEL WALL EFFECT
 
-/// Visual barrier for the duel arena border — NOT dense, ends duel on contact
+/// Visual barrier for the duel arena border - NOT dense, ends duel on contact
 /obj/effect/temp_visual/duel_wall
 	name = "duel barrier"
 	desc = "A shimmering barrier marking the edge of a duel."
@@ -536,7 +541,6 @@ GLOBAL_LIST_INIT(duel_fort_rewards, list())
 	if(crosser == duel_ref.challenger || crosser == duel_ref.opponent)
 		duel_ref.on_barrier_crossed(crosser)
 
-////////////////////////////////////////////////////////////
 // DUEL CHALLENGE ACTION
 
 /// Action button granted to Thumb Apprentices to challenge players/dummies to duels

--- a/ModularLobotomy/thumb_spider/palermitan_exp.dm
+++ b/ModularLobotomy/thumb_spider/palermitan_exp.dm
@@ -1,4 +1,4 @@
-/// Palermitan EXP Component — tracks EXP, skill points, and role duel counts for the apprentice.
+/// Palermitan EXP Component - tracks EXP, skill points, and role duel counts for the apprentice.
 /datum/component/palermitan_exp
 	/// Total accumulated EXP (never decreases)
 	var/exp = 0

--- a/ModularLobotomy/thumb_spider/palermitan_exp.dm
+++ b/ModularLobotomy/thumb_spider/palermitan_exp.dm
@@ -1,1 +1,122 @@
-// Stub - populated by the Thumb sub-PR
+/// Palermitan EXP Component — tracks EXP, skill points, and role duel counts for the apprentice.
+/datum/component/palermitan_exp
+	/// Total accumulated EXP (never decreases)
+	var/exp = 0
+	/// Available skill points to spend
+	var/skill_points = 0
+	/// Skill points already spent
+	var/skill_points_spent = 0
+	/// Associative list: role name -> duel count (e.g. "Butcher" = 3)
+	var/list/role_duel_counts = list()
+	/// List of school IDs the player has invested points in
+	var/list/schools_invested = list()
+	/// Maximum number of schools that can be invested in
+	var/max_schools = 3
+
+	/// EXP thresholds for earning skill points. 18 entries = enough for 3 full
+	/// schools (1+2+3 = 6 SP per school x 3 schools = 18 SP).
+	/// Pacing: 1 school by ~duel 6, 2 schools by ~duel 13 (at 200 attrs),
+	/// 3 schools by ~duel 26. See duel reward math in palermitan_duel.dm.
+	var/static/list/exp_thresholds = list(
+		25,
+		55,
+		90,
+		130,
+		170,
+		210,
+		245,
+		280,
+		315,
+		345,
+		375,
+		400,
+		430,
+		460,
+		490,
+		520,
+		560,
+		600,
+	)
+
+/datum/component/palermitan_exp/Initialize()
+	if(!ishuman(parent))
+		return COMPONENT_INCOMPATIBLE
+
+/// Add EXP (positive only). Checks for new skill points.
+/datum/component/palermitan_exp/proc/modify_exp(amount)
+	if(amount <= 0)
+		return
+	exp += amount
+	check_skill_points()
+	// Notify the player
+	var/mob/living/L = parent
+	if(L)
+		to_chat(L, span_notice("You gained [amount] Palermitan EXP! (Total: [exp])"))
+
+/// Checks if we've earned new skill points from crossing EXP thresholds.
+/datum/component/palermitan_exp/proc/check_skill_points()
+	var/total_points_earned = 0
+	for(var/i in 1 to length(exp_thresholds))
+		if(exp >= exp_thresholds[i])
+			total_points_earned = i
+		else
+			break
+	var/new_points = total_points_earned - skill_points_spent
+	if(new_points > skill_points)
+		var/gained = new_points - skill_points
+		skill_points = new_points
+		var/mob/living/L = parent
+		if(L && gained > 0)
+			to_chat(L, span_boldnotice("You earned [gained] new skill point[gained > 1 ? "s" : ""]! (Available: [skill_points])"))
+
+/// Spend skill points. Returns TRUE if successful.
+/datum/component/palermitan_exp/proc/spend_skill_point(cost = 1)
+	if(skill_points < cost)
+		return FALSE
+	skill_points -= cost
+	skill_points_spent += cost
+	return TRUE
+
+/// Get the next EXP threshold needed for the next skill point.
+/datum/component/palermitan_exp/proc/get_next_threshold()
+	var/total_points = skill_points + skill_points_spent
+	if(total_points >= length(exp_thresholds))
+		return exp_thresholds[length(exp_thresholds)]
+	return exp_thresholds[total_points + 1]
+
+/// Get the current EXP threshold (the one we just passed).
+/datum/component/palermitan_exp/proc/get_current_threshold()
+	var/total_points = skill_points + skill_points_spent
+	if(total_points <= 0)
+		return 0
+	if(total_points > length(exp_thresholds))
+		return exp_thresholds[length(exp_thresholds)]
+	return exp_thresholds[total_points]
+
+/// Increment the duel count for a specific role.
+/datum/component/palermitan_exp/proc/increment_role_duel(role_name)
+	if(!role_name)
+		return
+	if(!(role_name in role_duel_counts))
+		role_duel_counts[role_name] = 0
+	role_duel_counts[role_name] += 1
+	var/mob/living/L = parent
+	if(L)
+		to_chat(L, span_notice("Duel count vs [role_name]: [role_duel_counts[role_name]]"))
+
+/// Get the duel count for a specific role.
+/datum/component/palermitan_exp/proc/get_role_duel_count(role_name)
+	if(!(role_name in role_duel_counts))
+		return 0
+	return role_duel_counts[role_name]
+
+/// Check if the player can invest in a new school (hasn't hit max, or already invested in this one).
+/datum/component/palermitan_exp/proc/can_invest_in_school(school_id)
+	if(school_id in schools_invested)
+		return TRUE
+	return length(schools_invested) < max_schools
+
+/// Register that the player has invested in a school.
+/datum/component/palermitan_exp/proc/invest_in_school(school_id)
+	if(!(school_id in schools_invested))
+		schools_invested += school_id

--- a/ModularLobotomy/thumb_spider/palermitan_role_passives.dm
+++ b/ModularLobotomy/thumb_spider/palermitan_role_passives.dm
@@ -3,7 +3,7 @@
 // Tiers unlock at 1, 3, 5 duels against that role.
 // All passives use only vars + world.time checks, no timers.
 
-/// Base role passive component — all role passives inherit from this
+/// Base role passive component - all role passives inherit from this
 /datum/component/palermitan_role_passive
 	/// Reference to the human parent
 	var/mob/living/carbon/human/human_parent
@@ -39,8 +39,7 @@
 /datum/component/palermitan_role_passive/proc/set_tier(new_tier)
 	tier = clamp(new_tier, 1, 3)
 
-////////////////////////////////////////////////////////////
-// BUTCHER — "Predator's Instinct"
+// BUTCHER - "Predator's Instinct"
 // On Hit vs <50% HP: +5/10/15% bonus damage. T3: also heal 3 HP
 /datum/component/palermitan_role_passive/butcher
 
@@ -68,8 +67,7 @@
 	if(!QDELETED(weapon))
 		weapon.force -= bonus
 
-////////////////////////////////////////////////////////////
-// BLADE LINEAGE — "Resolve of the Salsu"
+// BLADE LINEAGE - "Resolve of the Salsu"
 // Below 30% HP: +10/15/20% damage. T3: attacks cannot be dodged
 /datum/component/palermitan_role_passive/blade_lineage
 
@@ -95,8 +93,7 @@
 	if(!QDELETED(weapon))
 		weapon.force -= bonus
 
-////////////////////////////////////////////////////////////
-// THUMB — "Soldato's Discipline"
+// THUMB - "Soldato's Discipline"
 // On taking RED damage: +2/3/3 DLU. T3: also +1 OLU
 /datum/component/palermitan_role_passive/thumb
 
@@ -124,8 +121,7 @@
 	else
 		user.apply_lc_defense_level_up(2)
 
-////////////////////////////////////////////////////////////
-// KUROKUMO — "Way of the Drawn Blade"
+// KUROKUMO - "Way of the Drawn Blade"
 // On Hit: +1 Poise. T2: crits +5% damage. T3: +10% crit damage + crits inflict 2 Tremor
 /datum/component/palermitan_role_passive/kurokumo
 
@@ -159,8 +155,7 @@
 			target.deal_damage(extra, RED_DAMAGE, source = parent, attack_type = ATTACK_TYPE_MELEE)
 		target.apply_lc_tremor(2, INFINITY)
 
-////////////////////////////////////////////////////////////
-// INDEX — "Prescript Discipline"
+// INDEX - "Prescript Discipline"
 // On Hit: 1 OLD. T2: +1 DLD. T3: 2 OLD +1 DLD
 /datum/component/palermitan_role_passive/index
 
@@ -176,8 +171,7 @@
 	else
 		target.apply_lc_offense_level_down(1)
 
-////////////////////////////////////////////////////////////
-// INSURGENCE — "Nightwatch Tremors"
+// INSURGENCE - "Nightwatch Tremors"
 // On Hit: 15/20/25% chance for 1/1/2 Tremor (no burst). T3: +5% dmg vs 10+ Tremor
 /datum/component/palermitan_role_passive/insurgence
 
@@ -194,8 +188,7 @@
 	if(prob(chance))
 		target.apply_lc_tremor(tremor_amount, INFINITY)
 
-////////////////////////////////////////////////////////////
-// MIDDLE — "Vengeance Mark"
+// MIDDLE - "Vengeance Mark"
 // On taking melee damage: +3/5/8% damage next attack. T3: counter inflicts 1 DE
 /datum/component/palermitan_role_passive/middle
 	var/buffed_next_hit = FALSE
@@ -238,8 +231,7 @@
 	if(!QDELETED(weapon))
 		weapon.force -= bonus
 
-////////////////////////////////////////////////////////////
-// N-CORP — "Methodical Strikes"
+// N-CORP - "Methodical Strikes"
 // On Hit: 1/1/2 DLD + 1/2/2 Overheat
 /datum/component/palermitan_role_passive/ncorp
 
@@ -256,8 +248,7 @@
 		target.apply_lc_defense_level_down(1)
 		target.apply_lc_overheat(1)
 
-////////////////////////////////////////////////////////////
-// RAT — "Scavenger's Luck"
+// RAT - "Scavenger's Luck"
 // On Hit: 5/8/10% chance +50% bonus damage. T3: lucky strikes +2 Tremor
 /datum/component/palermitan_role_passive/rat
 
@@ -283,8 +274,7 @@
 	if(!QDELETED(weapon))
 		weapon.force -= bonus
 
-////////////////////////////////////////////////////////////
-// CARNIVAL — "Silk Hunter's Patience"
+// CARNIVAL - "Silk Hunter's Patience"
 // After 3+ sec without attacking: next hit +10/20/30% damage. T3: +2 Overheat
 /datum/component/palermitan_role_passive/carnival
 	var/last_attack_time = 0
@@ -313,8 +303,7 @@
 	if(!QDELETED(weapon))
 		weapon.force -= bonus
 
-////////////////////////////////////////////////////////////
-// ZWEI — "Guardian's Resilience"
+// ZWEI - "Guardian's Resilience"
 // On taking damage: +2/3/3 DLU. T3: +1 OLD on attacker
 /datum/component/palermitan_role_passive/zwei
 
@@ -344,8 +333,7 @@
 	else
 		user.apply_lc_defense_level_up(2)
 
-////////////////////////////////////////////////////////////
-// SEVEN — "Analyst's Eye"
+// SEVEN - "Analyst's Eye"
 // On Hit vs debuffed target: +1/2/2 OLU. T3: +1 DE
 /datum/component/palermitan_role_passive/seven
 
@@ -377,8 +365,7 @@
 	if(tier >= 3)
 		target.apply_duel_escalates(1, user)
 
-////////////////////////////////////////////////////////////
-// DIECI — "Scholar's Insight"
+// DIECI - "Scholar's Insight"
 // On Hit: +3/5/7% damage per distinct debuff type on target (max 4 types)
 /datum/component/palermitan_role_passive/dieci
 
@@ -412,8 +399,7 @@
 	if(!QDELETED(weapon))
 		weapon.force -= bonus
 
-////////////////////////////////////////////////////////////
-// CINQ — "Duelist's Finesse" (roaming fixer only)
+// CINQ - "Duelist's Finesse" (roaming fixer only)
 // On Hit: +2/3/3 Poise. T3: halving crit +1 Concentration
 /datum/component/palermitan_role_passive/cinq
 	var/poise_before_crit = 0
@@ -448,8 +434,7 @@
 	if(poise_before_crit > 0 && poise_after < poise_before_crit * 0.75)
 		user.apply_lc_concentration(1)
 
-////////////////////////////////////////////////////////////
-// SHI — "Assassin's Sacrifice"
+// SHI - "Assassin's Sacrifice"
 // On Hit vs <30% HP (3s CD): +3/4/5 OLU, lose 3% max HP. T3: +2 Fragile
 /datum/component/palermitan_role_passive/shi
 	var/last_proc_time = 0
@@ -474,8 +459,7 @@
 	if(self_damage > 0)
 		user.adjustBruteLoss(self_damage)
 
-////////////////////////////////////////////////////////////
-// LIU — "Burning Fist"
+// LIU - "Burning Fist"
 // On Hit: +1 Overheat. T2: every 4th hit +2 extra. T3: every 3rd hit +3 extra
 /datum/component/palermitan_role_passive/liu
 	var/hit_count = 0
@@ -492,8 +476,7 @@
 		target.apply_lc_overheat(2)
 		hit_count = 0
 
-////////////////////////////////////////////////////////////
-// DEVYAT — "Berserker's Escalation"
+// DEVYAT - "Berserker's Escalation"
 // On Hit (3s CD): +2/3/3 OLU, lose 2% max HP. T3: below 50% HP also +2 DLU
 /datum/component/palermitan_role_passive/devyat
 	var/last_proc_time = 0
@@ -518,8 +501,7 @@
 		if(H.health < H.maxHealth * 0.5)
 			user.apply_lc_defense_level_up(2)
 
-////////////////////////////////////////////////////////////
-// HANA — "Adaptive Form"
+// HANA - "Adaptive Form"
 // On attacking with different weapon than last (5s CD): +2/2+2/3+2 OLU(+DLU)
 /datum/component/palermitan_role_passive/hana
 	var/obj/item/last_weapon_used
@@ -539,4 +521,16 @@
 				user.apply_lc_defense_level_up(2)
 			else
 				user.apply_lc_offense_level_up(2)
+	SetLastWeapon(weapon)
+
+/// Remembers the weapon this attack used, following its deletion
+/datum/component/palermitan_role_passive/hana/proc/SetLastWeapon(obj/item/weapon)
+	if(last_weapon_used)
+		UnregisterSignal(last_weapon_used, COMSIG_PARENT_QDELETING)
 	last_weapon_used = weapon
+	if(last_weapon_used)
+		RegisterSignal(last_weapon_used, COMSIG_PARENT_QDELETING, PROC_REF(on_weapon_deleted))
+
+/datum/component/palermitan_role_passive/hana/proc/on_weapon_deleted(datum/source)
+	SIGNAL_HANDLER
+	last_weapon_used = null

--- a/ModularLobotomy/thumb_spider/palermitan_role_passives.dm
+++ b/ModularLobotomy/thumb_spider/palermitan_role_passives.dm
@@ -1,1 +1,542 @@
-// Stub - populated by the Thumb sub-PR
+// Palermitan Role-Specific Passives
+// Each duelable role grants one passive with 3 tiers.
+// Tiers unlock at 1, 3, 5 duels against that role.
+// All passives use only vars + world.time checks, no timers.
+
+/// Base role passive component — all role passives inherit from this
+/datum/component/palermitan_role_passive
+	/// Reference to the human parent
+	var/mob/living/carbon/human/human_parent
+	/// Current tier (1-3), set externally based on duel count
+	var/tier = 1
+
+/datum/component/palermitan_role_passive/Initialize(_tier = 1)
+	. = ..()
+	if(!ishuman(parent))
+		return COMPONENT_INCOMPATIBLE
+	human_parent = parent
+	tier = _tier
+
+/datum/component/palermitan_role_passive/RegisterWithParent()
+	. = ..()
+	RegisterSignal(parent, COMSIG_MOB_ITEM_ATTACK, PROC_REF(on_attack))
+
+/datum/component/palermitan_role_passive/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_MOB_ITEM_ATTACK)
+	human_parent = null
+	. = ..()
+
+/datum/component/palermitan_role_passive/proc/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	SIGNAL_HANDLER
+	return
+
+/// Helper: get Duel Escalates stacks
+/datum/component/palermitan_role_passive/proc/get_duel_stacks(mob/living/target)
+	var/datum/status_effect/stacking/duel_escalates/D = target.has_status_effect(/datum/status_effect/stacking/duel_escalates)
+	return D ? D.stacks : 0
+
+/// Updates the tier. Called when duel count changes.
+/datum/component/palermitan_role_passive/proc/set_tier(new_tier)
+	tier = clamp(new_tier, 1, 3)
+
+////////////////////////////////////////////////////////////
+// BUTCHER — "Predator's Instinct"
+// On Hit vs <50% HP: +5/10/15% bonus damage. T3: also heal 3 HP
+/datum/component/palermitan_role_passive/butcher
+
+/datum/component/palermitan_role_passive/butcher/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	if(target.health > target.maxHealth * 0.5)
+		return
+	if(!weapon)
+		return
+	var/percent = 0.05
+	if(tier >= 3)
+		percent = 0.15
+	else if(tier >= 2)
+		percent = 0.10
+	var/bonus = round(weapon.force * percent)
+	if(bonus > 0)
+		weapon.force += bonus
+		INVOKE_ASYNC(src, PROC_REF(restore_force), weapon, bonus)
+	if(tier >= 3 && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		H.adjustBruteLoss(-3)
+
+/datum/component/palermitan_role_passive/butcher/proc/restore_force(obj/item/weapon, bonus)
+	if(!QDELETED(weapon))
+		weapon.force -= bonus
+
+////////////////////////////////////////////////////////////
+// BLADE LINEAGE — "Resolve of the Salsu"
+// Below 30% HP: +10/15/20% damage. T3: attacks cannot be dodged
+/datum/component/palermitan_role_passive/blade_lineage
+
+/datum/component/palermitan_role_passive/blade_lineage/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	if(!weapon || !ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	if(H.health > H.maxHealth * 0.3)
+		return
+	var/percent = 0.10
+	if(tier >= 3)
+		percent = 0.20
+	else if(tier >= 2)
+		percent = 0.15
+	var/bonus = round(weapon.force * percent)
+	if(bonus > 0)
+		weapon.force += bonus
+		INVOKE_ASYNC(src, PROC_REF(restore_force), weapon, bonus)
+
+/datum/component/palermitan_role_passive/blade_lineage/proc/restore_force(obj/item/weapon, bonus)
+	if(!QDELETED(weapon))
+		weapon.force -= bonus
+
+////////////////////////////////////////////////////////////
+// THUMB — "Soldato's Discipline"
+// On taking RED damage: +2/3/3 DLU. T3: also +1 OLU
+/datum/component/palermitan_role_passive/thumb
+
+/datum/component/palermitan_role_passive/thumb/RegisterWithParent()
+	. = ..()
+	RegisterSignal(parent, COMSIG_MOB_APPLY_DAMGE, PROC_REF(on_take_damage))
+
+/datum/component/palermitan_role_passive/thumb/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_MOB_APPLY_DAMGE)
+	. = ..()
+
+/datum/component/palermitan_role_passive/thumb/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	return
+
+/datum/component/palermitan_role_passive/thumb/proc/on_take_damage(datum/source, damage, damagetype, def_zone)
+	SIGNAL_HANDLER
+	if(!damage || damage <= 0 || damagetype != RED_DAMAGE)
+		return
+	var/mob/living/user = parent
+	if(tier >= 3)
+		user.apply_lc_defense_level_up(3)
+		user.apply_lc_offense_level_up(1)
+	else if(tier >= 2)
+		user.apply_lc_defense_level_up(3)
+	else
+		user.apply_lc_defense_level_up(2)
+
+////////////////////////////////////////////////////////////
+// KUROKUMO — "Way of the Drawn Blade"
+// On Hit: +1 Poise. T2: crits +5% damage. T3: +10% crit damage + crits inflict 2 Tremor
+/datum/component/palermitan_role_passive/kurokumo
+
+/datum/component/palermitan_role_passive/kurokumo/RegisterWithParent()
+	. = ..()
+	if(tier >= 2)
+		RegisterSignal(parent, COMSIG_POISE_CRIT_ATTACKER, PROC_REF(on_poise_crit))
+
+/datum/component/palermitan_role_passive/kurokumo/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_POISE_CRIT_ATTACKER)
+	. = ..()
+
+/datum/component/palermitan_role_passive/kurokumo/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	user.apply_lc_poise(1)
+
+/datum/component/palermitan_role_passive/kurokumo/proc/on_poise_crit(datum/source, mob/living/target, bonus_damage)
+	SIGNAL_HANDLER
+	if(!isliving(target))
+		return
+	// T2: deal extra RED damage equal to 5% of the crit's bonus damage
+	if(tier >= 2 && bonus_damage > 0)
+		var/extra = round(bonus_damage * 0.05)
+		if(extra > 0)
+			target.deal_damage(extra, RED_DAMAGE, source = parent, attack_type = ATTACK_TYPE_MELEE)
+	// T3: deal 10% instead of 5%, and crits inflict 2 Tremor
+	if(tier >= 3 && bonus_damage > 0)
+		var/extra = round(bonus_damage * 0.05)
+		if(extra > 0)
+			target.deal_damage(extra, RED_DAMAGE, source = parent, attack_type = ATTACK_TYPE_MELEE)
+		target.apply_lc_tremor(2, INFINITY)
+
+////////////////////////////////////////////////////////////
+// INDEX — "Prescript Discipline"
+// On Hit: 1 OLD. T2: +1 DLD. T3: 2 OLD +1 DLD
+/datum/component/palermitan_role_passive/index
+
+/datum/component/palermitan_role_passive/index/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	if(tier >= 3)
+		target.apply_lc_offense_level_down(2)
+		target.apply_lc_defense_level_down(1)
+	else if(tier >= 2)
+		target.apply_lc_offense_level_down(1)
+		target.apply_lc_defense_level_down(1)
+	else
+		target.apply_lc_offense_level_down(1)
+
+////////////////////////////////////////////////////////////
+// INSURGENCE — "Nightwatch Tremors"
+// On Hit: 15/20/25% chance for 1/1/2 Tremor (no burst). T3: +5% dmg vs 10+ Tremor
+/datum/component/palermitan_role_passive/insurgence
+
+/datum/component/palermitan_role_passive/insurgence/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	var/chance = 15
+	var/tremor_amount = 1
+	if(tier >= 3)
+		chance = 25
+		tremor_amount = 2
+	else if(tier >= 2)
+		chance = 20
+	if(prob(chance))
+		target.apply_lc_tremor(tremor_amount, INFINITY)
+
+////////////////////////////////////////////////////////////
+// MIDDLE — "Vengeance Mark"
+// On taking melee damage: +3/5/8% damage next attack. T3: counter inflicts 1 DE
+/datum/component/palermitan_role_passive/middle
+	var/buffed_next_hit = FALSE
+	var/buff_percent = 0
+
+/datum/component/palermitan_role_passive/middle/RegisterWithParent()
+	. = ..()
+	RegisterSignal(parent, COMSIG_MOB_APPLY_DAMGE, PROC_REF(on_take_damage))
+
+/datum/component/palermitan_role_passive/middle/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_MOB_APPLY_DAMGE)
+	. = ..()
+
+/datum/component/palermitan_role_passive/middle/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	if(!buffed_next_hit || !weapon)
+		return
+	buffed_next_hit = FALSE
+	var/bonus = round(weapon.force * buff_percent)
+	if(bonus > 0)
+		weapon.force += bonus
+		INVOKE_ASYNC(src, PROC_REF(restore_force), weapon, bonus)
+	if(tier >= 3)
+		target.apply_duel_escalates(1, user)
+
+/datum/component/palermitan_role_passive/middle/proc/on_take_damage(datum/source, damage, damagetype, def_zone)
+	SIGNAL_HANDLER
+	if(!damage || damage <= 0)
+		return
+	buffed_next_hit = TRUE
+	if(tier >= 3)
+		buff_percent = 0.08
+	else if(tier >= 2)
+		buff_percent = 0.05
+	else
+		buff_percent = 0.03
+
+/datum/component/palermitan_role_passive/middle/proc/restore_force(obj/item/weapon, bonus)
+	if(!QDELETED(weapon))
+		weapon.force -= bonus
+
+////////////////////////////////////////////////////////////
+// N-CORP — "Methodical Strikes"
+// On Hit: 1/1/2 DLD + 1/2/2 Overheat
+/datum/component/palermitan_role_passive/ncorp
+
+/datum/component/palermitan_role_passive/ncorp/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	if(tier >= 3)
+		target.apply_lc_defense_level_down(2)
+		target.apply_lc_overheat(2)
+	else if(tier >= 2)
+		target.apply_lc_defense_level_down(1)
+		target.apply_lc_overheat(2)
+	else
+		target.apply_lc_defense_level_down(1)
+		target.apply_lc_overheat(1)
+
+////////////////////////////////////////////////////////////
+// RAT — "Scavenger's Luck"
+// On Hit: 5/8/10% chance +50% bonus damage. T3: lucky strikes +2 Tremor
+/datum/component/palermitan_role_passive/rat
+
+/datum/component/palermitan_role_passive/rat/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	if(!weapon)
+		return
+	var/chance = 5
+	if(tier >= 3)
+		chance = 10
+	else if(tier >= 2)
+		chance = 8
+	if(prob(chance))
+		var/bonus = round(weapon.force * 0.5)
+		if(bonus > 0)
+			weapon.force += bonus
+			INVOKE_ASYNC(src, PROC_REF(restore_force), weapon, bonus)
+		if(tier >= 3)
+			target.apply_lc_tremor(2, INFINITY)
+
+/datum/component/palermitan_role_passive/rat/proc/restore_force(obj/item/weapon, bonus)
+	if(!QDELETED(weapon))
+		weapon.force -= bonus
+
+////////////////////////////////////////////////////////////
+// CARNIVAL — "Silk Hunter's Patience"
+// After 3+ sec without attacking: next hit +10/20/30% damage. T3: +2 Overheat
+/datum/component/palermitan_role_passive/carnival
+	var/last_attack_time = 0
+
+/datum/component/palermitan_role_passive/carnival/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	if(!weapon)
+		last_attack_time = world.time
+		return
+	if(world.time >= last_attack_time + 3 SECONDS && last_attack_time > 0)
+		var/percent = 0.10
+		if(tier >= 3)
+			percent = 0.30
+		else if(tier >= 2)
+			percent = 0.20
+		var/bonus = round(weapon.force * percent)
+		if(bonus > 0)
+			weapon.force += bonus
+			INVOKE_ASYNC(src, PROC_REF(restore_force), weapon, bonus)
+		if(tier >= 3)
+			target.apply_lc_overheat(2)
+	last_attack_time = world.time
+
+/datum/component/palermitan_role_passive/carnival/proc/restore_force(obj/item/weapon, bonus)
+	if(!QDELETED(weapon))
+		weapon.force -= bonus
+
+////////////////////////////////////////////////////////////
+// ZWEI — "Guardian's Resilience"
+// On taking damage: +2/3/3 DLU. T3: +1 OLD on attacker
+/datum/component/palermitan_role_passive/zwei
+
+/datum/component/palermitan_role_passive/zwei/RegisterWithParent()
+	. = ..()
+	RegisterSignal(parent, COMSIG_MOB_APPLY_DAMGE, PROC_REF(on_take_damage))
+
+/datum/component/palermitan_role_passive/zwei/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_MOB_APPLY_DAMGE)
+	. = ..()
+
+/datum/component/palermitan_role_passive/zwei/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	return
+
+/datum/component/palermitan_role_passive/zwei/proc/on_take_damage(datum/source, damage, damagetype, def_zone, atom/damage_source)
+	SIGNAL_HANDLER
+	if(!damage || damage <= 0)
+		return
+	var/mob/living/user = parent
+	if(tier >= 3)
+		user.apply_lc_defense_level_up(3)
+		if(isliving(damage_source))
+			var/mob/living/attacker = damage_source
+			attacker.apply_lc_offense_level_down(1)
+	else if(tier >= 2)
+		user.apply_lc_defense_level_up(3)
+	else
+		user.apply_lc_defense_level_up(2)
+
+////////////////////////////////////////////////////////////
+// SEVEN — "Analyst's Eye"
+// On Hit vs debuffed target: +1/2/2 OLU. T3: +1 DE
+/datum/component/palermitan_role_passive/seven
+
+/datum/component/palermitan_role_passive/seven/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	// Check for any debuff
+	var/has_debuff = FALSE
+	if(target.has_status_effect(/datum/status_effect/stacking/lc_tremor))
+		has_debuff = TRUE
+	else if(target.has_status_effect(/datum/status_effect/stacking/lc_burn))
+		has_debuff = TRUE
+	else if(target.has_status_effect(/datum/status_effect/stacking/lc_bleed))
+		has_debuff = TRUE
+	else if(target.has_status_effect(/datum/status_effect/stacking/lc_mental_decay))
+		has_debuff = TRUE
+	else if(target.has_status_effect(/datum/status_effect/stacking/protection/fragile))
+		has_debuff = TRUE
+	else if(target.has_status_effect(/datum/status_effect/stacking/defense_level_up/defense_level_down))
+		has_debuff = TRUE
+	else if(target.has_status_effect(/datum/status_effect/stacking/offense_level_up/offense_level_down))
+		has_debuff = TRUE
+	if(!has_debuff)
+		return
+	if(tier >= 2)
+		user.apply_lc_offense_level_up(2)
+	else
+		user.apply_lc_offense_level_up(1)
+	if(tier >= 3)
+		target.apply_duel_escalates(1, user)
+
+////////////////////////////////////////////////////////////
+// DIECI — "Scholar's Insight"
+// On Hit: +3/5/7% damage per distinct debuff type on target (max 4 types)
+/datum/component/palermitan_role_passive/dieci
+
+/datum/component/palermitan_role_passive/dieci/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	if(!weapon)
+		return
+	var/count = 0
+	if(target.has_status_effect(/datum/status_effect/stacking/lc_tremor))
+		count++
+	if(target.has_status_effect(/datum/status_effect/stacking/lc_burn))
+		count++
+	if(target.has_status_effect(/datum/status_effect/stacking/lc_bleed))
+		count++
+	if(target.has_status_effect(/datum/status_effect/stacking/lc_mental_decay))
+		count++
+	if(count <= 0)
+		return
+	var/percent_per = 0.03
+	if(tier >= 3)
+		percent_per = 0.07
+	else if(tier >= 2)
+		percent_per = 0.05
+	var/bonus = round(weapon.force * percent_per * count)
+	if(bonus > 0)
+		weapon.force += bonus
+		INVOKE_ASYNC(src, PROC_REF(restore_force), weapon, bonus)
+
+/datum/component/palermitan_role_passive/dieci/proc/restore_force(obj/item/weapon, bonus)
+	if(!QDELETED(weapon))
+		weapon.force -= bonus
+
+////////////////////////////////////////////////////////////
+// CINQ — "Duelist's Finesse" (roaming fixer only)
+// On Hit: +2/3/3 Poise. T3: halving crit +1 Concentration
+/datum/component/palermitan_role_passive/cinq
+	var/poise_before_crit = 0
+
+/datum/component/palermitan_role_passive/cinq/RegisterWithParent()
+	. = ..()
+	if(tier >= 3)
+		RegisterSignal(parent, COMSIG_POISE_CRIT_ATTACKER, PROC_REF(on_poise_crit))
+
+/datum/component/palermitan_role_passive/cinq/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_POISE_CRIT_ATTACKER)
+	. = ..()
+
+/datum/component/palermitan_role_passive/cinq/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	if(tier >= 2)
+		user.apply_lc_poise(3)
+	else
+		user.apply_lc_poise(2)
+	// Track poise for halving crit detection at T3
+	if(tier >= 3)
+		var/datum/status_effect/stacking/poise/P = user.has_status_effect(/datum/status_effect/stacking/poise)
+		poise_before_crit = P ? P.stacks : 0
+
+/datum/component/palermitan_role_passive/cinq/proc/on_poise_crit(datum/source, mob/living/target, bonus_damage)
+	SIGNAL_HANDLER
+	var/mob/living/user = parent
+	// Only grant Concentration if poise was halved (not saved by Concentration)
+	var/datum/status_effect/stacking/poise/P = user.has_status_effect(/datum/status_effect/stacking/poise)
+	var/poise_after = P ? P.stacks : 0
+	if(poise_before_crit > 0 && poise_after < poise_before_crit * 0.75)
+		user.apply_lc_concentration(1)
+
+////////////////////////////////////////////////////////////
+// SHI — "Assassin's Sacrifice"
+// On Hit vs <30% HP (3s CD): +3/4/5 OLU, lose 3% max HP. T3: +2 Fragile
+/datum/component/palermitan_role_passive/shi
+	var/last_proc_time = 0
+
+/datum/component/palermitan_role_passive/shi/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	if(target.health > target.maxHealth * 0.3)
+		return
+	if(world.time < last_proc_time + 3 SECONDS)
+		return
+	last_proc_time = world.time
+	var/olu = 3
+	if(tier >= 3)
+		olu = 5
+		target.apply_lc_fragile(2)
+	else if(tier >= 2)
+		olu = 4
+	user.apply_lc_offense_level_up(olu)
+	// Self-harm: lose 3% max HP
+	var/self_damage = round(user.maxHealth * 0.03)
+	if(self_damage > 0)
+		user.adjustBruteLoss(self_damage)
+
+////////////////////////////////////////////////////////////
+// LIU — "Burning Fist"
+// On Hit: +1 Overheat. T2: every 4th hit +2 extra. T3: every 3rd hit +3 extra
+/datum/component/palermitan_role_passive/liu
+	var/hit_count = 0
+
+/datum/component/palermitan_role_passive/liu/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	target.apply_lc_overheat(1)
+	hit_count++
+	if(tier >= 3 && hit_count >= 3)
+		target.apply_lc_overheat(3)
+		hit_count = 0
+	else if(tier >= 2 && hit_count >= 4)
+		target.apply_lc_overheat(2)
+		hit_count = 0
+
+////////////////////////////////////////////////////////////
+// DEVYAT — "Berserker's Escalation"
+// On Hit (3s CD): +2/3/3 OLU, lose 2% max HP. T3: below 50% HP also +2 DLU
+/datum/component/palermitan_role_passive/devyat
+	var/last_proc_time = 0
+
+/datum/component/palermitan_role_passive/devyat/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	if(world.time < last_proc_time + 3 SECONDS)
+		return
+	last_proc_time = world.time
+	var/olu = 2
+	if(tier >= 2)
+		olu = 3
+	user.apply_lc_offense_level_up(olu)
+	// Self-harm
+	var/self_damage = round(user.maxHealth * 0.02)
+	if(self_damage > 0)
+		user.adjustBruteLoss(self_damage)
+	// T3: DLU when low
+	if(tier >= 3 && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(H.health < H.maxHealth * 0.5)
+			user.apply_lc_defense_level_up(2)
+
+////////////////////////////////////////////////////////////
+// HANA — "Adaptive Form"
+// On attacking with different weapon than last (5s CD): +2/2+2/3+2 OLU(+DLU)
+/datum/component/palermitan_role_passive/hana
+	var/obj/item/last_weapon_used
+	var/last_switch_bonus_time = 0
+
+/datum/component/palermitan_role_passive/hana/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	if(weapon && last_weapon_used && weapon != last_weapon_used)
+		if(world.time >= last_switch_bonus_time + 5 SECONDS)
+			last_switch_bonus_time = world.time
+			if(tier >= 3)
+				user.apply_lc_offense_level_up(3)
+				user.apply_lc_defense_level_up(2)
+			else if(tier >= 2)
+				user.apply_lc_offense_level_up(2)
+				user.apply_lc_defense_level_up(2)
+			else
+				user.apply_lc_offense_level_up(2)
+	last_weapon_used = weapon

--- a/ModularLobotomy/thumb_spider/palermitan_skills.dm
+++ b/ModularLobotomy/thumb_spider/palermitan_skills.dm
@@ -1,8 +1,7 @@
-// Palermitan Skill Components — 4 Schools
+// Palermitan Skill Components - 4 Schools
 // All skills inherit from /datum/component/palermitan_skill base.
 // Pattern mirrors /datum/component/ring_skill from the Ring system.
 
-////////////////////////////////////////////////////////////
 // BASE SKILL COMPONENT
 /datum/component/palermitan_skill
 	/// Reference to the human parent
@@ -62,13 +61,11 @@
 /datum/component/palermitan_skill/proc/apply_tremor(mob/living/target, stacks)
 	target.apply_lc_tremor(stacks, get_burst_threshold())
 
-////////////////////////////////////////////////////////////
 //
 // SCHOOL 1: TERREMOTO (Tremor)
 //
-////////////////////////////////////////////////////////////
 
-// T1a: Il Cacciatore — On Hit: 2 Tremor (no burst). Vs DE: +1 OLU
+// T1a: Il Cacciatore - On Hit: 2 Tremor (no burst). Vs DE: +1 OLU
 /datum/component/palermitan_skill/terremoto/il_cacciatore
 
 /datum/component/palermitan_skill/terremoto/il_cacciatore/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
@@ -78,7 +75,7 @@
 	if(get_duel_stacks(target) >= 3)
 		user.apply_lc_offense_level_up(1)
 
-// T1b: Destabilizing Strikes — 1/2/3 Tremor scaling with DE
+// T1b: Destabilizing Strikes - 1/2/3 Tremor scaling with DE
 /datum/component/palermitan_skill/terremoto/destabilizing_strikes
 
 /datum/component/palermitan_skill/terremoto/destabilizing_strikes/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
@@ -92,9 +89,9 @@
 	else
 		apply_tremor(target, 1)
 
-// T2a: Palermitan Rapier — Unlocks burst at 15. On burst: +5 OLU +2 Poise
+// T2a: Palermitan Rapier - Unlocks burst at 15. On burst: +5 OLU +2 Poise
 // This skill modifies the burst threshold used by the apprentice's tremor applications.
-// It also needs to detect tremor bursts — done by checking stacks before/after.
+// It also needs to detect tremor bursts - done by checking stacks before/after.
 /datum/component/palermitan_skill/terremoto/palermitan_rapier
 	/// The burst threshold this skill sets
 	var/burst_threshold = 15
@@ -131,7 +128,7 @@
 		user.apply_lc_poise(5)
 		to_chat(user, span_nicegreen("Tremor Burst! Your Palermitan Rapier grants power!"))
 
-// T2b: Aftershock — Unlocks burst at 25. OLD on high tremor targets
+// T2b: Aftershock - Unlocks burst at 25. OLD on high tremor targets
 /datum/component/palermitan_skill/terremoto/aftershock
 	var/burst_threshold = 25
 
@@ -156,7 +153,7 @@
 	else if(tremor >= 10)
 		target.apply_lc_offense_level_down(2)
 
-// T3a: Sezionatura di Cervo — Activated ability (60s CD)
+// T3a: Sezionatura di Cervo - Activated ability (60s CD)
 // Force Tremor Burst + 4 Tremor + 4 Overheat + bonus RED = DE*5, consume 50% DE
 /datum/component/palermitan_skill/terremoto/sezionatura
 	/// Whether the next hit should trigger the finisher
@@ -220,7 +217,7 @@
 	skill_ref.primed = TRUE
 	to_chat(owner, span_danger("Your next attack will unleash Sezionatura di Cervo!"))
 
-// T3b: Tectonic Collapse — On Tremor Burst: 3 Fragile + 3 DLD + 2 Overheat
+// T3b: Tectonic Collapse - On Tremor Burst: 3 Fragile + 3 DLD + 2 Overheat
 /datum/component/palermitan_skill/terremoto/tectonic_collapse
 
 /datum/component/palermitan_skill/terremoto/tectonic_collapse/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
@@ -240,13 +237,11 @@
 		target.apply_lc_overheat(2)
 		to_chat(user, span_nicegreen("Tectonic Collapse! The burst devastates your target!"))
 
-////////////////////////////////////////////////////////////
 //
 // SCHOOL 2: INCENDIO (Overheat)
 //
-////////////////////////////////////////////////////////////
 
-// T1a: Colpi Sottani — On Hit: 2 Overheat. Vs DE: 3 instead
+// T1a: Colpi Sottani - On Hit: 2 Overheat. Vs DE: 3 instead
 /datum/component/palermitan_skill/incendio/colpi_sottani
 
 /datum/component/palermitan_skill/incendio/colpi_sottani/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
@@ -257,7 +252,7 @@
 	else
 		target.apply_lc_overheat(2)
 
-// T1b: Scorching Pursuit — 1 Overheat (2 at 5+ DE). Vs Overheat target: +1 OLU
+// T1b: Scorching Pursuit - 1 Overheat (2 at 5+ DE). Vs Overheat target: +1 OLU
 /datum/component/palermitan_skill/incendio/scorching_pursuit
 
 /datum/component/palermitan_skill/incendio/scorching_pursuit/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
@@ -271,7 +266,7 @@
 	if(get_overheat_stacks(target) > 0)
 		user.apply_lc_offense_level_up(1)
 
-// T2a: Firestorm — On Hit vs 10+ Overheat: +3 OLU +1 Poise +1 Fragile
+// T2a: Firestorm - On Hit vs 10+ Overheat: +3 OLU +1 Poise +1 Fragile
 /datum/component/palermitan_skill/incendio/firestorm
 
 /datum/component/palermitan_skill/incendio/firestorm/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
@@ -281,7 +276,7 @@
 		user.apply_lc_offense_level_up(3)
 		user.apply_lc_poise(3)
 
-// T2b: Smoldering Wounds — 1 DLD per 5 Overheat (max 3)
+// T2b: Smoldering Wounds - 1 DLD per 5 Overheat (max 3)
 /datum/component/palermitan_skill/incendio/smoldering_wounds
 
 /datum/component/palermitan_skill/incendio/smoldering_wounds/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
@@ -293,7 +288,7 @@
 		if(dld > 0)
 			target.apply_lc_defense_level_down(dld)
 
-// T3a: La Spada di Palermo — On Hit vs 10+ DE (30s CD): +5 OLU +3 Damage Up, consume 5 DE, inflict 3 Tremor
+// T3a: La Spada di Palermo - On Hit vs 10+ DE (30s CD): +5 OLU +3 Damage Up, consume 5 DE, inflict 3 Tremor
 /datum/component/palermitan_skill/incendio/la_spada
 	var/last_proc_time = 0
 
@@ -315,7 +310,7 @@
 		D.add_stacks(-5)
 	to_chat(user, span_nicegreen("La Spada di Palermo! Power surges through you!"))
 
-// T3b: Conflagration — On Hit vs 15+ Overheat (10s CD): bonus RED = stacks, reduce by 5, +2 Tremor
+// T3b: Conflagration - On Hit vs 15+ Overheat (10s CD): bonus RED = stacks, reduce by 5, +2 Tremor
 /datum/component/palermitan_skill/incendio/conflagration
 	var/last_proc_time = 0
 
@@ -337,11 +332,9 @@
 	apply_tremor(target, 2)
 	to_chat(user, span_nicegreen("Conflagration! [overheat] bonus RED damage!"))
 
-////////////////////////////////////////////////////////////
 //
 // SCHOOL 3: ELEGANZA (Poise/Concentration)
 //
-////////////////////////////////////////////////////////////
 
 // T1a: Relentless Pursuit
 // Under 5 DE: +2 Poise. 5+ DE: +5 Poise instead
@@ -533,13 +526,11 @@
 		target.apply_lc_fragile(3)
 		target.apply_lc_defense_level_down(3)
 
-////////////////////////////////////////////////////////////
 //
 // SCHOOL 4: FONDAMENTI (General)
 //
-////////////////////////////////////////////////////////////
 
-// T1a: Iron Constitution — On taking damage: +2 DLU
+// T1a: Iron Constitution - On taking damage: +2 DLU
 /datum/component/palermitan_skill/fondamenti/iron_constitution
 
 /datum/component/palermitan_skill/fondamenti/iron_constitution/RegisterWithParent()
@@ -560,7 +551,7 @@
 	var/mob/living/user = parent
 	user.apply_lc_defense_level_up(2)
 
-// T1b: Aggressive Footwork — On Hit: +1 OLU. On taking melee damage: +1 OLU
+// T1b: Aggressive Footwork - On Hit: +1 OLU. On taking melee damage: +1 OLU
 /datum/component/palermitan_skill/fondamenti/aggressive_footwork
 
 /datum/component/palermitan_skill/fondamenti/aggressive_footwork/RegisterWithParent()
@@ -583,7 +574,7 @@
 	var/mob/living/user = parent
 	user.apply_lc_offense_level_up(1)
 
-// T2a: Predator's Instinct — On Hit vs <50% HP: 2 Fragile +2 Poise. <25%: +5 OLU +2 Poise
+// T2a: Predator's Instinct - On Hit vs <50% HP: 2 Fragile +2 Poise. <25%: +5 OLU +2 Poise
 /datum/component/palermitan_skill/fondamenti/predators_instinct
 
 /datum/component/palermitan_skill/fondamenti/predators_instinct/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
@@ -599,7 +590,7 @@
 		target.apply_lc_fragile(2)
 		user.apply_lc_poise(2)
 
-// T2b: Enduring Spirit — On Hit vs 3+ DE: heal 1 HP/stack (max 5). On taking damage near DE target: +1 DLU
+// T2b: Enduring Spirit - On Hit vs 3+ DE: heal 1 HP/stack (max 5). On taking damage near DE target: +1 DLU
 /datum/component/palermitan_skill/fondamenti/enduring_spirit
 
 /datum/component/palermitan_skill/fondamenti/enduring_spirit/RegisterWithParent()
@@ -635,7 +626,7 @@
 			user.apply_lc_defense_level_up(1)
 			return
 
-// T3a: Coup de Grace — On Hit vs <20% HP with 5+ DE: bonus RED = DE*3, consume 50%
+// T3a: Coup de Grace - On Hit vs <20% HP with 5+ DE: bonus RED = DE*3, consume 50%
 /datum/component/palermitan_skill/fondamenti/coup_de_grace
 
 /datum/component/palermitan_skill/fondamenti/coup_de_grace/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
@@ -657,7 +648,7 @@
 			D.add_stacks(-consume)
 	to_chat(user, span_nicegreen("Coup de Gr\u00e2ce! [bonus] bonus RED damage!"))
 
-// T3b: Unbreakable Will — On entering soft crit (60s CD): +5 DLU +3 Protection +heal 10% max HP
+// T3b: Unbreakable Will - On entering soft crit (60s CD): +5 DLU +3 Protection +heal 10% max HP
 /datum/component/palermitan_skill/fondamenti/unbreakable_will
 	var/last_proc_time = 0
 

--- a/ModularLobotomy/thumb_spider/palermitan_skills.dm
+++ b/ModularLobotomy/thumb_spider/palermitan_skills.dm
@@ -1,1 +1,690 @@
-// Stub - populated by the Thumb sub-PR
+// Palermitan Skill Components — 4 Schools
+// All skills inherit from /datum/component/palermitan_skill base.
+// Pattern mirrors /datum/component/ring_skill from the Ring system.
+
+////////////////////////////////////////////////////////////
+// BASE SKILL COMPONENT
+/datum/component/palermitan_skill
+	/// Reference to the human parent
+	var/mob/living/carbon/human/human_parent
+
+/datum/component/palermitan_skill/Initialize()
+	. = ..()
+	if(!ishuman(parent))
+		return COMPONENT_INCOMPATIBLE
+	human_parent = parent
+
+/datum/component/palermitan_skill/RegisterWithParent()
+	. = ..()
+	RegisterSignal(parent, COMSIG_MOB_ITEM_ATTACK, PROC_REF(on_attack))
+
+/datum/component/palermitan_skill/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_MOB_ITEM_ATTACK)
+	human_parent = null
+	. = ..()
+
+/// Called when the parent attacks something with an item
+/datum/component/palermitan_skill/proc/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	SIGNAL_HANDLER
+	return
+
+/// Helper: get Duel Escalates stacks on target (0 if none)
+/datum/component/palermitan_skill/proc/get_duel_stacks(mob/living/target)
+	var/datum/status_effect/stacking/duel_escalates/D = target.has_status_effect(/datum/status_effect/stacking/duel_escalates)
+	if(D)
+		return D.stacks
+	return 0
+
+/// Helper: get Tremor stacks on target
+/datum/component/palermitan_skill/proc/get_tremor_stacks(mob/living/target)
+	var/datum/status_effect/stacking/lc_tremor/T = target.has_status_effect(/datum/status_effect/stacking/lc_tremor)
+	if(T)
+		return T.stacks
+	return 0
+
+/// Helper: get Overheat stacks on target
+/datum/component/palermitan_skill/proc/get_overheat_stacks(mob/living/target)
+	var/datum/status_effect/stacking/lc_burn/B = target.has_status_effect(/datum/status_effect/stacking/lc_burn)
+	if(B)
+		return B.stacks
+	return 0
+
+/// Helper: get the tremor burst threshold from the apprentice's base component
+/datum/component/palermitan_skill/proc/get_burst_threshold()
+	if(!human_parent)
+		return INFINITY
+	var/datum/component/palermitan_apprentice/pal = human_parent.GetComponent(/datum/component/palermitan_apprentice)
+	if(pal)
+		return pal.tremor_burst_threshold
+	return INFINITY
+
+/// Helper: apply tremor using the apprentice's current burst threshold
+/datum/component/palermitan_skill/proc/apply_tremor(mob/living/target, stacks)
+	target.apply_lc_tremor(stacks, get_burst_threshold())
+
+////////////////////////////////////////////////////////////
+//
+// SCHOOL 1: TERREMOTO (Tremor)
+//
+////////////////////////////////////////////////////////////
+
+// T1a: Il Cacciatore — On Hit: 2 Tremor (no burst). Vs DE: +1 OLU
+/datum/component/palermitan_skill/terremoto/il_cacciatore
+
+/datum/component/palermitan_skill/terremoto/il_cacciatore/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	apply_tremor(target, 2)
+	if(get_duel_stacks(target) >= 3)
+		user.apply_lc_offense_level_up(1)
+
+// T1b: Destabilizing Strikes — 1/2/3 Tremor scaling with DE
+/datum/component/palermitan_skill/terremoto/destabilizing_strikes
+
+/datum/component/palermitan_skill/terremoto/destabilizing_strikes/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	var/de = get_duel_stacks(target)
+	if(de >= 7)
+		apply_tremor(target, 3)
+	else if(de >= 3)
+		apply_tremor(target, 2)
+	else
+		apply_tremor(target, 1)
+
+// T2a: Palermitan Rapier — Unlocks burst at 15. On burst: +5 OLU +2 Poise
+// This skill modifies the burst threshold used by the apprentice's tremor applications.
+// It also needs to detect tremor bursts — done by checking stacks before/after.
+/datum/component/palermitan_skill/terremoto/palermitan_rapier
+	/// The burst threshold this skill sets
+	var/burst_threshold = 15
+
+/datum/component/palermitan_skill/terremoto/palermitan_rapier/RegisterWithParent()
+	. = ..()
+	// Set the burst threshold on the base component
+	var/datum/component/palermitan_apprentice/pal = parent.GetComponent(/datum/component/palermitan_apprentice)
+	if(pal)
+		pal.tremor_burst_threshold = burst_threshold
+
+/datum/component/palermitan_skill/terremoto/palermitan_rapier/UnregisterFromParent()
+	// Reset burst threshold
+	var/datum/component/palermitan_apprentice/pal = parent?.GetComponent(/datum/component/palermitan_apprentice)
+	if(pal)
+		pal.tremor_burst_threshold = INFINITY
+	. = ..()
+
+/datum/component/palermitan_skill/terremoto/palermitan_rapier/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	// Check tremor stacks before the hit resolves (other skills apply tremor in their on_attack too)
+	var/stacks_before = get_tremor_stacks(target)
+	if(stacks_before > 0)
+		INVOKE_ASYNC(src, PROC_REF(check_burst), target, user, stacks_before)
+
+/datum/component/palermitan_skill/terremoto/palermitan_rapier/proc/check_burst(mob/living/target, mob/living/user, stacks_before)
+	if(QDELETED(target) || QDELETED(user))
+		return
+	var/stacks_after = get_tremor_stacks(target)
+	// If tremor dropped significantly or disappeared, a burst happened
+	if(stacks_after < stacks_before - 5 || (stacks_before >= burst_threshold && !stacks_after))
+		user.apply_lc_offense_level_up(5)
+		user.apply_lc_poise(5)
+		to_chat(user, span_nicegreen("Tremor Burst! Your Palermitan Rapier grants power!"))
+
+// T2b: Aftershock — Unlocks burst at 25. OLD on high tremor targets
+/datum/component/palermitan_skill/terremoto/aftershock
+	var/burst_threshold = 25
+
+/datum/component/palermitan_skill/terremoto/aftershock/RegisterWithParent()
+	. = ..()
+	var/datum/component/palermitan_apprentice/pal = parent.GetComponent(/datum/component/palermitan_apprentice)
+	if(pal)
+		pal.tremor_burst_threshold = burst_threshold
+
+/datum/component/palermitan_skill/terremoto/aftershock/UnregisterFromParent()
+	var/datum/component/palermitan_apprentice/pal = parent?.GetComponent(/datum/component/palermitan_apprentice)
+	if(pal)
+		pal.tremor_burst_threshold = INFINITY
+	. = ..()
+
+/datum/component/palermitan_skill/terremoto/aftershock/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	var/tremor = get_tremor_stacks(target)
+	if(tremor >= 20)
+		target.apply_lc_offense_level_down(3)
+	else if(tremor >= 10)
+		target.apply_lc_offense_level_down(2)
+
+// T3a: Sezionatura di Cervo — Activated ability (60s CD)
+// Force Tremor Burst + 4 Tremor + 4 Overheat + bonus RED = DE*5, consume 50% DE
+/datum/component/palermitan_skill/terremoto/sezionatura
+	/// Whether the next hit should trigger the finisher
+	var/primed = FALSE
+	/// Cooldown tracking
+	var/last_use = 0
+
+/datum/component/palermitan_skill/terremoto/sezionatura/RegisterWithParent()
+	. = ..()
+	// Grant the activated action button
+	var/datum/action/innate/sezionatura_activate/act = new()
+	act.skill_ref = src
+	act.Grant(parent)
+
+/datum/component/palermitan_skill/terremoto/sezionatura/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	if(!primed)
+		return
+	primed = FALSE
+	// Apply effects
+	target.apply_lc_tremor(4, INFINITY)
+	target.apply_lc_overheat(4)
+	// Force tremor burst only if target has 10+ Duel Escalates
+	var/de = get_duel_stacks(target)
+	if(de >= 10)
+		var/datum/status_effect/stacking/lc_tremor/T = target.has_status_effect(/datum/status_effect/stacking/lc_tremor)
+		if(T)
+			T.TremorBurst()
+	// Bonus RED damage = DE * 2
+	if(de > 0)
+		var/bonus = de * 2
+		target.deal_damage(bonus, RED_DAMAGE, source = user, attack_type = ATTACK_TYPE_MELEE)
+		to_chat(user, span_green("Sezionatura deals [bonus] bonus RED damage!"))
+	// Consume 50% DE
+	var/datum/status_effect/stacking/duel_escalates/D = target.has_status_effect(/datum/status_effect/stacking/duel_escalates)
+	if(D)
+		var/consume = round(D.stacks / 2)
+		if(consume > 0)
+			D.add_stacks(-consume)
+	shake_camera(user, 2, 3)
+	playsound(user, 'sound/weapons/punch4.ogg', 60, TRUE)
+	to_chat(user, span_userdanger("Sezionatura di Cervo!"))
+
+/// Action button for Sezionatura activation
+/datum/action/innate/sezionatura_activate
+	name = "Sezionatura di Cervo"
+	desc = "Prime your next attack for a devastating finisher. 60 second cooldown."
+	button_icon_state = "yourswordinhand"
+	var/datum/component/palermitan_skill/terremoto/sezionatura/skill_ref
+	var/cooldown_time = 60 SECONDS
+	var/last_use = 0
+
+/datum/action/innate/sezionatura_activate/Activate()
+	if(!skill_ref)
+		return
+	if(world.time < last_use + cooldown_time)
+		to_chat(owner, span_warning("Sezionatura is on cooldown!"))
+		return
+	last_use = world.time
+	skill_ref.primed = TRUE
+	to_chat(owner, span_danger("Your next attack will unleash Sezionatura di Cervo!"))
+
+// T3b: Tectonic Collapse — On Tremor Burst: 3 Fragile + 3 DLD + 2 Overheat
+/datum/component/palermitan_skill/terremoto/tectonic_collapse
+
+/datum/component/palermitan_skill/terremoto/tectonic_collapse/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	var/stacks_before = get_tremor_stacks(target)
+	if(stacks_before > 0)
+		INVOKE_ASYNC(src, PROC_REF(check_burst), target, user, stacks_before)
+
+/datum/component/palermitan_skill/terremoto/tectonic_collapse/proc/check_burst(mob/living/target, mob/living/user, stacks_before)
+	if(QDELETED(target) || QDELETED(user))
+		return
+	var/stacks_after = get_tremor_stacks(target)
+	if(stacks_after < stacks_before - 5 || (stacks_before > 0 && !stacks_after))
+		target.apply_lc_fragile(3)
+		target.apply_lc_defense_level_down(3)
+		target.apply_lc_overheat(2)
+		to_chat(user, span_nicegreen("Tectonic Collapse! The burst devastates your target!"))
+
+////////////////////////////////////////////////////////////
+//
+// SCHOOL 2: INCENDIO (Overheat)
+//
+////////////////////////////////////////////////////////////
+
+// T1a: Colpi Sottani — On Hit: 2 Overheat. Vs DE: 3 instead
+/datum/component/palermitan_skill/incendio/colpi_sottani
+
+/datum/component/palermitan_skill/incendio/colpi_sottani/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	if(get_duel_stacks(target) >= 3)
+		target.apply_lc_overheat(3)
+	else
+		target.apply_lc_overheat(2)
+
+// T1b: Scorching Pursuit — 1 Overheat (2 at 5+ DE). Vs Overheat target: +1 OLU
+/datum/component/palermitan_skill/incendio/scorching_pursuit
+
+/datum/component/palermitan_skill/incendio/scorching_pursuit/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	var/de = get_duel_stacks(target)
+	if(de >= 5)
+		target.apply_lc_overheat(2)
+	else
+		target.apply_lc_overheat(1)
+	if(get_overheat_stacks(target) > 0)
+		user.apply_lc_offense_level_up(1)
+
+// T2a: Firestorm — On Hit vs 10+ Overheat: +3 OLU +1 Poise +1 Fragile
+/datum/component/palermitan_skill/incendio/firestorm
+
+/datum/component/palermitan_skill/incendio/firestorm/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	if(get_overheat_stacks(target) >= 10)
+		user.apply_lc_offense_level_up(3)
+		user.apply_lc_poise(3)
+
+// T2b: Smoldering Wounds — 1 DLD per 5 Overheat (max 3)
+/datum/component/palermitan_skill/incendio/smoldering_wounds
+
+/datum/component/palermitan_skill/incendio/smoldering_wounds/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	var/overheat = get_overheat_stacks(target)
+	if(overheat > 0)
+		var/dld = min(round(overheat / 5), 3)
+		if(dld > 0)
+			target.apply_lc_defense_level_down(dld)
+
+// T3a: La Spada di Palermo — On Hit vs 10+ DE (30s CD): +5 OLU +3 Damage Up, consume 5 DE, inflict 3 Tremor
+/datum/component/palermitan_skill/incendio/la_spada
+	var/last_proc_time = 0
+
+/datum/component/palermitan_skill/incendio/la_spada/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	if(world.time < last_proc_time + 30 SECONDS)
+		return
+	var/de = get_duel_stacks(target)
+	if(de < 10)
+		return
+	last_proc_time = world.time
+	user.apply_lc_offense_level_up(5)
+	user.apply_lc_strength(3)
+	apply_tremor(target, 3)
+	// Consume 5 DE
+	var/datum/status_effect/stacking/duel_escalates/D = target.has_status_effect(/datum/status_effect/stacking/duel_escalates)
+	if(D)
+		D.add_stacks(-5)
+	to_chat(user, span_nicegreen("La Spada di Palermo! Power surges through you!"))
+
+// T3b: Conflagration — On Hit vs 15+ Overheat (10s CD): bonus RED = stacks, reduce by 5, +2 Tremor
+/datum/component/palermitan_skill/incendio/conflagration
+	var/last_proc_time = 0
+
+/datum/component/palermitan_skill/incendio/conflagration/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	if(world.time < last_proc_time + 10 SECONDS)
+		return
+	var/overheat = get_overheat_stacks(target)
+	if(overheat < 15)
+		return
+	last_proc_time = world.time
+	// Bonus RED = overheat stacks
+	target.deal_damage(overheat, RED_DAMAGE, source = user, attack_type = ATTACK_TYPE_MELEE)
+	// Reduce overheat by 5
+	var/datum/status_effect/stacking/lc_burn/B = target.has_status_effect(/datum/status_effect/stacking/lc_burn)
+	if(B)
+		B.add_stacks(-5)
+	apply_tremor(target, 2)
+	to_chat(user, span_nicegreen("Conflagration! [overheat] bonus RED damage!"))
+
+////////////////////////////////////////////////////////////
+//
+// SCHOOL 3: ELEGANZA (Poise/Concentration)
+//
+////////////////////////////////////////////////////////////
+
+// T1a: Relentless Pursuit
+// Under 5 DE: +2 Poise. 5+ DE: +5 Poise instead
+/datum/component/palermitan_skill/eleganza/relentless_pursuit
+
+/datum/component/palermitan_skill/eleganza/relentless_pursuit/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	var/de = get_duel_stacks(target)
+	if(de < 1)
+		return
+	if(de >= 5)
+		user.apply_lc_poise(5)
+	else
+		user.apply_lc_poise(2)
+
+// T1b: Focused Mind
+// Under 5 DE: +1 Poise +1 Concentration (10s CD). 5+ DE: +3 Poise instead
+/datum/component/palermitan_skill/eleganza/focused_mind
+	var/last_conc_time = 0
+
+/datum/component/palermitan_skill/eleganza/focused_mind/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	var/de = get_duel_stacks(target)
+	if(de < 1)
+		return
+	if(de >= 5)
+		user.apply_lc_poise(3)
+	else
+		user.apply_lc_poise(1)
+		if(world.time >= last_conc_time + 10 SECONDS)
+			last_conc_time = world.time
+			user.apply_lc_concentration(1)
+
+// T2a: Duello Feroce
+// On Hit vs 3+ DE: +1 Poise per 3 stacks (max 3) + heal 2 HP/stack (max 10). Halving crit: +1 Concentration
+/datum/component/palermitan_skill/eleganza/duello_feroce
+	/// Tracks poise before crit to detect halving
+	var/poise_before_crit = 0
+
+/datum/component/palermitan_skill/eleganza/duello_feroce/RegisterWithParent()
+	. = ..()
+	RegisterSignal(parent, COMSIG_POISE_CRIT_ATTACKER, PROC_REF(on_poise_crit))
+
+/datum/component/palermitan_skill/eleganza/duello_feroce/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_POISE_CRIT_ATTACKER)
+	. = ..()
+
+/datum/component/palermitan_skill/eleganza/duello_feroce/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	var/de = get_duel_stacks(target)
+	if(de < 3)
+		return
+	// Poise: 1 per 3 stacks, max 3
+	var/poise_gain = min(round(de / 3), 3)
+	if(poise_gain > 0)
+		user.apply_lc_poise(poise_gain)
+	// Heal: 2 HP per stack, max 10
+	var/heal = min(de * 2, 10)
+	if(heal > 0 && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		H.adjustBruteLoss(-heal)
+	// Store poise for crit detection
+	var/datum/status_effect/stacking/poise/P = user.has_status_effect(/datum/status_effect/stacking/poise)
+	poise_before_crit = P ? P.stacks : 0
+
+/datum/component/palermitan_skill/eleganza/duello_feroce/proc/on_poise_crit(datum/source, mob/living/target, bonus_damage)
+	SIGNAL_HANDLER
+	// Check if poise was halved (no concentration consumed)
+	var/mob/living/user = parent
+	var/datum/status_effect/stacking/poise/P = user.has_status_effect(/datum/status_effect/stacking/poise)
+	var/poise_after = P ? P.stacks : 0
+	// If poise was halved (dropped significantly), concentration wasn't consumed
+	if(poise_before_crit > 0 && poise_after < poise_before_crit * 0.75)
+		user.apply_lc_concentration(1)
+
+// T2b: Severed Tendon
+// On Poise crit: 3 OLD + 1 Fragile. Halving crit: +1 Poise back
+/datum/component/palermitan_skill/eleganza/severed_tendon
+	var/poise_before_crit = 0
+
+/datum/component/palermitan_skill/eleganza/severed_tendon/RegisterWithParent()
+	. = ..()
+	RegisterSignal(parent, COMSIG_POISE_CRIT_ATTACKER, PROC_REF(on_poise_crit))
+
+/datum/component/palermitan_skill/eleganza/severed_tendon/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_POISE_CRIT_ATTACKER)
+	. = ..()
+
+/datum/component/palermitan_skill/eleganza/severed_tendon/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	// Store poise for crit detection
+	var/datum/status_effect/stacking/poise/P = user.has_status_effect(/datum/status_effect/stacking/poise)
+	poise_before_crit = P ? P.stacks : 0
+
+/datum/component/palermitan_skill/eleganza/severed_tendon/proc/on_poise_crit(datum/source, mob/living/target, bonus_damage)
+	SIGNAL_HANDLER
+	if(!isliving(target))
+		return
+	// Always on crit: 3 OLD + 1 Fragile
+	target.apply_lc_offense_level_down(3)
+	target.apply_lc_fragile(1)
+	// If poise was halved: +5 Poise back
+	var/mob/living/user = parent
+	var/datum/status_effect/stacking/poise/P = user.has_status_effect(/datum/status_effect/stacking/poise)
+	var/poise_after = P ? P.stacks : 0
+	if(poise_before_crit > 0 && poise_after < poise_before_crit * 0.75)
+		user.apply_lc_poise(5)
+
+// T3a: Valencina's Legacy
+// On crit: 3 Tremor + 3 Overheat + DE spread 2 tiles. On crit (15s CD): +1 Concentration
+/datum/component/palermitan_skill/eleganza/valencinas_legacy
+	var/last_conc_time = 0
+
+/datum/component/palermitan_skill/eleganza/valencinas_legacy/RegisterWithParent()
+	. = ..()
+	RegisterSignal(parent, COMSIG_POISE_CRIT_ATTACKER, PROC_REF(on_poise_crit))
+
+/datum/component/palermitan_skill/eleganza/valencinas_legacy/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_POISE_CRIT_ATTACKER)
+	. = ..()
+
+/datum/component/palermitan_skill/eleganza/valencinas_legacy/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	return
+
+/datum/component/palermitan_skill/eleganza/valencinas_legacy/proc/on_poise_crit(datum/source, mob/living/target, bonus_damage)
+	SIGNAL_HANDLER
+	if(!isliving(target))
+		return
+	var/mob/living/user = parent
+	// 3 Tremor + 3 Overheat on target
+	apply_tremor(target, 3)
+	target.apply_lc_overheat(3)
+	// DE spread to nearby enemies within 2 tiles
+	for(var/mob/living/L in range(2, get_turf(target)))
+		if(L == user || L == target)
+			continue
+		L.apply_duel_escalates(1, user)
+	// Concentration on 15s cooldown
+	if(world.time >= last_conc_time + 15 SECONDS)
+		last_conc_time = world.time
+		user.apply_lc_concentration(1)
+
+// T3b: The Famiglia's Honor
+// DE max to 30. At 15+ DE: +2 Poise. Halving crit at 15+ DE: +1 Conc. Crit at 20+ DE: 3 Fragile + 3 DLD
+/datum/component/palermitan_skill/eleganza/famiglias_honor
+	var/poise_before_crit = 0
+
+/datum/component/palermitan_skill/eleganza/famiglias_honor/RegisterWithParent()
+	. = ..()
+	RegisterSignal(parent, COMSIG_POISE_CRIT_ATTACKER, PROC_REF(on_poise_crit))
+
+/datum/component/palermitan_skill/eleganza/famiglias_honor/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_POISE_CRIT_ATTACKER)
+	. = ..()
+
+/datum/component/palermitan_skill/eleganza/famiglias_honor/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	var/de = get_duel_stacks(target)
+	// Increase DE max to 30
+	var/datum/status_effect/stacking/duel_escalates/D = target.has_status_effect(/datum/status_effect/stacking/duel_escalates)
+	if(D)
+		D.max_stacks = 30
+	// At 15+ DE: +2 Poise
+	if(de >= 15)
+		user.apply_lc_poise(2)
+	// Store poise for crit detection
+	var/datum/status_effect/stacking/poise/P = user.has_status_effect(/datum/status_effect/stacking/poise)
+	poise_before_crit = P ? P.stacks : 0
+
+/datum/component/palermitan_skill/eleganza/famiglias_honor/proc/on_poise_crit(datum/source, mob/living/target, bonus_damage)
+	SIGNAL_HANDLER
+	if(!isliving(target))
+		return
+	var/mob/living/user = parent
+	var/de = get_duel_stacks(target)
+	// Halving crit at 15+ DE: +1 Concentration
+	if(de >= 15)
+		var/datum/status_effect/stacking/poise/P = user.has_status_effect(/datum/status_effect/stacking/poise)
+		var/poise_after = P ? P.stacks : 0
+		if(poise_before_crit > 0 && poise_after < poise_before_crit * 0.75)
+			user.apply_lc_concentration(1)
+	// Crit at 20+ DE: 3 Fragile + 3 DLD
+	if(de >= 20)
+		target.apply_lc_fragile(3)
+		target.apply_lc_defense_level_down(3)
+
+////////////////////////////////////////////////////////////
+//
+// SCHOOL 4: FONDAMENTI (General)
+//
+////////////////////////////////////////////////////////////
+
+// T1a: Iron Constitution — On taking damage: +2 DLU
+/datum/component/palermitan_skill/fondamenti/iron_constitution
+
+/datum/component/palermitan_skill/fondamenti/iron_constitution/RegisterWithParent()
+	. = ..()
+	RegisterSignal(parent, COMSIG_MOB_APPLY_DAMGE, PROC_REF(on_take_damage))
+
+/datum/component/palermitan_skill/fondamenti/iron_constitution/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_MOB_APPLY_DAMGE)
+	. = ..()
+
+/datum/component/palermitan_skill/fondamenti/iron_constitution/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	return
+
+/datum/component/palermitan_skill/fondamenti/iron_constitution/proc/on_take_damage(datum/source, damage, damagetype, def_zone)
+	SIGNAL_HANDLER
+	if(!damage || damage <= 0)
+		return
+	var/mob/living/user = parent
+	user.apply_lc_defense_level_up(2)
+
+// T1b: Aggressive Footwork — On Hit: +1 OLU. On taking melee damage: +1 OLU
+/datum/component/palermitan_skill/fondamenti/aggressive_footwork
+
+/datum/component/palermitan_skill/fondamenti/aggressive_footwork/RegisterWithParent()
+	. = ..()
+	RegisterSignal(parent, COMSIG_MOB_APPLY_DAMGE, PROC_REF(on_take_damage))
+
+/datum/component/palermitan_skill/fondamenti/aggressive_footwork/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_MOB_APPLY_DAMGE)
+	. = ..()
+
+/datum/component/palermitan_skill/fondamenti/aggressive_footwork/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	user.apply_lc_offense_level_up(1)
+
+/datum/component/palermitan_skill/fondamenti/aggressive_footwork/proc/on_take_damage(datum/source, damage, damagetype, def_zone)
+	SIGNAL_HANDLER
+	if(!damage || damage <= 0)
+		return
+	var/mob/living/user = parent
+	user.apply_lc_offense_level_up(1)
+
+// T2a: Predator's Instinct — On Hit vs <50% HP: 2 Fragile +2 Poise. <25%: +5 OLU +2 Poise
+/datum/component/palermitan_skill/fondamenti/predators_instinct
+
+/datum/component/palermitan_skill/fondamenti/predators_instinct/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	var/hp_percent = target.health / target.maxHealth
+	if(hp_percent < 0.25)
+		target.apply_lc_fragile(2)
+		user.apply_lc_poise(2)
+		user.apply_lc_offense_level_up(5)
+		user.apply_lc_poise(2)
+	else if(hp_percent < 0.5)
+		target.apply_lc_fragile(2)
+		user.apply_lc_poise(2)
+
+// T2b: Enduring Spirit — On Hit vs 3+ DE: heal 1 HP/stack (max 5). On taking damage near DE target: +1 DLU
+/datum/component/palermitan_skill/fondamenti/enduring_spirit
+
+/datum/component/palermitan_skill/fondamenti/enduring_spirit/RegisterWithParent()
+	. = ..()
+	RegisterSignal(parent, COMSIG_MOB_APPLY_DAMGE, PROC_REF(on_take_damage))
+
+/datum/component/palermitan_skill/fondamenti/enduring_spirit/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_MOB_APPLY_DAMGE)
+	. = ..()
+
+/datum/component/palermitan_skill/fondamenti/enduring_spirit/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	var/de = get_duel_stacks(target)
+	if(de < 3)
+		return
+	var/heal = min(de, 5)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		H.adjustBruteLoss(-heal)
+
+/datum/component/palermitan_skill/fondamenti/enduring_spirit/proc/on_take_damage(datum/source, damage, damagetype, def_zone)
+	SIGNAL_HANDLER
+	if(!damage || damage <= 0)
+		return
+	var/mob/living/user = parent
+	// Check if any nearby mob has DE from us
+	for(var/mob/living/L in range(3, get_turf(user)))
+		if(L == user)
+			continue
+		var/datum/status_effect/stacking/duel_escalates/D = L.has_status_effect(/datum/status_effect/stacking/duel_escalates)
+		if(D && D.duelist == user)
+			user.apply_lc_defense_level_up(1)
+			return
+
+// T3a: Coup de Grace — On Hit vs <20% HP with 5+ DE: bonus RED = DE*3, consume 50%
+/datum/component/palermitan_skill/fondamenti/coup_de_grace
+
+/datum/component/palermitan_skill/fondamenti/coup_de_grace/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	if(!isliving(target) || target == user)
+		return
+	var/hp_percent = target.health / target.maxHealth
+	if(hp_percent >= 0.2)
+		return
+	var/de = get_duel_stacks(target)
+	if(de < 5)
+		return
+	var/bonus = de * 3
+	target.deal_damage(bonus, RED_DAMAGE, source = user, attack_type = ATTACK_TYPE_MELEE)
+	// Consume 50%
+	var/datum/status_effect/stacking/duel_escalates/D = target.has_status_effect(/datum/status_effect/stacking/duel_escalates)
+	if(D)
+		var/consume = round(D.stacks / 2)
+		if(consume > 0)
+			D.add_stacks(-consume)
+	to_chat(user, span_nicegreen("Coup de Gr\u00e2ce! [bonus] bonus RED damage!"))
+
+// T3b: Unbreakable Will — On entering soft crit (60s CD): +5 DLU +3 Protection +heal 10% max HP
+/datum/component/palermitan_skill/fondamenti/unbreakable_will
+	var/last_proc_time = 0
+
+/datum/component/palermitan_skill/fondamenti/unbreakable_will/RegisterWithParent()
+	. = ..()
+	RegisterSignal(parent, COMSIG_MOB_STATCHANGE, PROC_REF(on_stat_change))
+
+/datum/component/palermitan_skill/fondamenti/unbreakable_will/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_MOB_STATCHANGE)
+	. = ..()
+
+/datum/component/palermitan_skill/fondamenti/unbreakable_will/on_attack(datum/source, mob/living/target, mob/living/user, obj/item/weapon)
+	return
+
+/datum/component/palermitan_skill/fondamenti/unbreakable_will/proc/on_stat_change(datum/source, new_stat, old_stat)
+	SIGNAL_HANDLER
+	if(new_stat < SOFT_CRIT)
+		return
+	if(old_stat >= SOFT_CRIT)
+		return
+	if(world.time < last_proc_time + 60 SECONDS)
+		return
+	last_proc_time = world.time
+	var/mob/living/user = parent
+	user.apply_lc_defense_level_up(5)
+	user.apply_lc_protection(3)
+	var/heal = round(user.maxHealth * 0.1)
+	if(heal > 0)
+		user.adjustBruteLoss(-heal)
+	to_chat(user, span_boldnotice("Unbreakable Will activates! You refuse to fall!"))

--- a/ModularLobotomy/thumb_spider/palermitan_tree.dm
+++ b/ModularLobotomy/thumb_spider/palermitan_tree.dm
@@ -279,7 +279,7 @@
 		var/datum/component/palermitan_role_passive/P = locate(passive_type) in viewer.GetComponents(/datum/component/palermitan_role_passive)
 		if(P)
 			current_tier = P.tier
-		// Get duel count — check various possible key names
+		// Get duel count - check various possible key names
 		var/duels = 0
 		if(exp_comp)
 			// Check exact match first, then partial matches
@@ -340,7 +340,6 @@
 		return "Adaptive Form (Hana)"
 	return "Unknown Passive"
 
-////////////////////////////////////////////////////////////
 // SKILL TREE ACTION BUTTON
 
 /datum/action/innate/palermitan_tree
@@ -355,15 +354,14 @@
 	var/datum/palermitan_skill_tree/tree = new(user)
 	tree.ui_interact(user)
 
-////////////////////////////////////////////////////////////
-// GLOBAL SKILL DEFINITIONS — 4 SCHOOLS
+// GLOBAL SKILL DEFINITIONS - 4 SCHOOLS
 
 GLOBAL_LIST_INIT(palermitan_skill_definitions, init_palermitan_skill_definitions())
 
 /proc/init_palermitan_skill_definitions()
 	var/list/defs = list()
 
-	// ========== TERREMOTO (Tremor) ==========
+	// TERREMOTO (Tremor)
 	defs["terremoto"] = list(
 		"tier1" = list(
 			"a" = list(
@@ -403,7 +401,7 @@ GLOBAL_LIST_INIT(palermitan_skill_definitions, init_palermitan_skill_definitions
 		)
 	)
 
-	// ========== INCENDIO (Overheat) ==========
+	// INCENDIO (Overheat)
 	defs["incendio"] = list(
 		"tier1" = list(
 			"a" = list(
@@ -443,7 +441,7 @@ GLOBAL_LIST_INIT(palermitan_skill_definitions, init_palermitan_skill_definitions
 		)
 	)
 
-	// ========== ELEGANZA (Poise/Concentration) ==========
+	// ELEGANZA (Poise/Concentration)
 	defs["eleganza"] = list(
 		"tier1" = list(
 			"a" = list(
@@ -483,7 +481,7 @@ GLOBAL_LIST_INIT(palermitan_skill_definitions, init_palermitan_skill_definitions
 		)
 	)
 
-	// ========== FONDAMENTI (General) ==========
+	// FONDAMENTI (General)
 	defs["fondamenti"] = list(
 		"tier1" = list(
 			"a" = list(

--- a/ModularLobotomy/thumb_spider/palermitan_tree.dm
+++ b/ModularLobotomy/thumb_spider/palermitan_tree.dm
@@ -1,1 +1,526 @@
-// Stub - populated by the Thumb sub-PR
+// Palermitan Skill Tree Datum
+// 4 schools, 3 tiers each, 2 mutually exclusive choices per tier.
+// Mirrors the Ring skill tree system exactly.
+
+/datum/palermitan_skill_tree
+	/// The mob viewing the skill tree
+	var/mob/living/carbon/human/viewer
+
+/datum/palermitan_skill_tree/New(mob/living/carbon/human/user)
+	viewer = user
+
+/datum/palermitan_skill_tree/Destroy()
+	viewer = null
+	return ..()
+
+/datum/palermitan_skill_tree/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "PalermitanSkillTree")
+		ui.open()
+
+/datum/palermitan_skill_tree/ui_state(mob/user)
+	return GLOB.conscious_state
+
+/datum/palermitan_skill_tree/ui_data(mob/user)
+	var/list/data = list()
+
+	var/datum/component/palermitan_exp/exp_comp = viewer.GetComponent(/datum/component/palermitan_exp)
+	if(!exp_comp)
+		return data
+
+	data["exp"] = exp_comp.exp
+	data["next_threshold"] = exp_comp.get_next_threshold()
+	data["skill_points"] = exp_comp.skill_points
+	data["skill_points_spent"] = exp_comp.skill_points_spent
+	data["schools_invested"] = exp_comp.schools_invested
+	data["max_schools"] = exp_comp.max_schools
+
+	// Gear tier
+	var/gear_tier = 1
+	for(var/obj/item/ego_weapon/city/thumbapprentice_katana/K in viewer.GetAllContents())
+		gear_tier = K.tier
+		break
+	data["gear_tier"] = gear_tier
+
+	// All possible role passives with unlock status
+	data["all_passives"] = get_all_passive_data(exp_comp)
+
+	// Build school data
+	data["schools"] = list()
+
+	data["schools"] += list(list(
+		"name" = "Terremoto",
+		"id" = "terremoto",
+		"desc" = "The path of the earthquake. Destabilize your prey with tremor, culminating in devastating tremor bursts.",
+		"theme" = "Tremor application and burst. Tier 2 unlocks tremor bursting.",
+		"tiers" = get_school_tiers("terremoto", exp_comp)
+	))
+
+	data["schools"] += list(list(
+		"name" = "Incendio",
+		"id" = "incendio",
+		"desc" = "The path of the inferno. Burn the target down with escalating overheat.",
+		"theme" = "Overheat application and scaling debuffs.",
+		"tiers" = get_school_tiers("incendio", exp_comp)
+	))
+
+	data["schools"] += list(list(
+		"name" = "Eleganza",
+		"id" = "eleganza",
+		"desc" = "The path of elegance. Build Poise for critical strikes and Concentration to sustain momentum.",
+		"theme" = "Poise and Concentration. The refined swordsman.",
+		"tiers" = get_school_tiers("eleganza", exp_comp)
+	))
+
+	data["schools"] += list(list(
+		"name" = "Fondamenti",
+		"id" = "fondamenti",
+		"desc" = "The fundamentals of combat. Core improvements that benefit any build.",
+		"theme" = "General offense and defense. No status specialization.",
+		"tiers" = get_school_tiers("fondamenti", exp_comp)
+	))
+
+	return data
+
+/datum/palermitan_skill_tree/proc/get_school_tiers(school_id, datum/component/palermitan_exp/exp_comp)
+	var/list/tiers = list()
+	var/list/skill_defs = GLOB.palermitan_skill_definitions[school_id]
+
+	if(!skill_defs)
+		return tiers
+
+	for(var/tier_num in 1 to 3)
+		var/list/tier_data = list(
+			"tier" = tier_num,
+			"cost" = tier_num,
+			"choices" = list()
+		)
+
+		var/previous_completed = (tier_num == 1) || has_tier_completed(school_id, tier_num - 1)
+		var/can_afford = exp_comp.skill_points >= tier_num
+		var/can_invest = exp_comp.can_invest_in_school(school_id)
+
+		var/list/tier_skills = skill_defs["tier[tier_num]"]
+		if(tier_skills)
+			for(var/choice in list("a", "b"))
+				var/list/skill_info = tier_skills[choice]
+				if(!skill_info)
+					continue
+
+				var/skill_type = skill_info["type"]
+				var/is_selected = has_skill(skill_type)
+				var/other_choice = (choice == "a") ? "b" : "a"
+				var/other_selected = has_skill(tier_skills[other_choice]["type"])
+
+				tier_data["choices"] += list(list(
+					"id" = choice,
+					"name" = skill_info["name"],
+					"desc" = skill_info["desc"],
+					"type" = "[skill_type]",
+					"selected" = is_selected,
+					"excluded" = other_selected,
+					"available" = (previous_completed && can_afford && can_invest && !is_selected && !other_selected),
+					"locked" = !previous_completed
+				))
+
+		tiers += list(tier_data)
+
+	return tiers
+
+/datum/palermitan_skill_tree/proc/has_tier_completed(school_id, tier_num)
+	var/list/skill_defs = GLOB.palermitan_skill_definitions[school_id]
+	if(!skill_defs)
+		return FALSE
+
+	var/list/tier_skills = skill_defs["tier[tier_num]"]
+	if(!tier_skills)
+		return FALSE
+
+	for(var/choice in list("a", "b"))
+		var/list/skill_info = tier_skills[choice]
+		if(skill_info && has_skill(skill_info["type"]))
+			return TRUE
+
+	return FALSE
+
+/datum/palermitan_skill_tree/proc/has_skill(skill_type)
+	var/datum/component/palermitan_skill/skill = locate(skill_type) in viewer.GetComponents(/datum/component/palermitan_skill)
+	return !!skill
+
+/datum/palermitan_skill_tree/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	if(.)
+		return
+
+	switch(action)
+		if("select_skill")
+			var/skill_type = text2path(params["skill_type"])
+			var/school_id = params["school"]
+			var/tier = text2num(params["tier"])
+
+			if(!skill_type || !school_id || !tier)
+				return FALSE
+
+			var/datum/component/palermitan_exp/exp_comp = viewer.GetComponent(/datum/component/palermitan_exp)
+			if(!exp_comp)
+				return FALSE
+
+			if(exp_comp.skill_points < tier)
+				to_chat(viewer, span_warning("You don't have enough skill points!"))
+				return FALSE
+
+			if(!exp_comp.can_invest_in_school(school_id))
+				to_chat(viewer, span_warning("You can only invest in [exp_comp.max_schools] schools!"))
+				return FALSE
+
+			if(tier > 1 && !has_tier_completed(school_id, tier - 1))
+				to_chat(viewer, span_warning("You must complete the previous tier first!"))
+				return FALSE
+
+			if(has_skill(skill_type))
+				to_chat(viewer, span_warning("You already have this skill!"))
+				return FALSE
+
+			if(!exp_comp.spend_skill_point(tier))
+				return FALSE
+
+			exp_comp.invest_in_school(school_id)
+			viewer.AddComponent(skill_type)
+
+			to_chat(viewer, span_nicegreen("You have learned a new Palermitan technique!"))
+			playsound(viewer, 'sound/machines/chime.ogg', 50, TRUE)
+
+			return TRUE
+
+	return FALSE
+
+/// Builds data for all possible role passives, showing unlock status
+/datum/palermitan_skill_tree/proc/get_all_passive_data(datum/component/palermitan_exp/exp_comp)
+	var/list/passives = list()
+	var/list/all_roles = list(
+		list("id" = "Butcher", "name" = "Predator's Instinct", "source" = "Butcher", "type" = /datum/component/palermitan_role_passive/butcher,
+			"t1" = "Hitting targets below 50% HP deals 5% bonus damage.",
+			"t2" = "Bonus increases to 10%.",
+			"t3" = "Bonus increases to 15%, and heals 3 HP per hit."),
+		list("id" = "Blade Lineage", "name" = "Resolve of the Salsu", "source" = "Blade Lineage", "type" = /datum/component/palermitan_role_passive/blade_lineage,
+			"t1" = "While below 30% HP, deal 10% more damage.",
+			"t2" = "Bonus increases to 15%.",
+			"t3" = "Bonus increases to 20%."),
+		list("id" = "Thumb", "name" = "Soldato's Discipline", "source" = "Thumb", "type" = /datum/component/palermitan_role_passive/thumb,
+			"t1" = "On taking RED damage: gain 2 Defense Level Up.",
+			"t2" = "Gain 3 Defense Level Up instead.",
+			"t3" = "Also gain 1 Offense Level Up."),
+		list("id" = "Kurokumo", "name" = "Way of the Drawn Blade", "source" = "Kurokumo", "type" = /datum/component/palermitan_role_passive/kurokumo,
+			"t1" = "On Hit: gain 1 Poise.",
+			"t2" = "Poise crits deal 5% extra RED damage.",
+			"t3" = "Crits deal 10% extra and inflict 2 Tremor."),
+		list("id" = "Index", "name" = "Prescript Discipline", "source" = "Index", "type" = /datum/component/palermitan_role_passive/index,
+			"t1" = "On Hit: inflict 1 Offense Level Down on target.",
+			"t2" = "Also inflict 1 Defense Level Down.",
+			"t3" = "Inflict 2 Offense Level Down instead."),
+		list("id" = "Insurgence", "name" = "Nightwatch Tremors", "source" = "Insurgence", "type" = /datum/component/palermitan_role_passive/insurgence,
+			"t1" = "On Hit: 15% chance to inflict 1 Tremor.",
+			"t2" = "Chance increases to 20%.",
+			"t3" = "25% chance for 2 Tremor instead."),
+		list("id" = "Middle", "name" = "Vengeance Mark", "source" = "Middle", "type" = /datum/component/palermitan_role_passive/middle,
+			"t1" = "On taking melee damage: next attack deals 3% more.",
+			"t2" = "Bonus increases to 5%.",
+			"t3" = "8% bonus, and the counter-hit inflicts 1 Duel Escalates."),
+		list("id" = "N-Corp", "name" = "Methodical Strikes", "source" = "N-Corp", "type" = /datum/component/palermitan_role_passive/ncorp,
+			"t1" = "On Hit: inflict 1 Defense Level Down and 1 Overheat.",
+			"t2" = "Overheat increases to 2.",
+			"t3" = "Defense Level Down increases to 2."),
+		list("id" = "Rat", "name" = "Scavenger's Luck", "source" = "Rat", "type" = /datum/component/palermitan_role_passive/rat,
+			"t1" = "On Hit: 5% chance for 50% bonus damage.",
+			"t2" = "Chance increases to 8%.",
+			"t3" = "10% chance, and lucky strikes inflict 2 Tremor."),
+		list("id" = "Carnival", "name" = "Silk Hunter's Patience", "source" = "Carnival", "type" = /datum/component/palermitan_role_passive/carnival,
+			"t1" = "After 3+ seconds without attacking: next hit deals 10% more.",
+			"t2" = "Bonus increases to 20%.",
+			"t3" = "30% bonus, and inflicts 2 Overheat."),
+		list("id" = "Zwei", "name" = "Guardian's Resilience", "source" = "Zwei Association", "type" = /datum/component/palermitan_role_passive/zwei,
+			"t1" = "On taking damage: gain 2 Defense Level Up.",
+			"t2" = "Gain 3 Defense Level Up instead.",
+			"t3" = "Also inflict 1 Offense Level Down on the attacker."),
+		list("id" = "Seven", "name" = "Analyst's Eye", "source" = "Seven Association", "type" = /datum/component/palermitan_role_passive/seven,
+			"t1" = "On Hit vs debuffed target: gain 1 Offense Level Up.",
+			"t2" = "Gain 2 Offense Level Up instead.",
+			"t3" = "Also inflict 1 Duel Escalates on the target."),
+		list("id" = "Dieci", "name" = "Scholar's Insight", "source" = "Dieci Association", "type" = /datum/component/palermitan_role_passive/dieci,
+			"t1" = "On Hit: deal 3% more per distinct debuff on target.",
+			"t2" = "Bonus increases to 5% per debuff.",
+			"t3" = "7% per debuff (max 28% with 4 debuffs)."),
+		list("id" = "Cinq", "name" = "Duelist's Finesse", "source" = "Cinq (Roaming)", "type" = /datum/component/palermitan_role_passive/cinq,
+			"t1" = "On Hit: gain 2 Poise.",
+			"t2" = "Gain 3 Poise instead.",
+			"t3" = "Crits that halve your Poise grant 1 Concentration."),
+		list("id" = "Shi", "name" = "Assassin's Sacrifice", "source" = "Shi (Roaming)", "type" = /datum/component/palermitan_role_passive/shi,
+			"t1" = "On Hit vs target below 30% HP: gain 3 Offense Level Up, lose 3% max HP. 3s cooldown.",
+			"t2" = "Gain 4 Offense Level Up instead.",
+			"t3" = "5 Offense Level Up, and inflict 2 Fragile."),
+		list("id" = "Liu", "name" = "Burning Fist", "source" = "Liu (Roaming)", "type" = /datum/component/palermitan_role_passive/liu,
+			"t1" = "On Hit: inflict 1 Overheat.",
+			"t2" = "Every 4th hit: 2 extra Overheat.",
+			"t3" = "Every 3rd hit: 3 extra Overheat."),
+		list("id" = "Devyat", "name" = "Berserker's Escalation", "source" = "Devyat (Roaming)", "type" = /datum/component/palermitan_role_passive/devyat,
+			"t1" = "On Hit: gain 2 Offense Level Up, lose 2% max HP. 3s cooldown.",
+			"t2" = "Gain 3 Offense Level Up instead.",
+			"t3" = "Below 50% HP: also gain 2 Defense Level Up."),
+		list("id" = "Hana", "name" = "Adaptive Form", "source" = "Hana (Roaming)", "type" = /datum/component/palermitan_role_passive/hana,
+			"t1" = "Attacking with a different weapon than last: gain 2 Offense Level Up. 5s cooldown.",
+			"t2" = "Also gain 2 Defense Level Up.",
+			"t3" = "3 Offense Level Up and 2 Defense Level Up."),
+	)
+
+	for(var/list/role_info in all_roles)
+		var/passive_type = role_info["type"]
+		var/current_tier = 0
+		var/datum/component/palermitan_role_passive/P = locate(passive_type) in viewer.GetComponents(/datum/component/palermitan_role_passive)
+		if(P)
+			current_tier = P.tier
+		// Get duel count — check various possible key names
+		var/duels = 0
+		if(exp_comp)
+			// Check exact match first, then partial matches
+			for(var/key in exp_comp.role_duel_counts)
+				if(findtext(key, role_info["id"]))
+					duels = exp_comp.role_duel_counts[key]
+					break
+		passives += list(list(
+			"name" = role_info["name"],
+			"source" = role_info["source"],
+			"tier" = current_tier,
+			"duels" = duels,
+			"unlocked" = (current_tier > 0),
+			"t1" = role_info["t1"],
+			"t2" = role_info["t2"],
+			"t3" = role_info["t3"],
+		))
+
+	return passives
+
+/// Gets a display name for a role passive component
+/datum/palermitan_skill_tree/proc/get_passive_display_name(datum/component/palermitan_role_passive/P)
+	if(istype(P, /datum/component/palermitan_role_passive/butcher))
+		return "Predator's Instinct (Butcher)"
+	if(istype(P, /datum/component/palermitan_role_passive/blade_lineage))
+		return "Resolve of the Salsu (Blade Lineage)"
+	if(istype(P, /datum/component/palermitan_role_passive/thumb))
+		return "Soldato's Discipline (Thumb)"
+	if(istype(P, /datum/component/palermitan_role_passive/kurokumo))
+		return "Way of the Drawn Blade (Kurokumo)"
+	if(istype(P, /datum/component/palermitan_role_passive/index))
+		return "Prescript Discipline (Index)"
+	if(istype(P, /datum/component/palermitan_role_passive/insurgence))
+		return "Nightwatch Tremors (Insurgence)"
+	if(istype(P, /datum/component/palermitan_role_passive/middle))
+		return "Vengeance Mark (Middle)"
+	if(istype(P, /datum/component/palermitan_role_passive/ncorp))
+		return "Methodical Strikes (N-Corp)"
+	if(istype(P, /datum/component/palermitan_role_passive/rat))
+		return "Scavenger's Luck (Rat)"
+	if(istype(P, /datum/component/palermitan_role_passive/carnival))
+		return "Silk Hunter's Patience (Carnival)"
+	if(istype(P, /datum/component/palermitan_role_passive/zwei))
+		return "Guardian's Resilience (Zwei)"
+	if(istype(P, /datum/component/palermitan_role_passive/seven))
+		return "Analyst's Eye (Seven)"
+	if(istype(P, /datum/component/palermitan_role_passive/dieci))
+		return "Scholar's Insight (Dieci)"
+	if(istype(P, /datum/component/palermitan_role_passive/cinq))
+		return "Duelist's Finesse (Cinq)"
+	if(istype(P, /datum/component/palermitan_role_passive/shi))
+		return "Assassin's Sacrifice (Shi)"
+	if(istype(P, /datum/component/palermitan_role_passive/liu))
+		return "Burning Fist (Liu)"
+	if(istype(P, /datum/component/palermitan_role_passive/devyat))
+		return "Berserker's Escalation (Devyat)"
+	if(istype(P, /datum/component/palermitan_role_passive/hana))
+		return "Adaptive Form (Hana)"
+	return "Unknown Passive"
+
+////////////////////////////////////////////////////////////
+// SKILL TREE ACTION BUTTON
+
+/datum/action/innate/palermitan_tree
+	name = "Palermitan Skill Tree"
+	desc = "Open the Palermitan Style skill tree."
+	button_icon_state = "yourswordinhand"
+
+/datum/action/innate/palermitan_tree/Activate()
+	var/mob/living/carbon/human/user = owner
+	if(!istype(user))
+		return
+	var/datum/palermitan_skill_tree/tree = new(user)
+	tree.ui_interact(user)
+
+////////////////////////////////////////////////////////////
+// GLOBAL SKILL DEFINITIONS — 4 SCHOOLS
+
+GLOBAL_LIST_INIT(palermitan_skill_definitions, init_palermitan_skill_definitions())
+
+/proc/init_palermitan_skill_definitions()
+	var/list/defs = list()
+
+	// ========== TERREMOTO (Tremor) ==========
+	defs["terremoto"] = list(
+		"tier1" = list(
+			"a" = list(
+				"name" = "Il Cacciatore",
+				"desc" = "Your attacks inflict 2 Tremor on the target. Against targets with 3+ 'The Duel Escalates' stacks, you also gain 1 Offense Level Up.",
+				"type" = /datum/component/palermitan_skill/terremoto/il_cacciatore
+			),
+			"b" = list(
+				"name" = "Destabilizing Strikes",
+				"desc" = "Your attacks inflict Tremor that scales with 'The Duel Escalates' stacks on the target: 1 Tremor normally, 2 at 3+ stacks, 3 at 7+ stacks.",
+				"type" = /datum/component/palermitan_skill/terremoto/destabilizing_strikes
+			)
+		),
+		"tier2" = list(
+			"a" = list(
+				"name" = "Palermitan Rapier",
+				"desc" = "Unlocks Tremor Burst at 15 stacks. When you trigger a Tremor Burst, gain 5 Offense Level Up and 5 Poise.",
+				"type" = /datum/component/palermitan_skill/terremoto/palermitan_rapier
+			),
+			"b" = list(
+				"name" = "Aftershock",
+				"desc" = "Unlocks Tremor Burst at 25 stacks. Hitting targets with 10+ Tremor inflicts 2 Offense Level Down. At 20+ Tremor, inflicts 3 instead.",
+				"type" = /datum/component/palermitan_skill/terremoto/aftershock
+			)
+		),
+		"tier3" = list(
+			"a" = list(
+				"name" = "Sezionatura di Cervo",
+				"desc" = "Activate to prime your next attack (60s cooldown). The primed hit inflicts 4 Tremor and 4 Overheat, forces a Tremor Burst if the target has 10+ 'The Duel Escalates' stacks, and deals bonus RED damage equal to 2 times the target's stacks. Consumes half the stacks.",
+				"type" = /datum/component/palermitan_skill/terremoto/sezionatura
+			),
+			"b" = list(
+				"name" = "Tectonic Collapse",
+				"desc" = "Whenever you trigger a Tremor Burst, the target gains 3 Fragile, 3 Defense Level Down, and 2 Overheat.",
+				"type" = /datum/component/palermitan_skill/terremoto/tectonic_collapse
+			)
+		)
+	)
+
+	// ========== INCENDIO (Overheat) ==========
+	defs["incendio"] = list(
+		"tier1" = list(
+			"a" = list(
+				"name" = "Colpi Sottani",
+				"desc" = "Your attacks inflict 2 Overheat on the target. Against targets with 3+ 'The Duel Escalates' stacks, inflict 3 Overheat instead.",
+				"type" = /datum/component/palermitan_skill/incendio/colpi_sottani
+			),
+			"b" = list(
+				"name" = "Scorching Pursuit",
+				"desc" = "Your attacks inflict 1 Overheat (2 at 5+ 'The Duel Escalates' stacks). Hitting a burning target also grants you 1 Offense Level Up.",
+				"type" = /datum/component/palermitan_skill/incendio/scorching_pursuit
+			)
+		),
+		"tier2" = list(
+			"a" = list(
+				"name" = "Firestorm",
+				"desc" = "Hitting a target with 10 or more Overheat stacks grants you 3 Offense Level Up and 3 Poise.",
+				"type" = /datum/component/palermitan_skill/incendio/firestorm
+			),
+			"b" = list(
+				"name" = "Smoldering Wounds",
+				"desc" = "Hitting a burning target inflicts 1 Defense Level Down for every 5 Overheat stacks on them (max 3 Defense Level Down).",
+				"type" = /datum/component/palermitan_skill/incendio/smoldering_wounds
+			)
+		),
+		"tier3" = list(
+			"a" = list(
+				"name" = "La Spada di Palermo",
+				"desc" = "Hitting a target with 10+ 'The Duel Escalates' stacks grants a massive power surge: 5 Offense Level Up and 3 Damage Up. Also inflicts 3 Tremor. Consumes 5 stacks. 30 second cooldown.",
+				"type" = /datum/component/palermitan_skill/incendio/la_spada
+			),
+			"b" = list(
+				"name" = "Conflagration",
+				"desc" = "Hitting a target with 15+ Overheat detonates their burn: deals bonus RED damage equal to their Overheat stacks, reduces Overheat by 5, and inflicts 2 Tremor. 10 second cooldown.",
+				"type" = /datum/component/palermitan_skill/incendio/conflagration
+			)
+		)
+	)
+
+	// ========== ELEGANZA (Poise/Concentration) ==========
+	defs["eleganza"] = list(
+		"tier1" = list(
+			"a" = list(
+				"name" = "Relentless Pursuit",
+				"desc" = "When the target has under 5 'The Duel Escalates' stacks: gain 2 Poise per hit. At 5+ stacks: gain 5 Poise per hit instead.",
+				"type" = /datum/component/palermitan_skill/eleganza/relentless_pursuit
+			),
+			"b" = list(
+				"name" = "Focused Mind",
+				"desc" = "When the target has under 5 'The Duel Escalates' stacks: gain 1 Poise and 1 Concentration every 10 seconds. At 5+ stacks: gain 3 Poise per hit instead.",
+				"type" = /datum/component/palermitan_skill/eleganza/focused_mind
+			)
+		),
+		"tier2" = list(
+			"a" = list(
+				"name" = "Duello Feroce",
+				"desc" = "Hitting a target with 3+ 'The Duel Escalates' stacks grants Poise (1 per 3 stacks, max 3) and heals you (2 HP per stack, max 10). When a crit halves your Poise, gain 1 Concentration.",
+				"type" = /datum/component/palermitan_skill/eleganza/duello_feroce
+			),
+			"b" = list(
+				"name" = "Severed Tendon",
+				"desc" = "Your Poise crits inflict 3 Offense Level Down and 1 Fragile on the target. When a crit halves your Poise, you recover 5 Poise.",
+				"type" = /datum/component/palermitan_skill/eleganza/severed_tendon
+			)
+		),
+		"tier3" = list(
+			"a" = list(
+				"name" = "Valencina's Legacy",
+				"desc" = "Your Poise crits inflict 3 Tremor and 3 Overheat on the target, and spread 'The Duel Escalates' to enemies within 2 tiles. Every 15 seconds, a crit also grants 1 Concentration.",
+				"type" = /datum/component/palermitan_skill/eleganza/valencinas_legacy
+			),
+			"b" = list(
+				"name" = "The Famiglia's Honor",
+				"desc" = "'The Duel Escalates' can stack to 30. At 15+ stacks you gain 2 Poise per hit, and crits that halve your Poise grant 1 Concentration. Crits at 20+ stacks inflict 3 Fragile and 3 Defense Level Down.",
+				"type" = /datum/component/palermitan_skill/eleganza/famiglias_honor
+			)
+		)
+	)
+
+	// ========== FONDAMENTI (General) ==========
+	defs["fondamenti"] = list(
+		"tier1" = list(
+			"a" = list(
+				"name" = "Iron Constitution",
+				"desc" = "Whenever you take damage, gain 2 Defense Level Up, reducing future damage taken.",
+				"type" = /datum/component/palermitan_skill/fondamenti/iron_constitution
+			),
+			"b" = list(
+				"name" = "Aggressive Footwork",
+				"desc" = "Gain 1 Offense Level Up whenever you hit a target or take melee damage. Every exchange makes you stronger.",
+				"type" = /datum/component/palermitan_skill/fondamenti/aggressive_footwork
+			)
+		),
+		"tier2" = list(
+			"a" = list(
+				"name" = "Predator's Instinct",
+				"desc" = "Hitting targets below 50% HP makes them Fragile and grants you 2 Poise. Below 25% HP also grants 5 Offense Level Up and 2 more Poise.",
+				"type" = /datum/component/palermitan_skill/fondamenti/predators_instinct
+			),
+			"b" = list(
+				"name" = "Enduring Spirit",
+				"desc" = "Hitting a target with 3+ 'The Duel Escalates' stacks heals you (1 HP per stack, max 5). Taking damage near a target with 'The Duel Escalates' grants 1 Defense Level Up.",
+				"type" = /datum/component/palermitan_skill/fondamenti/enduring_spirit
+			)
+		),
+		"tier3" = list(
+			"a" = list(
+				"name" = "Coup de Gr\u00e2ce",
+				"desc" = "Hitting a target below 20% HP who has 5+ 'The Duel Escalates' stacks deals massive bonus RED damage (3 per stack). Consumes half the stacks.",
+				"type" = /datum/component/palermitan_skill/fondamenti/coup_de_grace
+			),
+			"b" = list(
+				"name" = "Unbreakable Will",
+				"desc" = "When you enter critical condition, gain 5 Defense Level Up, 3 Protection, and heal 10% of your max HP. 60 second cooldown.",
+				"type" = /datum/component/palermitan_skill/fondamenti/unbreakable_will
+			)
+		)
+	)
+
+	return defs

--- a/code/datums/components/nursefather_passive.dm
+++ b/code/datums/components/nursefather_passive.dm
@@ -69,6 +69,7 @@
 /datum/component/nursefather_passive/middle
 
 /datum/component/nursefather_passive/middle/on_damage_taken(datum/source, damage, damagetype, def_zone, attack_source, flags, attack_type)
+	SIGNAL_HANDLER
 	if(!damage || damage <= 0)
 		return
 

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -2100,7 +2100,10 @@
 	else
 		// Humans: deal sanity damage equal to stacks
 		var/mob/living/carbon/human/H = owner
-		H.adjustSanityLoss(stacks)
+		if(!HAS_TRAIT(H, TRAIT_BRUTESANITY))
+			H.adjustSanityLoss(stacks)
+		else
+			H.adjustBruteLoss(stacks)
 
 	triggering = FALSE
 
@@ -2246,3 +2249,105 @@
 		return
 	R.add_undecaying_stacks(undecaying_stacks)
 	R.add_stacks(stacks)
+
+////////////////////////////////////////////////////////////
+// THE DUEL ESCALATES - Palermitan Style apprentice debuff
+// Stacks on the target as the apprentice hits them repeatedly.
+// Grants the apprentice scaling bonuses against targets with this effect.
+// Expires if no new stacks are added within the tick interval.
+/datum/status_effect/stacking/duel_escalates
+	id = "duel_escalates"
+	alert_type = /atom/movable/screen/alert/status_effect/duel_escalates
+	stacking_display_name = "duel escalates"
+	max_stacks = 20
+	tick_interval = 10 SECONDS
+	consumed_on_threshold = FALSE
+	/// Which mob inflicted this (the apprentice)
+	var/mob/living/duelist
+	/// Whether new stacks were added this tick period
+	var/new_stack = TRUE
+
+/atom/movable/screen/alert/status_effect/duel_escalates
+	name = "The Duel Escalates"
+	desc = "Your opponent grows stronger against you with each exchange! Stacks: "
+	icon = 'ModularLobotomy/_Lobotomyicons/status_sprites.dmi'
+	icon_state = "tremor"
+
+/datum/status_effect/stacking/duel_escalates/on_apply()
+	. = ..()
+
+/datum/status_effect/stacking/duel_escalates/add_stacks(stacks_added)
+	. = ..()
+	if(stacks_added > 0)
+		new_stack = TRUE
+	if(owner)
+		linked_alert.desc = initial(linked_alert.desc) + "[stacks]"
+
+/datum/status_effect/stacking/duel_escalates/can_have_status()
+	return (owner.stat != DEAD || !(owner.status_flags & GODMODE))
+
+/datum/status_effect/stacking/duel_escalates/tick()
+	if(new_stack)
+		new_stack = FALSE
+	else
+		qdel(src)
+
+/// Mob proc to apply Duel Escalates stacks. Pass the duelist (apprentice) who is inflicting it.
+/mob/living/proc/apply_duel_escalates(stacks, mob/living/duelist)
+	var/datum/status_effect/stacking/duel_escalates/D = src.has_status_effect(/datum/status_effect/stacking/duel_escalates)
+	if(!D)
+		var/datum/status_effect/stacking/duel_escalates/new_D = src.apply_status_effect(/datum/status_effect/stacking/duel_escalates, stacks)
+		if(new_D)
+			new_D.duelist = duelist
+		return
+	D.duelist = duelist
+	D.add_stacks(stacks)
+
+////////////////////////////////////////////////////////////
+// SEVERED TENDON - Palermitan Style debuff (from skill tree tier 1a)
+// Reduces the target's melee damage via Offense Level Down application.
+// Decays 1 stack per tick.
+/datum/status_effect/stacking/severed_tendon
+	id = "severed_tendon"
+	alert_type = /atom/movable/screen/alert/status_effect/severed_tendon
+	stacking_display_name = "severed tendon"
+	max_stacks = 3
+	tick_interval = 10 SECONDS
+	consumed_on_threshold = FALSE
+
+/atom/movable/screen/alert/status_effect/severed_tendon
+	name = "Severed Tendon"
+	desc = "Your tendons have been cut, weakening your attacks! Stacks: "
+	icon = 'ModularLobotomy/_Lobotomyicons/status_sprites.dmi'
+	icon_state = "feeble"
+
+/datum/status_effect/stacking/severed_tendon/on_apply()
+	. = ..()
+	if(owner)
+		owner.apply_lc_offense_level_down(stacks * 5)
+
+/datum/status_effect/stacking/severed_tendon/add_stacks(stacks_added)
+	var/old_stacks = stacks
+	. = ..()
+	if(owner)
+		var/diff = stacks - old_stacks
+		if(diff > 0)
+			owner.apply_lc_offense_level_down(diff * 5)
+		linked_alert.desc = initial(linked_alert.desc) + "[stacks]"
+
+/datum/status_effect/stacking/severed_tendon/can_have_status()
+	return (owner.stat != DEAD || !(owner.status_flags & GODMODE))
+
+/// Decay 1 stack per tick
+/datum/status_effect/stacking/severed_tendon/tick()
+	add_stacks(-1)
+	if(stacks <= 0)
+		qdel(src)
+
+/// Mob proc to apply Severed Tendon stacks
+/mob/living/proc/apply_severed_tendon(stacks)
+	var/datum/status_effect/stacking/severed_tendon/S = src.has_status_effect(/datum/status_effect/stacking/severed_tendon)
+	if(!S)
+		src.apply_status_effect(/datum/status_effect/stacking/severed_tendon, stacks)
+		return
+	S.add_stacks(stacks)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -2250,7 +2250,6 @@
 	R.add_undecaying_stacks(undecaying_stacks)
 	R.add_stacks(stacks)
 
-////////////////////////////////////////////////////////////
 // THE DUEL ESCALATES - Palermitan Style apprentice debuff
 // Stacks on the target as the apprentice hits them repeatedly.
 // Grants the apprentice scaling bonuses against targets with this effect.
@@ -2303,7 +2302,6 @@
 	D.duelist = duelist
 	D.add_stacks(stacks)
 
-////////////////////////////////////////////////////////////
 // SEVERED TENDON - Palermitan Style debuff (from skill tree tier 1a)
 // Reduces the target's melee damage via Offense Level Down application.
 // Decays 1 stack per tick.

--- a/code/modules/clothing/suits/ego_gear/non_abnormality/thumb.dm
+++ b/code/modules/clothing/suits/ego_gear/non_abnormality/thumb.dm
@@ -124,7 +124,6 @@
 		/obj/item/stack/thumb_east_ammo/spent/tigermark/savage,
 		))
 
-////////////////////////////////////////////////////////////
 // THUMB SPIDER ARMOR SECTION.
 /obj/item/clothing/suit/armor/ego_gear/city/thumb_spider
 	icon = 'icons/obj/spider_house/thumb/thumb_spider_icon.dmi'

--- a/code/modules/clothing/suits/ego_gear/non_abnormality/thumb.dm
+++ b/code/modules/clothing/suits/ego_gear/non_abnormality/thumb.dm
@@ -123,3 +123,60 @@
 		/obj/item/stack/thumb_east_ammo/spent/tigermark,
 		/obj/item/stack/thumb_east_ammo/spent/tigermark/savage,
 		))
+
+////////////////////////////////////////////////////////////
+// THUMB SPIDER ARMOR SECTION.
+/obj/item/clothing/suit/armor/ego_gear/city/thumb_spider
+	icon = 'icons/obj/spider_house/thumb/thumb_spider_icon.dmi'
+	worn_icon = 'icons/obj/spider_house/thumb/thumb_spider_worn.dmi'
+
+/obj/item/clothing/suit/armor/ego_gear/city/thumb_spider/ex_sottocapo
+	name = "thumb ex-sottocapo armor"
+	desc = "Armor once worn by a sottocapo of the Thumb. It has been repurposed for a new owner."
+	icon_state = "thumb_ex_sottocapo"
+	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 40, BLACK_DAMAGE = 50, PALE_DAMAGE = 60)
+	attribute_requirements = list(
+							FORTITUDE_ATTRIBUTE = 100,
+							PRUDENCE_ATTRIBUTE = 100,
+							TEMPERANCE_ATTRIBUTE = 100,
+							JUSTICE_ATTRIBUTE = 100
+							)
+
+/obj/item/clothing/suit/armor/ego_gear/city/thumb_spider/apprentice
+	name = "thumb apprentice armor"
+	desc = "Armor worn by an apprentice of the Thumb. It seems to have room to grow."
+	icon_state = "thumb_apprentice"
+	armor = list(RED_DAMAGE = 20, WHITE_DAMAGE = 10, BLACK_DAMAGE = 10, PALE_DAMAGE = 20)
+	attribute_requirements = list(
+							FORTITUDE_ATTRIBUTE = 40,
+							PRUDENCE_ATTRIBUTE = 40,
+							TEMPERANCE_ATTRIBUTE = 40,
+							JUSTICE_ATTRIBUTE = 40
+							)
+	/// Current evolution tier (1-4)
+	var/tier = 1
+
+/// Sets the armor to a specific evolution tier. Updates armor values, requirements, name, and desc.
+/obj/item/clothing/suit/armor/ego_gear/city/thumb_spider/apprentice/proc/set_tier(new_tier)
+	tier = clamp(new_tier, 1, 4)
+	switch(tier)
+		if(1) // 60 total, below soldato tier
+			name = "thumb apprentice armor"
+			desc = "Armor worn by an apprentice of the Thumb. It seems to have room to grow."
+			armor = getArmor(red = 20, white = 10, black = 10, pale = 20)
+			attribute_requirements = list(FORTITUDE_ATTRIBUTE = 40, PRUDENCE_ATTRIBUTE = 40, TEMPERANCE_ATTRIBUTE = 40, JUSTICE_ATTRIBUTE = 40)
+		if(2) // 90 total, soldato tier
+			name = "thumb apprentice armor"
+			desc = "Armor worn by an apprentice of the Thumb. It has been tempered through experience."
+			armor = getArmor(red = 30, white = 20, black = 20, pale = 20)
+			attribute_requirements = list(FORTITUDE_ATTRIBUTE = 60, PRUDENCE_ATTRIBUTE = 60, TEMPERANCE_ATTRIBUTE = 60, JUSTICE_ATTRIBUTE = 60)
+		if(3) // 130 total, capo tier
+			name = "thumb apprentice armor"
+			desc = "Armor worn by an apprentice of the Thumb. It has been battle-hardened."
+			armor = getArmor(red = 40, white = 30, black = 30, pale = 30)
+			attribute_requirements = list(FORTITUDE_ATTRIBUTE = 80, PRUDENCE_ATTRIBUTE = 80, TEMPERANCE_ATTRIBUTE = 80, JUSTICE_ATTRIBUTE = 80)
+		if(4) // 210 total, sottocapo tier
+			name = "thumb apprentice armor"
+			desc = "Armor worn by an apprentice of the Thumb. It has reached its full potential."
+			armor = getArmor(red = 60, white = 50, black = 50, pale = 50)
+			attribute_requirements = list(FORTITUDE_ATTRIBUTE = 100, PRUDENCE_ATTRIBUTE = 100, TEMPERANCE_ATTRIBUTE = 100, JUSTICE_ATTRIBUTE = 100)

--- a/code/modules/jobs/job_types/trusted_players/thumb_nursefather.dm
+++ b/code/modules/jobs/job_types/trusted_players/thumb_nursefather.dm
@@ -40,6 +40,8 @@
 /datum/job/ex_thumb_sottocapo/after_spawn(mob/living/carbon/human/H, mob/M)
 	ADD_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE, JOB_TRAIT)
 	ADD_TRAIT(H, TRAIT_WORK_FORBIDDEN, JOB_TRAIT)
+	H.AddComponent(/datum/component/nursefather_passive)
+	H.AddComponent(/datum/component/nursefather_music, NURSEFATHER_FINGER_THUMB)
 
 	// Insert the Eye of Odin
 	var/obj/item/organ/eyes/robotic/odin_eye/eye = new()
@@ -388,6 +390,11 @@
 
 	to_chat(H, span_boldnotice("Transforming into Ex Thumb Sottocapo..."))
 
+	// Drop all held and worn items
+	H.drop_all_held_items()
+	for(var/obj/item/I in H.get_equipped_items())
+		H.dropItemToGround(I, TRUE)
+
 	// Set attributes
 	H.set_attribute_limit(200)
 	for(var/attr_name in list(FORTITUDE_ATTRIBUTE, PRUDENCE_ATTRIBUTE, TEMPERANCE_ATTRIBUTE, JUSTICE_ATTRIBUTE))
@@ -413,6 +420,7 @@
 
 	// Add nursefather passive
 	H.AddComponent(/datum/component/nursefather_passive)
+	H.AddComponent(/datum/component/nursefather_music, NURSEFATHER_FINGER_THUMB)
 
 	// Equip outfit basics
 	var/datum/outfit/job/ex_thumb_sottocapo/outfit = new()
@@ -437,4 +445,109 @@
 	to_chat(H, span_boldnotice("You are now the Ex Thumb Sottocapo. Check your backpack for weapons and ammo."))
 
 	// Consume the debug item
+	qdel(src)
+
+////////////////////////////////////////////////////////////
+// GHOST POLL SPAWN ITEM
+// Use in hand to poll trusted ghosts, then spawn the selected one as Ex Thumb Sottocapo.
+
+/obj/item/thumb_nursefather_ghost_spawn
+	name = "thumbfather's calling card"
+	desc = "A debug item. Use in hand to poll trusted ghosts for an Ex Thumb Sottocapo player."
+	icon = 'icons/obj/radio.dmi'
+	icon_state = "radio"
+	w_class = WEIGHT_CLASS_TINY
+	/// Whether a poll is currently active
+	var/polling = FALSE
+
+/obj/item/thumb_nursefather_ghost_spawn/attack_self(mob/living/user)
+	if(!ishuman(user))
+		to_chat(user, span_warning("Only humans can use this."))
+		return
+	if(polling)
+		to_chat(user, span_warning("A poll is already in progress!"))
+		return
+
+	polling = TRUE
+	to_chat(user, span_notice("Polling ghosts for an Ex Thumb Sottocapo candidate..."))
+
+	var/turf/spawn_loc = get_turf(src)
+
+	var/list/candidates = pollGhostCandidates("Do you wish to become the Ex Thumb Sottocapo?", ROLE_TRAITOR, poll_time = 300)
+
+	if(QDELETED(src))
+		return
+
+	// Filter for trusted players
+	var/list/trusted_candidates = list()
+	for(var/mob/dead/observer/candidate in candidates)
+		if(candidate.client && is_trusted_player(candidate.client))
+			trusted_candidates += candidate
+		else if(candidate.client)
+			to_chat(candidate, span_warning("You were not selected because this role requires trusted player status."))
+
+	if(!length(trusted_candidates))
+		to_chat(user, span_warning("No trusted candidates accepted the poll."))
+		polling = FALSE
+		return
+
+	var/mob/dead/observer/chosen = pick(trusted_candidates)
+	var/mob/living/carbon/human/H = makeBody(chosen)
+	if(!H)
+		to_chat(user, span_warning("Failed to create a body for the candidate."))
+		polling = FALSE
+		return
+
+	H.forceMove(spawn_loc)
+
+	// Set attributes
+	H.set_attribute_limit(200)
+	for(var/attr_name in list(FORTITUDE_ATTRIBUTE, PRUDENCE_ATTRIBUTE, TEMPERANCE_ATTRIBUTE, JUSTICE_ATTRIBUTE))
+		var/datum/attribute/A = H.attributes[attr_name]
+		if(A)
+			if(attr_name in list(FORTITUDE_ATTRIBUTE, PRUDENCE_ATTRIBUTE))
+				A.level = 150
+			else
+				A.level = 100
+			A.on_update(H)
+
+	// Set role
+	if(H.mind)
+		H.mind.assigned_role = "Ex Thumb Sottocapo"
+
+	// Add traits
+	ADD_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE, JOB_TRAIT)
+	ADD_TRAIT(H, TRAIT_WORK_FORBIDDEN, JOB_TRAIT)
+
+	// Insert Eye of Odin
+	var/obj/item/organ/eyes/robotic/odin_eye/eye = new()
+	eye.Insert(H)
+
+	// Add nursefather components
+	H.AddComponent(/datum/component/nursefather_passive)
+	H.AddComponent(/datum/component/nursefather_music, NURSEFATHER_FINGER_THUMB)
+
+	// Equip outfit
+	var/datum/outfit/job/ex_thumb_sottocapo/outfit = new()
+	outfit.equip(H)
+
+	// Spawn armor into hand
+	var/obj/item/clothing/suit/armor/ego_gear/city/thumb_spider/ex_sottocapo/armor = new(H)
+	H.put_in_hands(armor)
+
+	// Spawn weapons and ammo into backpack
+	var/obj/item/storage/backpack/BP = locate() in H.contents
+	if(BP)
+		new /obj/item/ego_weapon/city/thumbfather_rapier(BP)
+		new /obj/item/ego_weapon/city/thumbfather_katana(BP)
+		new /obj/item/storage/box/thumb_east_ammo/acceleration(BP)
+		new /obj/item/storage/box/thumb_east_ammo/acceleration(BP)
+
+	// Grant rules action
+	var/datum/action/innate/view_role_rules/thumb_nursefather/rules = new
+	rules.Grant(H)
+
+	to_chat(H, span_boldnotice("You are the Ex Thumb Sottocapo. Check your backpack for weapons and ammo."))
+
+	// Consume the item
 	qdel(src)

--- a/code/modules/jobs/job_types/trusted_players/thumb_nursefather.dm
+++ b/code/modules/jobs/job_types/trusted_players/thumb_nursefather.dm
@@ -1,11 +1,9 @@
-////////////////////////////////////////////////////////////
 // EX THUMB SOTTOCAPO
 //
 // A trusted player role for a former Sottocapo of the Thumb's spider house
 // who dual-wields a rapier and katana with acceleration propellant ammunition.
 // They have 150 Fortitude and come equipped with their weapons, armor, ammo,
 // Eye of Odin, and a suspicious phone for ordering additional ammo supplies.
-////////////////////////////////////////////////////////////
 
 /datum/job/ex_thumb_sottocapo
 	title = "Ex Thumb Sottocapo"
@@ -76,12 +74,10 @@
 	r_pocket = /obj/item/nursefather_phone
 	l_pocket = /obj/item/apprentice_recruitment/thumb_nursefather
 
-////////////////////////////////////////////////////////////
 // NURSEFATHER PHONE - Ammo requisition device
 //
 // A suspicious phone that lets the Ex Thumb Sottocapo order additional
 // boxes of acceleration propellant ammunition for 1500 ahn.
-////////////////////////////////////////////////////////////
 
 /obj/item/nursefather_phone
 	name = "suspicious phone"
@@ -134,7 +130,6 @@
 	. = ..()
 	. += span_notice("Use in-hand to order a box of acceleration propellant ammunition for <b>1500 ahn</b>.")
 
-////////////////////////////////////////////////////////////
 // THUMB APPRENTICE RECRUITMENT SCROLL
 /obj/item/apprentice_recruitment/thumb_nursefather
 	name = "thumb apprenticeship scroll"
@@ -222,7 +217,6 @@
 	to_chat(H, span_boldnotice("Review your role rules by clicking the 'View Thumb Rules' action button."))
 	to_chat(H, span_boldwarning("Follow the orders of your mentor. Act in the Thumb's interest."))
 
-////////////////////////////////////////////////////////////
 // ROLE RULES ACTIONS
 
 /datum/action/innate/view_role_rules/thumb_nursefather
@@ -370,7 +364,6 @@
 	</div>
 	"}
 
-////////////////////////////////////////////////////////////
 // DEBUG TRANSFORM ITEM
 // Use in hand to become the Ex Thumb Sottocapo with full loadout.
 
@@ -447,7 +440,6 @@
 	// Consume the debug item
 	qdel(src)
 
-////////////////////////////////////////////////////////////
 // GHOST POLL SPAWN ITEM
 // Use in hand to poll trusted ghosts, then spawn the selected one as Ex Thumb Sottocapo.
 

--- a/code/modules/jobs/job_types/trusted_players/thumb_nursefather.dm
+++ b/code/modules/jobs/job_types/trusted_players/thumb_nursefather.dm
@@ -367,3 +367,74 @@
 		</ul>
 	</div>
 	"}
+
+////////////////////////////////////////////////////////////
+// DEBUG TRANSFORM ITEM
+// Use in hand to become the Ex Thumb Sottocapo with full loadout.
+
+/obj/item/thumb_nursefather_debug
+	name = "thumbfather signet ring"
+	desc = "A debug item. Use in hand to transform into the Ex Thumb Sottocapo with full gear and abilities."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "hypertool"
+	w_class = WEIGHT_CLASS_TINY
+
+/obj/item/thumb_nursefather_debug/attack_self(mob/living/user)
+	. = ..()
+	if(!ishuman(user))
+		to_chat(user, span_warning("Only humans can use this."))
+		return
+	var/mob/living/carbon/human/H = user
+
+	to_chat(H, span_boldnotice("Transforming into Ex Thumb Sottocapo..."))
+
+	// Set attributes
+	H.set_attribute_limit(200)
+	for(var/attr_name in list(FORTITUDE_ATTRIBUTE, PRUDENCE_ATTRIBUTE, TEMPERANCE_ATTRIBUTE, JUSTICE_ATTRIBUTE))
+		var/datum/attribute/A = H.attributes[attr_name]
+		if(A)
+			if(attr_name in list(FORTITUDE_ATTRIBUTE, PRUDENCE_ATTRIBUTE))
+				A.level = 150
+			else
+				A.level = 100
+			A.on_update(H)
+
+	// Set role
+	if(H.mind)
+		H.mind.assigned_role = "Ex Thumb Sottocapo"
+
+	// Add traits
+	ADD_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE, JOB_TRAIT)
+	ADD_TRAIT(H, TRAIT_WORK_FORBIDDEN, JOB_TRAIT)
+
+	// Insert Eye of Odin
+	var/obj/item/organ/eyes/robotic/odin_eye/eye = new()
+	eye.Insert(H)
+
+	// Add nursefather passive
+	H.AddComponent(/datum/component/nursefather_passive)
+
+	// Equip outfit basics
+	var/datum/outfit/job/ex_thumb_sottocapo/outfit = new()
+	outfit.equip(H)
+
+	// Spawn armor into hand
+	var/obj/item/clothing/suit/armor/ego_gear/city/thumb_spider/ex_sottocapo/armor = new(H)
+	H.put_in_hands(armor)
+
+	// Spawn weapons and ammo into backpack
+	var/obj/item/storage/backpack/BP = locate() in H.contents
+	if(BP)
+		new /obj/item/ego_weapon/city/thumbfather_rapier(BP)
+		new /obj/item/ego_weapon/city/thumbfather_katana(BP)
+		new /obj/item/storage/box/thumb_east_ammo/acceleration(BP)
+		new /obj/item/storage/box/thumb_east_ammo/acceleration(BP)
+
+	// Grant rules action
+	var/datum/action/innate/view_role_rules/thumb_nursefather/rules = new
+	rules.Grant(H)
+
+	to_chat(H, span_boldnotice("You are now the Ex Thumb Sottocapo. Check your backpack for weapons and ammo."))
+
+	// Consume the debug item
+	qdel(src)

--- a/code/modules/jobs/job_types/trusted_players/thumb_nursefather.dm
+++ b/code/modules/jobs/job_types/trusted_players/thumb_nursefather.dm
@@ -1,1 +1,369 @@
-// Stub - populated by the Thumb sub-PR
+////////////////////////////////////////////////////////////
+// EX THUMB SOTTOCAPO
+//
+// A trusted player role for a former Sottocapo of the Thumb's spider house
+// who dual-wields a rapier and katana with acceleration propellant ammunition.
+// They have 150 Fortitude and come equipped with their weapons, armor, ammo,
+// Eye of Odin, and a suspicious phone for ordering additional ammo supplies.
+////////////////////////////////////////////////////////////
+
+/datum/job/ex_thumb_sottocapo
+	title = "Ex Thumb Sottocapo"
+	outfit = /datum/outfit/job/ex_thumb_sottocapo
+	department_head = list("Thumb Sottocapo")
+	faction = "Station"
+	supervisors = "the Thumb's hierarchy"
+	selection_color = "#8b0000"
+	total_positions = 0
+	spawn_positions = 0
+	display_order = JOB_DISPLAY_ORDER_SYNDICATEHEAD
+	trusted_only = TRUE
+	access = list(ACCESS_SYNDICATE, ACCESS_SYNDICATE_LEADER)
+	minimal_access = list(ACCESS_SYNDICATE, ACCESS_SYNDICATE_LEADER)
+	departments = DEPARTMENT_COMMAND | DEPARTMENT_CITY_ANTAGONIST
+	paycheck = 1000
+	maptype = list("city", "fixers")
+	job_important = "You are a former Sottocapo of the Thumb - a high-ranking operative of the spider house. \
+		You dual-wield a rapier and katana loaded with acceleration propellant ammunition. \
+		Your combo requires weapon-swapping: lunge with one weapon, AoE sweep with the other, then finish with the first. \
+		Your Eye of Odin grants precognitive evasion against melee attacks, but overheats if overused. \
+		Use your suspicious phone to order additional ammunition."
+	job_notice = "You are a Syndicate operative. Act accordingly."
+
+	roundstart_attributes = list(
+		FORTITUDE_ATTRIBUTE = 150,
+		PRUDENCE_ATTRIBUTE = 150,
+		TEMPERANCE_ATTRIBUTE = 100,
+		JUSTICE_ATTRIBUTE = 100
+	)
+
+/datum/job/ex_thumb_sottocapo/after_spawn(mob/living/carbon/human/H, mob/M)
+	ADD_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE, JOB_TRAIT)
+	ADD_TRAIT(H, TRAIT_WORK_FORBIDDEN, JOB_TRAIT)
+
+	// Insert the Eye of Odin
+	var/obj/item/organ/eyes/robotic/odin_eye/eye = new()
+	eye.Insert(H)
+
+	// Equip armor into hand (too bulky for suit slot auto-equip)
+	var/obj/item/clothing/suit/armor/ego_gear/city/thumb_spider/ex_sottocapo/armor = new(H)
+	H.put_in_l_hand(armor)
+
+	// Put weapons and ammo boxes into backpack directly
+	var/obj/item/storage/backpack/BP = locate() in H.contents
+	if(BP)
+		new /obj/item/ego_weapon/city/thumbfather_rapier(BP)
+		new /obj/item/ego_weapon/city/thumbfather_katana(BP)
+		new /obj/item/storage/box/thumb_east_ammo/acceleration(BP)
+		new /obj/item/storage/box/thumb_east_ammo/acceleration(BP)
+
+	// Grant rules action
+	var/datum/action/innate/view_role_rules/thumb_nursefather/rules = new
+	rules.Grant(H)
+
+	. = ..()
+
+/datum/outfit/job/ex_thumb_sottocapo
+	name = "Ex Thumb Sottocapo"
+	jobtype = /datum/job/ex_thumb_sottocapo
+
+	id = /obj/item/card/id/silver/plastic
+	belt = /obj/item/pda/security
+	uniform = /obj/item/clothing/under/suit/charcoal
+	shoes = /obj/item/clothing/shoes/laceup
+	r_pocket = /obj/item/nursefather_phone
+	l_pocket = /obj/item/apprentice_recruitment/thumb_nursefather
+
+////////////////////////////////////////////////////////////
+// NURSEFATHER PHONE - Ammo requisition device
+//
+// A suspicious phone that lets the Ex Thumb Sottocapo order additional
+// boxes of acceleration propellant ammunition for 1500 ahn.
+////////////////////////////////////////////////////////////
+
+/obj/item/nursefather_phone
+	name = "suspicious phone"
+	desc = "A heavily encrypted phone used by Thumb operatives to place discreet supply orders. The contact list has a single entry labeled 'Procurement'."
+	icon = 'icons/obj/items_and_weapons.dmi'
+	icon_state = "suspiciousphone"
+	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/nursefather_phone/attack_self(mob/living/user)
+	. = ..()
+	if(!isliving(user))
+		return
+
+	var/obj/item/card/id/C = user.get_idcard(TRUE)
+	if(!C)
+		to_chat(user, span_warning("You need an ID card to place an order."))
+		return
+	if(!C.registered_account)
+		to_chat(user, span_warning("Your ID card has no registered bank account."))
+		return
+
+	var/datum/bank_account/account = C.registered_account
+	var/cost = 1500
+
+	if(!account.has_money(cost))
+		to_chat(user, span_warning("Insufficient funds. You need [cost] ahn to order ammunition. You have [account.account_balance] ahn."))
+		playsound(src, 'sound/machines/buzz-two.ogg', 25, TRUE)
+		return
+
+	// Confirm the purchase
+	var/confirm = tgui_alert(user, "Order a box of acceleration propellant ammunition for [cost] ahn? (Balance: [account.account_balance] ahn)", "Ammunition Requisition", list("Confirm", "Cancel"))
+	if(confirm != "Confirm")
+		return
+	// Re-check after the alert (user could have moved, spent money, etc.)
+	if(!Adjacent(user) || QDELETED(src) || QDELETED(user))
+		return
+	if(!account.has_money(cost))
+		to_chat(user, span_warning("Insufficient funds."))
+		playsound(src, 'sound/machines/buzz-two.ogg', 25, TRUE)
+		return
+
+	account.adjust_money(-cost)
+	var/obj/item/storage/box/thumb_east_ammo/acceleration/ammo_box = new(get_turf(user))
+	if(!user.put_in_hands(ammo_box))
+		ammo_box.forceMove(get_turf(user))
+	playsound(src, 'sound/effects/cashregister.ogg', 25, TRUE)
+	to_chat(user, span_notice("Order confirmed. A box of acceleration propellant ammunition has been delivered. Remaining balance: [account.account_balance] ahn."))
+
+/obj/item/nursefather_phone/examine(mob/user)
+	. = ..()
+	. += span_notice("Use in-hand to order a box of acceleration propellant ammunition for <b>1500 ahn</b>.")
+
+////////////////////////////////////////////////////////////
+// THUMB APPRENTICE RECRUITMENT SCROLL
+/obj/item/apprentice_recruitment/thumb_nursefather
+	name = "thumb apprenticeship scroll"
+	desc = "A scroll that allows you to recruit an apprentice into the Thumb's spider house."
+
+/obj/item/apprentice_recruitment/thumb_nursefather/get_offer_text(mob/living/user)
+	return "[user] is offering to make you their Thumb Apprentice. Do you accept?"
+
+/obj/item/apprentice_recruitment/thumb_nursefather/get_offer_title()
+	return "Apprenticeship Offer"
+
+/obj/item/apprentice_recruitment/thumb_nursefather/recruit_apprentice(mob/living/carbon/human/H, mob/living/user)
+	// Any prior Nursefather role (Ring, Index, etc.) is automatically cleaned up by
+	// COMSIG_NURSEFATHER_RECRUITMENT_OVERRIDE sent in the base class before this proc runs.
+
+	// Set attributes
+	H.set_attribute_limit(200)
+
+	var/datum/attribute/fort = H.attributes[FORTITUDE_ATTRIBUTE]
+	var/datum/attribute/prud = H.attributes[PRUDENCE_ATTRIBUTE]
+	var/datum/attribute/temp = H.attributes[TEMPERANCE_ATTRIBUTE]
+	var/datum/attribute/just = H.attributes[JUSTICE_ATTRIBUTE]
+
+	if(fort)
+		fort.level = 40
+		fort.on_update(H)
+	if(prud)
+		prud.level = 40
+		prud.on_update(H)
+	if(temp)
+		temp.level = 40
+		temp.on_update(H)
+	if(just)
+		just.level = 40
+		just.on_update(H)
+
+	// Give armor (tier 1)
+	var/obj/item/clothing/suit/armor/ego_gear/city/thumb_spider/apprentice/armor = new(H.loc)
+	H.put_in_hands(armor)
+
+	// Give weapons (tier 1)
+	var/obj/item/ego_weapon/city/thumbapprentice_katana/katana = new(H.loc)
+	H.put_in_hands(katana)
+	var/obj/item/ego_weapon/city/thumbapprentice_greatsword/greatsword = new(H.loc)
+	H.put_in_hands(greatsword)
+
+	// Update ID card
+	update_id_card(H, "Thumb Apprentice")
+
+	// Update mind role
+	if(H.mind)
+		H.mind.assigned_role = "Thumb Apprentice"
+
+	// Add traits
+	ADD_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE, "thumb_apprentice")
+	ADD_TRAIT(H, TRAIT_WORK_FORBIDDEN, "thumb_apprentice")
+
+	// Grant Palermitan systems
+	// Base passives (Duello + Palermitan Style + nursefather interactions)
+	H.AddComponent(/datum/component/palermitan_apprentice, user)
+	// EXP tracking
+	H.AddComponent(/datum/component/palermitan_exp)
+	// Duel challenge action
+	var/datum/action/innate/thumb_duel_challenge/duel_action = new()
+	duel_action.Grant(H)
+	// Skill tree action
+	var/datum/action/innate/palermitan_tree/tree_action = new()
+	tree_action.Grant(H)
+
+	// Grant rules action
+	var/datum/action/innate/view_role_rules/thumb_apprentice/app_rules = new
+	app_rules.Grant(H)
+
+	// Feedback
+	to_chat(user, span_notice("You have recruited [H] as your apprentice."))
+	playsound(get_turf(H), 'sound/abnormalities/onesin/bless.ogg', 50, 0, 4)
+
+	to_chat(H, span_userdanger("You have become a Thumb Apprentice!"))
+	to_chat(H, span_boldnotice("You are now an apprentice of [user], a former Sottocapo of the Thumb's spider house. \
+		You have been given a katana and greatsword, along with apprentice armor. \
+		Your gear will grow stronger as you do."))
+	to_chat(H, span_boldnotice("You have two new abilities: \
+		'Challenge to Duel' lets you challenge others to duels for progression. \
+		'Palermitan Skill Tree' lets you spend skill points earned from duels."))
+	to_chat(H, span_boldnotice("Review your role rules by clicking the 'View Thumb Rules' action button."))
+	to_chat(H, span_boldwarning("Follow the orders of your mentor. Act in the Thumb's interest."))
+
+////////////////////////////////////////////////////////////
+// ROLE RULES ACTIONS
+
+/datum/action/innate/view_role_rules/thumb_nursefather
+	name = "View Thumb Rules"
+	desc = "Review the Ex Thumb Sottocapo's trusted role rulings."
+	rules_title = "Ex Thumb Sottocapo - Trusted Role Rulings"
+	accent_color = "#8b0000"
+	window_name = "thumb_nursefather_rules"
+	window_size = "600x700"
+
+/datum/action/innate/view_role_rules/thumb_nursefather/get_rules_content()
+	return {"
+	<div class="section">
+		<h2>Your Purpose</h2>
+		<p>You are a former Sottocapo of the Thumb's spider house &mdash; a high-ranking operative who dual-wields a rapier and katana loaded with acceleration propellant ammunition. You have gone independent, but your skills and connections remain.</p>
+	</div>
+
+	<div class="section">
+		<h2>Combat Style</h2>
+		<p>Your weapons use the <b>Acceleration Round</b> system and a <b>cross-combo</b> that requires weapon-swapping between your rapier and katana.</p>
+		<ul>
+			<li>Every 2nd hit triggers your off-hand weapon for a follow-up attack at reduced damage.</li>
+			<li>Spending acceleration rounds grants <span class="good">Poise</span> (rapier) or <span class="good">Concentration</span> (katana).</li>
+			<li>Poise crits apply Tremor and Overheat to your target.</li>
+			<li>Use your <b>suspicious phone</b> to order additional ammunition.</li>
+		</ul>
+	</div>
+
+	<div class="section">
+		<h2>Recruiting an Apprentice</h2>
+		<p>You have a <b>Thumb Apprenticeship Scroll</b> that lets you recruit one player as your apprentice. This is a <span class="good">roleplay opportunity</span> &mdash; choose someone who will engage with the role.</p>
+		<ul>
+			<li>Your apprentice starts weak (40 attributes) with evolving gear that grows through duels.</li>
+			<li>They learn the <b>Palermitan Style</b> &mdash; a sword technique focused on single-target hunts.</li>
+			<li>You are their <span class="good">mentor</span>. Guide them, correct them when they lose, share drinks with them.</li>
+			<li>The scroll can only be used <span class="warning">once</span>. Choose wisely.</li>
+		</ul>
+	</div>
+
+	<div class="section">
+		<h2>Mentoring Your Apprentice</h2>
+		<p>Your apprentice benefits from your guidance in several ways:</p>
+		<ul>
+			<li><b>Sharing drinks:</b> When your apprentice offers you an alcoholic drink, they gain EXP from the exchange.</li>
+			<li><b>Sharing meals:</b> When your apprentice offers you food, they gain EXP. Accept their service graciously.</li>
+			<li><b>Glass bottles:</b> Throwing or hitting your apprentice with a glass bottle grants them EXP. A Thumb tradition.</li>
+			<li><b>Daily training:</b> Striking your apprentice with a weapon grants them EXP. Discipline through combat is the Thumb way.</li>
+			<li><b>Post-duel correction:</b> After your apprentice loses a duel, punch them with <b>bare fists</b> within 1.5 minutes to grant bonus attributes. The correction escalates in severity with repeated use.</li>
+		</ul>
+	</div>
+
+	<div class="section">
+		<h2>Conduct and Escalation</h2>
+		<ul>
+			<li><span class="warning">Avoid killing other players without a reason.</span> You are a Syndicate operative, but not a mindless killer.</li>
+			<li>You may use your apprentice recruitment as an RP hook to interact with other players.</li>
+			<li>Your apprentice's duels require the other player to accept the challenge prompt.</li>
+			<li><span class="good">You may intimidate others</span> into dueling your apprentice &mdash; leveraging your status and reputation to pressure people into accepting is the Thumb way.</li>
+			<li>If someone of <span class="highlight">lower rank</span> than you tries to avoid a duel, you may <span class="good">rough them up</span> to remind them of their place. The Thumb does not tolerate disrespect from inferiors.</li>
+			<li>However, <span class="warning">avoid killing without buildup and escalation</span>. Outright murdering someone over a refused duel with no warning is a violation. Threaten first, escalate if they persist, and only resort to serious violence after giving them chances.</li>
+		</ul>
+	</div>
+
+	<div class="section">
+		<h2>The Thumb's Interest</h2>
+		<p>You may still have connections to the Thumb, but you operate independently. Your primary goal is to <span class="good">train your apprentice</span> and pursue your own interests in the City.</p>
+	</div>
+	"}
+
+/datum/action/innate/view_role_rules/thumb_apprentice
+	name = "View Thumb Rules"
+	desc = "Review the Thumb Apprentice's trusted role rulings."
+	rules_title = "Thumb Apprentice - Trusted Role Rulings"
+	accent_color = "#8b0000"
+	window_name = "thumb_apprentice_rules"
+	window_size = "600x800"
+
+/datum/action/innate/view_role_rules/thumb_apprentice/get_rules_content()
+	return {"
+	<div class="section">
+		<h2>Your Purpose</h2>
+		<p>You have been recruited by a former Sottocapo of the Thumb to learn the <b>Palermitan Style</b> &mdash; a sword technique renowned for relentlessly focusing on a single prey during a hunt, concluded with a Coup de Gr&acirc;ce.</p>
+	</div>
+
+	<div class="section">
+		<h2>Progression Through Duels</h2>
+		<p>Your primary means of growing stronger is through <b>dueling other players</b>. Use the 'Challenge to Duel' action to challenge someone.</p>
+		<ul>
+			<li>Duels create an arena ring. Stepping outside the ring or entering critical condition means you lose.</li>
+			<li><span class="good">Winning</span> grants more attributes and EXP. <span class="warning">Losing</span> still grants some &mdash; you always learn.</li>
+			<li>Fighting <span class="good">stronger opponents</span> grants more rewards than fighting weaker ones.</li>
+			<li>Your gear <span class="good">evolves automatically</span> as your attributes grow (4 tiers).</li>
+			<li>At tier 2+, your weapons gain a <span class="good">dual-wield follow-up</span> mechanic.</li>
+		</ul>
+	</div>
+
+	<div class="section">
+		<h2>The Palermitan Skill Tree</h2>
+		<p>Open your <b>Palermitan Skill Tree</b> to spend skill points earned from duels. There are 4 schools:</p>
+		<ul>
+			<li><b>Terremoto</b> &mdash; Tremor focus. Destabilize your prey and trigger devastating Tremor Bursts.</li>
+			<li><b>Incendio</b> &mdash; Overheat focus. Burn them down with escalating fire damage.</li>
+			<li><b>Eleganza</b> &mdash; Poise and Concentration. Build crit chance and sustain your momentum.</li>
+			<li><b>Fondamenti</b> &mdash; General combat fundamentals. Offense and defense for any build.</li>
+		</ul>
+		<p>You can invest in <span class="warning">2 schools maximum</span>. Choose wisely.</p>
+	</div>
+
+	<div class="section">
+		<h2>Lessons Learned</h2>
+		<p>Dueling different types of opponents teaches you unique passive abilities. Check the <b>Lessons Learned</b> tab in your skill tree to see what you've unlocked and what's available.</p>
+		<ul>
+			<li>Each role has its own passive with 3 tiers (unlocked at 1, 3, and 5 duels).</li>
+			<li>Passives are permanent and themed around the opponent's fighting style.</li>
+		</ul>
+	</div>
+
+	<div class="section">
+		<h2>The Duel Escalates</h2>
+		<p>Your core mechanic: every hit inflicts <b>'The Duel Escalates'</b> on your target. The more stacks they have, the stronger you become against them &mdash; more damage, less damage taken, and your skills scale with the stacks.</p>
+	</div>
+
+	<div class="section">
+		<h2>Your Mentor</h2>
+		<p>The Sottocapo who recruited you is your mentor. They can help you in several ways:</p>
+		<ul>
+			<li><b>Sharing drinks:</b> Offering your mentor an alcoholic drink grants you EXP. Show respect to your teacher.</li>
+			<li><b>Sharing a meal:</b> Offering your mentor food also grants EXP. Service to your superiors is expected.</li>
+			<li><b>Showing respect:</b> Bowing or saluting near higher-ranked players or your mentor grants EXP. The Thumb values politeness above all.</li>
+			<li><b>Daily training:</b> When your mentor strikes you with a weapon, you gain EXP from the discipline. Pain is the best teacher.</li>
+			<li><b>Post-duel correction:</b> After you lose a duel, your mentor can punch you with bare fists to grant bonus attributes. It hurts, but you learn.</li>
+		</ul>
+	</div>
+
+	<div class="section">
+		<h2>Conduct and Escalation</h2>
+		<ul>
+			<li>Duels must be <span class="good">consensual</span> &mdash; the other player must accept your challenge.</li>
+			<li>Your mentor may <span class="good">intimidate and rough up</span> those who try to avoid dueling you &mdash; that is the Thumb way. Let your mentor handle the persuasion.</li>
+			<li>You yourself should <span class="warning">not attack people who decline</span>. You are an apprentice &mdash; you have no authority to punish others. That is your mentor's role.</li>
+			<li><span class="warning">Avoid killing other players without a reason.</span> Duels are non-lethal by design (healing on duel end).</li>
+			<li>Follow your mentor's lead. Act in the Thumb's interest.</li>
+			<li>Your duels are meant to be a <span class="good">spectacle</span> &mdash; the Palermitan Style is put on display for all to behold.</li>
+		</ul>
+	</div>
+	"}

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -286,7 +286,7 @@ GLOBAL_LIST_INIT(city_antagonist_positions, list(
 
 	"Corporist Maestro",
 	"Ex Thumb Sottocapo",
-	"Ex Great Brother",
+	"Middle Ex-Great Brother",
 ))
 
 

--- a/tgui/packages/tgui/interfaces/PalermitanSkillTree.js
+++ b/tgui/packages/tgui/interfaces/PalermitanSkillTree.js
@@ -1,0 +1,496 @@
+import { useBackend, useLocalState } from '../backend';
+import {
+  Box,
+  Button,
+  Flex,
+  Icon,
+  NoticeBox,
+  ProgressBar,
+  Section,
+  Stack,
+  Tabs,
+} from '../components';
+import { Window } from '../layouts';
+
+const SCHOOL_COLORS = {
+  terremoto: '#8b6914',
+  incendio: '#c44536',
+  eleganza: '#5b7c99',
+  fondamenti: '#8b8b8b',
+};
+
+export const PalermitanSkillTree = (props, context) => {
+  const { act, data } = useBackend(context);
+  const [selectedSchool, setSelectedSchool]
+    = useLocalState(
+      context,
+      'selectedSchool',
+      'terremoto'
+    );
+
+  const {
+    exp = 0,
+    next_threshold = 20,
+    skill_points = 0,
+    skill_points_spent = 0,
+    schools_invested = [],
+    schools = [],
+    max_schools = 2,
+    gear_tier = 1,
+    all_passives = [],
+  } = data;
+
+  const currentSchool = schools.find(
+    s => s.id === selectedSchool
+  );
+  const canInvest
+    = schools_invested.length < max_schools
+    || schools_invested.includes(selectedSchool);
+
+  return (
+    <Window
+      width={700}
+      height={580}
+      title="Palermitan Style">
+      <Window.Content scrollable>
+        <Section
+          title="Palermitan Style"
+          buttons={
+            <Box inline color="label">
+              {'Points: '}
+              <Box inline color="good" bold>
+                {skill_points}
+              </Box>
+              {' | Schools: '}
+              <Box inline color="label">
+                {schools_invested.length}
+                {'/'}
+                {max_schools}
+              </Box>
+            </Box>
+          }>
+          <Box italic color="label" mb={1}>
+            {'Renowned for relentlessly focusing '
+              + 'on a single prey during a hunt, '
+              + 'concluded with a Coup de '
+              + 'Gr\u00e2ce.'}
+          </Box>
+          <ProgressBar
+            value={exp}
+            maxValue={next_threshold}
+            color="#8b0000">
+            {'EXP: ' + exp + ' / '
+              + next_threshold}
+          </ProgressBar>
+          <Box mt={1}>
+            <Box inline bold color="label">
+              {'Gear Tier: '}
+            </Box>
+            <Box inline bold color="good">
+              {gear_tier}
+              {' / 4'}
+            </Box>
+          </Box>
+        </Section>
+        <Tabs>
+          <Tabs.Tab
+            selected={
+              selectedSchool === 'lessons'
+            }
+            color="#9e7c0c"
+            onClick={() => setSelectedSchool(
+              'lessons'
+            )}>
+            Lessons Learned
+          </Tabs.Tab>
+          {schools.map(school => (
+            <Tabs.Tab
+              key={school.id}
+              selected={
+                selectedSchool === school.id
+              }
+              color={SCHOOL_COLORS[school.id]}
+              onClick={() => setSelectedSchool(
+                school.id
+              )}>
+              {school.name}
+            </Tabs.Tab>
+          ))}
+        </Tabs>
+        {selectedSchool === 'lessons'
+          ? (
+            <LessonsDisplay
+              passives={all_passives}
+            />
+          )
+          : currentSchool
+            ? (
+              <SchoolDisplay
+                school={currentSchool}
+                canInvest={canInvest}
+                schoolsInvested={
+                schools_invested
+                }
+                act={act}
+                skillPoints={skill_points}
+              />
+            )
+            : (
+              <NoticeBox>
+                Select a school above.
+              </NoticeBox>
+            )}
+      </Window.Content>
+    </Window>
+  );
+};
+
+const SchoolDisplay = props => {
+  const {
+    school,
+    canInvest,
+    schoolsInvested,
+    act,
+    skillPoints,
+  } = props;
+  const color = SCHOOL_COLORS[school.id]
+    || '#888';
+  const invested = schoolsInvested.includes(
+    school.id
+  );
+
+  return (
+    <Section
+      title={school.name}
+      style={{
+        borderTop: '2px solid ' + color,
+      }}>
+      <Box color="label" mb={1}>
+        {school.desc}
+      </Box>
+      <Box
+        italic
+        color={color}
+        fontSize={0.9}
+        mb={1}>
+        {school.theme}
+      </Box>
+      {!canInvest && !invested
+        ? (
+          <NoticeBox danger>
+            {'Max schools reached. '
+              + 'Cannot invest here.'}
+          </NoticeBox>
+        )
+        : null}
+      {(school.tiers || []).map(tier => (
+        <TierDisplay
+          key={tier.tier}
+          tier={tier}
+          school={school}
+          act={act}
+          skillPoints={skillPoints}
+        />
+      ))}
+    </Section>
+  );
+};
+
+const TierDisplay = props => {
+  const { tier, school, act, skillPoints }
+    = props;
+  const { choices = [] } = tier;
+  const completed = choices.some(
+    c => c.selected
+  );
+  const locked = choices.length > 0
+    && choices[0].locked;
+
+  return (
+    <Section
+      title={
+        <Flex align="center" inline>
+          <Flex.Item>
+            {locked
+              ? (
+                <Icon
+                  name="lock"
+                  color="bad"
+                  mr={1}
+                />
+              )
+              : completed
+                ? (
+                  <Icon
+                    name="check"
+                    color="good"
+                    mr={1}
+                  />
+                )
+                : (
+                  <Icon
+                    name="circle"
+                    color="label"
+                    mr={1}
+                  />
+                )}
+          </Flex.Item>
+          <Flex.Item>
+            {'Tier ' + tier.tier}
+          </Flex.Item>
+          <Flex.Item grow={1} />
+          <Flex.Item>
+            <Box
+              inline
+              color="label"
+              fontSize={0.9}>
+              {'Cost: ' + tier.cost}
+              {tier.cost > 1
+                ? ' points'
+                : ' point'}
+            </Box>
+          </Flex.Item>
+        </Flex>
+      }>
+      <Flex>
+        {choices.map(choice => (
+          <Flex.Item
+            key={choice.id}
+            grow={1}
+            mr={1}>
+            <SkillChoice
+              choice={choice}
+              tier={tier}
+              school={school}
+              act={act}
+            />
+          </Flex.Item>
+        ))}
+      </Flex>
+    </Section>
+  );
+};
+
+const SkillChoice = props => {
+  const { choice, tier, school, act } = props;
+  const schoolColor
+    = SCHOOL_COLORS[school.id] || '#888';
+
+  let borderColor = 'rgba(255,255,255,0.1)';
+  let bgColor = 'rgba(0,0,0,0.2)';
+  let statusText = '';
+  let statusColor = 'label';
+
+  if (choice.selected) {
+    borderColor = '#2d8c2d';
+    bgColor = 'rgba(45,140,45,0.15)';
+    statusText = 'LEARNED';
+    statusColor = 'good';
+  } else if (choice.excluded) {
+    borderColor = '#8c2d2d';
+    bgColor = 'rgba(140,45,45,0.1)';
+    statusText = 'EXCLUDED';
+    statusColor = 'bad';
+  } else if (choice.locked) {
+    borderColor = 'rgba(255,255,255,0.05)';
+    bgColor = 'rgba(0,0,0,0.3)';
+    statusText = 'LOCKED';
+    statusColor = 'label';
+  } else if (choice.available) {
+    borderColor = schoolColor;
+    bgColor = schoolColor + '26';
+    statusText = 'AVAILABLE';
+    statusColor = schoolColor;
+  }
+
+  return (
+    <Box
+      style={{
+        border: '2px solid ' + borderColor,
+        borderRadius: '4px',
+        padding: '8px',
+        background: bgColor,
+        minHeight: '100px',
+      }}>
+      <Flex direction="column" height="100%">
+        <Flex.Item>
+          <Box bold color={statusColor} mb={0.5}>
+            {choice.name}
+          </Box>
+          {statusText
+            ? (
+              <Box
+                inline
+                color={statusColor}
+                fontSize={0.8}
+                mb={0.5}>
+                {'[' + statusText + ']'}
+              </Box>
+            )
+            : null}
+        </Flex.Item>
+        <Flex.Item grow={1}>
+          <Box color="label" fontSize={0.9}>
+            {choice.desc}
+          </Box>
+        </Flex.Item>
+        <Flex.Item mt={1}>
+          {choice.available
+            ? (
+              <Button
+                fluid
+                color="red"
+                content="Learn Skill"
+                onClick={() => act(
+                  'select_skill',
+                  {
+                    skill_type: choice.type,
+                    school: school.id,
+                    tier: tier.tier,
+                  }
+                )}
+              />
+            )
+            : null}
+        </Flex.Item>
+      </Flex>
+    </Box>
+  );
+};
+
+const LessonsDisplay = props => {
+  const { passives = [] } = props;
+
+  const getNextTier = duels => {
+    if (duels < 1) return '1';
+    if (duels < 3) return '3';
+    if (duels < 5) return '5';
+    return 'MAX';
+  };
+
+  const getTierColor = tier => {
+    if (tier >= 3) return '#c4a000';
+    if (tier >= 2) return '#8ba86e';
+    if (tier >= 1) return '#6e8ba8';
+    return null;
+  };
+
+  return (
+    <Section
+      title="Lessons Learned"
+      style={{
+        borderTop: '2px solid #9e7c0c',
+      }}>
+      <Box color="label" italic mb={1}>
+        {'Techniques absorbed from those '
+          + 'you have dueled. Each opponent '
+          + 'teaches you something new.'}
+      </Box>
+      {passives.map((p, i) => {
+        const unlocked = p.tier > 0;
+        const tierColor = getTierColor(
+          p.tier
+        );
+        return (
+          <Box
+            key={i}
+            mb={0.5}
+            style={{
+              border: '1px solid '
+                + (unlocked
+                  ? 'rgba(255,255,255,0.2)'
+                  : 'rgba(255,255,255,0.05)'
+                ),
+              borderRadius: '3px',
+              padding: '8px',
+              background: unlocked
+                ? 'rgba(255,255,255,0.05)'
+                : 'rgba(0,0,0,0.3)',
+              opacity: unlocked
+                ? 1
+                : 0.5,
+            }}>
+            <Flex align="center">
+              <Flex.Item grow={1}>
+                <Box
+                  bold
+                  color={unlocked
+                    ? 'white'
+                    : 'label'}>
+                  {p.name}
+                </Box>
+                <Box
+                  color="label"
+                  fontSize={0.85}>
+                  {'Duel: ' + p.source}
+                </Box>
+              </Flex.Item>
+              <Flex.Item>
+                {unlocked
+                  ? (
+                    <Box
+                      bold
+                      color={tierColor}>
+                      {'Tier '
+                        + p.tier
+                        + '/3'}
+                    </Box>
+                  )
+                  : (
+                    <Box color="label">
+                      {'Locked ('
+                        + p.duels
+                        + ' duels, '
+                        + 'next: '
+                        + getNextTier(
+                          p.duels
+                        )
+                        + ')'}
+                    </Box>
+                  )}
+              </Flex.Item>
+            </Flex>
+            <Box mt={0.5} fontSize={0.85}>
+              <Box
+                color={p.tier >= 1
+                  ? '#6e8ba8'
+                  : 'label'}
+                style={{
+                  opacity: p.tier >= 1
+                    ? 1
+                    : 0.6,
+                }}>
+                {'T1 (1 duel): '
+                  + p.t1}
+              </Box>
+              <Box
+                color={p.tier >= 2
+                  ? '#8ba86e'
+                  : 'label'}
+                style={{
+                  opacity: p.tier >= 2
+                    ? 1
+                    : 0.6,
+                }}>
+                {'T2 (3 duels): '
+                  + p.t2}
+              </Box>
+              <Box
+                color={p.tier >= 3
+                  ? '#c4a000'
+                  : 'label'}
+                style={{
+                  opacity: p.tier >= 3
+                    ? 1
+                    : 0.6,
+                }}>
+                {'T3 (5 duels): '
+                  + p.t3}
+              </Box>
+            </Box>
+          </Box>
+        );
+      })}
+    </Section>
+  );
+};


### PR DESCRIPTION
## About The Pull Request

This is the Thumb Nursefather sub-PR, branched off the CoL Major Update: The House of Spiders [Core PR]. It adds the **Ex Thumb Sottocapo** trusted role and the Palermitan Style apprentice system.

## Ex Thumb Sottocapo

### Role Overview
- A former high-ranking operative of the Thumb spider house
- Dual-wields a rapier and katana loaded with acceleration propellant ammunition
- Available on city and fixers maps
- Trusted player role with 150 FOR/PRU, 100 TEM/JUS
- Equipped with the Eye of Odin cybernetic implant for precognitive evasion
- Can recruit one apprentice using a recruitment contract
- Uses a suspicious phone to order additional ammunition

### Thumbfather Weapons (Dual-Wield System)
| Weapon | Damage | Type | Special |
|--------|--------|------|---------|
| Thumbfather Rapier | 45 | RED | Loaded with acceleration propellant ammunition |
| Thumbfather Katana | 55 | RED | Partner weapon for dual-wield combo system |

**Combo System:** Requires weapon-swapping between rapier and katana — lunge with one weapon, AoE sweep with the other, then finish with the first. Both weapons must be loaded with acceleration propellant ammunition.

### Eye of Odin
Cybernetic eye implant replacing the right eye. Grants precognitive evasion through a stack-based resource system.

| Stat | Value |
|------|-------|
| Max Precognition Stacks | 30 |
| Evasion Chance | Scales linearly: 100% at 30 stacks → 40% at 1 stack |
| Melee Evasion Cost | max(1, ceiling(damage / 10)) stacks per evade |
| Ranged Evasion Cost | max(1, ceiling(damage / 25)) stacks per evade (more efficient vs projectiles) |
| Regeneration | +10 stacks every 5 seconds |
| Overheat (at 0 stacks) | 30 seconds — no evasion, no regen, melee hits deal 5% clone damage |
| Recovery | Full stacks restored after overheat ends |

Evasion creates an afterimage and shifts the user to a random adjacent tile. No cooldown between evades — sustained fire drains stacks faster than they regenerate.

## Palermitan Style Apprentice

### Role Overview
- Recruited in-round by the Ex Thumb Sottocapo
- Starts at **40 all attributes** with tier 1 gear (capped at 200, scaling up through duels)
- Gains the Palermitan Style component — a duel-focused progression system
- Can invest in up to **3 of 4** skill tree schools
- At 150+ attributes from duel progression, gains the Nursefather Passive (precognitive evasion + clone decay)
- Equipped with dual weapons (katana + greatsword) and armor that evolve through 4 tiers as attributes grow

### Apprentice Weapons
The apprentice dual-wields a katana and greatsword. Both have 4 evolution tiers — attack speed is fixed per weapon, only force scales. Tiers upgrade automatically when all 4 attributes meet the threshold (checked as `min_attribute / 2 >= requirement`).

**Katana** (Speed: 1.0)
| Tier | Force | Attribute Requirement | Dual-Wield Threshold |
|------|-------|-----------------------|----------------------|
| 1 | 22 | 40 all (starts here) | None |
| 2 | 32 | 60 all (120+ attrs) | Every 2nd hit |
| 3 | 44 | 80 all (160+ attrs) | Every 2nd hit |
| 4 | 65 | 100 all (200 attrs) | Every hit |

**Greatsword** (Speed: 1.5)
| Tier | Force | Attribute Requirement | Dual-Wield Threshold |
|------|-------|-----------------------|----------------------|
| 1 | 33 | 40 all (starts here) | None |
| 2 | 48 | 60 all (120+ attrs) | Every 2nd hit |
| 3 | 66 | 80 all (160+ attrs) | Every 2nd hit |
| 4 | 98 | 100 all (200 attrs) | Every hit |

DPS targets per tier: 22 → 32 → 44 → 65. Dual-wield follow-ups trigger the partner weapon at 25% damage + inflict 1 Duel Escalates (every 2nd hit at tiers 2-3, every hit at tier 4).

The apprentice's armor also evolves through the same 4 tiers alongside the weapons.

### Duel System
Formal PvP duels initiated by the apprentice. Creates a 7-tile radius arena. Both participants are tracked for win/loss, and rewards scale based on relative strength.

**Reward Scaling:**
| Factor | Calculation |
|--------|-------------|
| Base Attribute Gain | 16 per attribute |
| Base EXP Gain | 40 |
| Strength Ratio | opponent_avg / apprentice_avg, clamped 0.5x–2.5x |
| Underleveled Multiplier | 1.0x at 200 attrs → 1.75x at 40 attrs (linear catch-up) |
| Loss Modifier | 0.5x (losses still grant half rewards to keep early progression flowing) |

**Opponent Rewards:** Non-apprentice duel opponents gain Fortitude (+3 on win, +1 on loss, capped at 20 total from duels) and Association/Ring EXP if applicable.

**Mentor Correction:** After a duel loss, the mentor has 1.5 minutes to "correct" the apprentice (harm-intent unarmed punch) for bonus attribute growth (0.25x of the win value, also benefits from the underleveled multiplier).

### EXP Sources

Dueling is the primary EXP source, but several nursefather interaction RP mechanics also grant EXP:

| Source | EXP | Cooldown | Trigger |
|--------|-----|----------|---------|
| **Duel (win)** | 40 x ratio x underleveled | Per duel | Winning a formal duel |
| **Duel (loss)** | 40 x ratio x underleveled x 0.5 | Per duel | Losing a formal duel |
| **Share a Drink** | 5 | 2 minutes | Offering a drink to the mentor |
| **Offer Food** | 3 | 2 minutes | Hitting the mentor with food (attack intent) |
| **Glass Bottle Hit** | 3 | 30 seconds | Mentor throws/hits apprentice with a glass bottle |
| **Training Strike** | 2 | 3 minutes | Mentor hits apprentice with a weapon |
| **Show Respect** | 3 | 2 minutes | Bow or salute emote near a stronger player or the mentor |

### EXP and Skill Points
18 EXP thresholds granting 1 skill point each (enough for 3 full school tiers):

| Point | EXP | Point | EXP | Point | EXP |
|-------|-----|-------|-----|-------|-----|
| 1 | 25 | 7 | 245 | 13 | 430 |
| 2 | 55 | 8 | 280 | 14 | 460 |
| 3 | 90 | 9 | 315 | 15 | 490 |
| 4 | 130 | 10 | 345 | 16 | 520 |
| 5 | 170 | 11 | 375 | 17 | 560 |
| 6 | 210 | 12 | 400 | 18 | 600 |

### The Duel Escalates
A stacking debuff applied to targets as the apprentice hits them (1 stack per hit). Max 20 stacks (30 with Famiglia's Honor). Grants the apprentice scaling bonuses against targets with this effect. Expires if no new stacks are added within 10 seconds. Many skills in the Palermitan skill tree key off of this stack count.

**Base Passives (always active):**
- **Duello**: Each hit applies 1 Duel Escalates stack + heals sanity (3 per stack on target, max 15)
- **Palermitan Style**: Bonus damage scaling with Duel Escalates stacks on the target

### Palermitan Skill Tree (4 Schools)

**Terremoto — The Path of the Earthquake**
| Tier | Skill | Effect |
|------|-------|--------|
| 1a | Il Cacciatore | Attacks inflict 2 Tremor. At 3+ Duel stacks, also gain 1 Offense Level Up |
| 1b | Destabilizing Strikes | Tremor scales with Duel stacks: 1/2/3 Tremor at 0/3/7+ stacks |
| 2a | Palermitan Rapier | Tremor Burst at 15 stacks, grants 5 Offense Level Up + 5 Poise |
| 2b | Aftershock | Tremor Burst at 25 stacks. 10+ Tremor inflicts Offense Level Down |
| 3a | Sezionatura di Cervo | Active (60s CD): Prime next attack for massive Tremor + Overheat + bonus RED damage |
| 3b | Tectonic Collapse | Tremor Bursts inflict 3 Fragile, 3 Defense Level Down, and 2 Overheat |

**Incendio — The Path of the Inferno**
| Tier | Skill | Effect |
|------|-------|--------|
| 1a | Colpi Sottani | Attacks inflict 2 Overheat. At 3+ Duel stacks, inflict 3 instead |
| 1b | Scorching Pursuit | Attacks inflict scaling Overheat. Hitting burning targets grants Offense Level Up |
| 2a | Firestorm | Hitting 10+ Overheat targets grants 3 Offense Level Up + 3 Poise |
| 2b | Smoldering Wounds | Hitting burning targets inflicts Defense Level Down per 5 Overheat stacks |
| 3a | La Spada di Palermo | At 10+ Duel stacks: massive power surge (5 Offense Up, 3 Damage Up, 3 Tremor) |
| 3b | Conflagration | At 15+ Overheat: detonate for bonus RED damage equal to stacks |

**Eleganza — The Path of Elegance**
| Tier | Skill | Effect |
|------|-------|--------|
| 1a | Relentless Pursuit | Under 5 Duel stacks: gain 1 Concentration (10s CD). At 5+: gain 3 Poise instead |
| 1b | Focused Mind | Under 5 Duel stacks: gain 1 Poise + 1 Concentration (10s CD). At 5+: gain 3 Poise instead |
| 2a | Duello Feroce | Hitting 3+ Duel stacks: gain 1 Poise per 3 stacks (max 3) + heal 2 HP/stack (max 10). Crit halving grants 1 Concentration |
| 2b | Severed Tendon | Poise crits inflict 3 Offense Level Down + 1 Fragile. Crit halving recovers 1 Poise |
| 3a | Valencina's Legacy | Poise crits inflict 3 Tremor + 3 Overheat and spread Duel Escalates to enemies within 2 tiles. +1 Concentration (15s CD) |
| 3b | The Famiglia's Honor | Duel stacks cap to 30. 15+ stacks: +2 Poise/hit. Crit halving at 15+: +1 Concentration. Crits at 20+: 3 Fragile + 3 Defense Level Down |

**Fondamenti — The Fundamentals**
| Tier | Skill | Effect |
|------|-------|--------|
| 1a | Iron Constitution | Taking damage grants 2 Defense Level Up |
| 1b | Aggressive Footwork | Gain 1 Offense Level Up on hit or when taking melee damage |
| 2a | Predator's Instinct | Hitting targets below 50% HP: 2 Fragile + 2 Poise. Below 25%: +5 Offense Level Up + 2 more Poise |
| 2b | Enduring Spirit | Hitting Duel-stacked targets: heal 1 HP/stack (max 5). Taking damage near Duel-stacked target: +1 Defense Level Up |
| 3a | Coup de Grâce | At 5+ Duel stacks, hitting below 20% HP: bonus RED damage = stacks x3, consumes 50% stacks |
| 3b | Unbreakable Will | Entering soft crit (60s CD): gain 5 Defense Level Up, 3 Protection, heal 10% max HP |

### Duel Passives (Lesson System)
The apprentice earns passive abilities based on the association of opponents they've dueled. Each passive has 3 tiers, unlocking at 1, 3, and 5 duels against that faction. All passives trigger on melee hit unless noted otherwise.

| Source | Passive | T1 | T2 | T3 |
|--------|---------|----|----|-----|
| Butcher | Predator's Instinct | +5% dmg vs <50% HP targets | +10% dmg | +15% dmg, heal 3 HP |
| Blade Lineage | Resolve of the Salsu | +10% dmg when below 30% HP | +15% dmg | +20% dmg |
| Thumb | Soldato's Discipline | On RED dmg taken: +2 DLU | +3 DLU | +3 DLU, +1 OLU |
| Kurokumo | Way of the Drawn Blade | +1 Poise per hit | Crits +5% dmg | Crits +10% dmg, +2 Tremor |
| Index | Prescript Discipline | 1 OLD per hit | +1 DLD | 2 OLD, +1 DLD |
| Insurgence | Nightwatch Tremors | 15% chance: 1 Tremor | 20% chance | 25% chance: 2 Tremor |
| Middle | Vengeance Mark | On dmg taken: next hit +3% | +5% | +8%, +1 Duel Escalates |
| N-Corp | Methodical Strikes | 1 DLD + 1 Overheat per hit | +2 Overheat | 2 DLD + 2 Overheat |
| Rat | Scavenger's Luck | 5% chance: +50% dmg | 8% chance | 10% chance, +2 Tremor |
| Carnival | Silk Hunter's Patience | After 3s idle: +10% dmg | +20% dmg | +30% dmg, +2 Overheat |
| Zwei | Guardian's Resilience | On dmg taken: +2 DLU | +3 DLU | +3 DLU, attacker gets 1 OLD |
| Seven | Analyst's Eye | +1 OLU vs debuffed targets | +2 OLU | +2 OLU, +1 Duel Escalates |
| Dieci | Scholar's Insight | +3% dmg per debuff type on target | +5% per type | +7% per type (max 4) |
| Cinq | Duelist's Finesse | +2 Poise per hit | +3 Poise | +3 Poise, crit halving grants Concentration |
| Shi | Assassin's Sacrifice | vs <30% HP (3s CD): +3 OLU, self -3% HP | +4 OLU | +5 OLU, +2 Fragile on target |
| Liu | Burning Fist | +1 Overheat per hit | Every 4th hit: +2 extra | Every 3rd hit: +3 extra |
| Devyat | Berserker's Escalation | On hit (3s CD): +2 OLU, self -2% HP | +3 OLU | +3 OLU, below 50% HP also +2 DLU |
| Hana | Adaptive Form | Weapon swap (5s CD): +2 OLU | +2 OLU, +2 DLU | +3 OLU, +2 DLU |

*Abbreviations: OLU = Offense Level Up, OLD = Offense Level Down, DLU = Defense Level Up, DLD = Defense Level Down*

### Status Effects
- **The Duel Escalates** — stacking debuff on targets, grants apprentice scaling bonuses, expires after 10s without new stacks
- **Severed Tendon** — reduces target's melee damage via Offense Level Down, decays 1 stack per 10 seconds

## Refactoring Notes

This sub-PR includes the following changes from the original PR (#288) to work with the atomized structure:
- Switched `AddComponent(/datum/component/oracle_proxy_passive)` to `AddComponent(/datum/component/nursefather_passive)` in `palermitan_duel.dm`
- Removed the manual Ring-stripping block from `thumb_nursefather.dm` (lines 148-176 of the original). The base `apprentice_recruitment.dm` in the fundamental PR now sends `COMSIG_NURSEFATHER_RECRUITMENT_OVERRIDE` automatically, and Ring components self-clean via their signal handlers
- Removed the Ring artistic EXP reward from duel victories in `palermitan_duel.dm` (cross-boundary type reference). Can be restored after both Ring and Thumb sub-PRs merge

## Why It's Good For The Game

The Ex Thumb Sottocapo introduces a duel-focused progression system that directly involves other players as opponents. Unlike the Index Proxy (who interacts through prescripts) or the Ring Maestro (who draws in artists), the Thumb apprentice's power grows specifically by fighting — and the "Duel Escalates" stacking mechanic means prolonged combat with the same target becomes increasingly dangerous. Other players who fight a Thumb apprentice aren't just obstacles; they're actively fueling the apprentice's progression.

The Lesson system (duel passives) creates a unique incentive to seek out diverse opponents. An apprentice who only fights one faction will have a narrow set of passives, while one who duels members from many different factions (Zwei, Seven, Blade Lineage, etc.) unlocks a wider toolkit. This encourages the apprentice to roam and engage with as many different player roles as possible rather than sticking to a few players.

For the 4-school skill tree, Terremoto and Incendio offer aggressive status-stacking styles (Tremor and Overheat respectively), Eleganza rewards sustained combat with Poise critical strikes, and Fondamenti provides universal survivability. This build diversity means two Thumb apprentices can play very differently, making encounters with them less predictable for defenders.

The apprentice recruitment also interacts with other Nursefather roles — recruiting a Ring student severs their Ring connection (handled automatically via signals).

### Did you test this PR?

* [X] This PR compiles
* [ ] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

## Changelog
:cl:
add: Added Ex Thumb Sottocapo, a new trusted player role for city/fixers maps
add: Added Thumbfather dual-wield rapier/katana system with acceleration propellant ammunition
add: Added Eye of Odin cybernetic implant with precognitive melee evasion
add: Added Palermitan Style apprentice system with duel-based progression
add: Palermitan Skill Tree with 4 schools (Terremoto, Incendio, Eleganza, Fondamenti), each with 6 skills
add: Duel Lesson system — 18 faction-specific passives earned by defeating diverse opponents
add: The Duel Escalates stacking mechanic for scaling combat intensity
add: Severed Tendon debuff status effect
add: Apprentice recruitment via contract
add: Suspicious phone for ordering ammunition resupply
/:cl:
