### PR TITLE
CoL Update: Removing BRUTEPALE/BRUTEPALE and people will always Suicide panic.

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -147,8 +147,6 @@
 
 	if(SSmaptype.maptype in SSmaptype.citymaps)
 		ADD_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE, CITY_TRAIT)
-		ADD_TRAIT(H, TRAIT_BRUTEPALE, CITY_TRAIT)
-		ADD_TRAIT(H, TRAIT_BRUTESANITY, CITY_TRAIT)
 
 	if(!config)	//Needed for robots.
 		roundstart_experience = minimal_skills

--- a/code/modules/mob/living/carbon/human/damage_procs.dm
+++ b/code/modules/mob/living/carbon/human/damage_procs.dm
@@ -85,7 +85,7 @@
 		sanity_lost = TRUE
 		apply_status_effect(/datum/status_effect/panicked)
 		var/highest_atr = PRUDENCE_ATTRIBUTE
-		if(LAZYLEN(attributes))
+		if(!(SSmaptype.maptype in SSmaptype.citymaps) && LAZYLEN(attributes))
 			var/highest_level = -1
 			for(var/i in shuffle(attributes))
 				var/datum/attribute/atr = attributes[i]


### PR DESCRIPTION
## About The Pull Request

Two changes for city maps:

1. **Removed `TRAIT_BRUTEPALE` and `TRAIT_BRUTESANITY` from city map jobs** — Players on city maps will no longer have PALE damage converted to BRUTE or WHITE/sanity damage converted to BRUTE. All four damage types now function normally on city maps.

2. **City map panic always uses Prudence (suicide/despair) behavior** — When a player panics on a city map, they will always get the Prudence panic effect (stops moving, loses all hope) regardless of their highest attribute. This prevents inappropriate panic types like Release (approaching containment zones) which don't make sense in a city context.

## Why It's Good For The Game

City maps don't have containment cells or the same facility structure, so damage conversion traits and attribute-based panic types designed for the facility don't translate well. Removing BRUTEPALE/BRUTESANITY lets city combat use the full damage type system as intended, and forcing Prudence panic avoids nonsensical AI behaviors (like trying to find containment zones that don't exist).

### Did you test this PR?

* [ ] This PR compiles
* [ ] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

## Changelog
:cl:
balance: City maps no longer convert PALE damage to BRUTE or WHITE damage to BRUTE
balance: Panicking on city maps now always results in Prudence-type panic behavior
/:cl:
