### PR TITLE
CoL Update: Carnival Rules Action/Clarifications [DONE]

### DIFF
--- a/code/game/objects/items/stacks/sheets/silk.dm
+++ b/code/game/objects/items/stacks/sheets/silk.dm
@@ -11,6 +11,13 @@
 	return M.silk_results || ishuman(M)
 
 /datum/component/butchering/silkbutchering/ButcherEffects(mob/living/meat)
+	if(ishuman(meat))
+		var/mob/living/carbon/human/meat_human = meat
+		var/obj/item/bodypart/head/head = meat_human.get_bodypart(BODY_ZONE_HEAD)
+		if(head)
+			head.drop_limb()
+			head.forceMove(meat_human.drop_location())
+
 	var/turf/T = meat.drop_location()
 
 	// Track silk harvesting for achievement

--- a/code/modules/jobs/job_types/city/carnival.dm
+++ b/code/modules/jobs/job_types/city/carnival.dm
@@ -31,10 +31,13 @@
 	ADD_TRAIT(H, TRAIT_WORK_FORBIDDEN, JOB_TRAIT)
 	ADD_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE, JOB_TRAIT)
 	H.set_species(/datum/species/synth/carnival)
-	job_important = "You are allowed to enter the ruins to hunt for silk. However, DO NOT LOOT THE WEAPONS, CASH OR ARMOR FROM THE BACKSTREETS! \
-			Your primary goal is to kill monsters in the ruins and/or humans to weave silk so you can then sell it to the humans. \
-			You have a base on the left side of the nest. \
-			You are allowed to hunt down players as you see fit, especially if they are by themselves! (However avoid spawn killing them, by waiting at the entrance.)"
+	job_important = "You are a Carnival member. Your goal is to gather silk by using the silkweaver on mobs and humans, then sell your woven armors.\n\
+			You MAY enter the Ruins to hunt mobs for silk, but you must NOT loot any weapons, armor, or ahn from the Backstreets.\n\
+			While wearing your Carnival Robes, you do NOT need to escalate — you may freely hunt and silk other players. Other players may also attack you without escalation.\n\
+			You must NOT kill other players before the 10 minute mark, to give them time to ready up.\n\
+			You must NEVER remove someone from the round. Do NOT throw away, eat, or otherwise destroy a player's head."
+	var/datum/action/innate/carnival_rules/rules_action = new(H)
+	rules_action.Grant(H)
 	..()
 
 /datum/outfit/job/carnival
@@ -59,3 +62,95 @@
 	implants = list(
 		/obj/item/organ/cyberimp/arm/carnival,		//theyre full body prosthetics, the blades are inside them
 		/obj/item/organ/cyberimp/eyes/hud/medical,)	//replaces their med nvg
+
+/datum/action/innate/carnival_rules
+	name = "Carnival Rules"
+	desc = "Review the rules and guidelines for playing as a Carnival member."
+	icon_icon = 'icons/hud/actions.dmi'
+	button_icon_state = "round_end"
+	check_flags = AB_CHECK_CONSCIOUS
+
+/datum/action/innate/carnival_rules/Activate()
+	var/mob/living/L = owner
+	if(!istype(L))
+		return
+
+	var/html = {"
+<!DOCTYPE html>
+<html>
+<head>
+	<style>
+		body {
+			background-color: #1a1a1a;
+			color: #c0c0c0;
+			font-family: 'Segoe UI', Tahoma, sans-serif;
+			padding: 20px;
+			line-height: 1.6;
+		}
+		h1 {
+			color: #8b4513;
+			border-bottom: 2px solid #8b4513;
+			padding-bottom: 10px;
+		}
+		h2 {
+			color: #d4af37;
+			margin-top: 20px;
+		}
+		.highlight {
+			color: #ff6b6b;
+			font-weight: bold;
+		}
+		.good {
+			color: #7cfc00;
+		}
+		ul {
+			margin-left: 20px;
+		}
+		li {
+			margin-bottom: 8px;
+		}
+		.section {
+			background-color: #2a2a2a;
+			padding: 15px;
+			margin: 10px 0;
+			border-left: 3px solid #8b4513;
+		}
+	</style>
+</head>
+<body>
+	<h1>Carnival Rules</h1>
+
+	<div class='section'>
+		<h2>Your Goal</h2>
+		<p>You are a member of the Carnival. Your <span class='good'>primary objective</span> is to gather silk
+		by using your <span class='good'>silkweaver</span> on mobs and humans, and then selling your woven armors to other players.</p>
+	</div>
+
+	<div class='section'>
+		<h2>Ruins &amp; Looting</h2>
+		<p>You <span class='good'>ARE allowed</span> to enter the Ruins for the purpose of hunting down mobs for silk.</p>
+		<p>You are <span class='highlight'>NOT allowed</span> to loot any <span class='highlight'>weapons, armor, or ahn</span> from the Backstreets.
+		You are there to hunt, not to scavenge.</p>
+	</div>
+
+	<div class='section'>
+		<h2>PvP Rules</h2>
+		<p>While you are wearing your <span class='good'>Carnival Robes</span>, there is <span class='good'>no need to escalate</span>.
+		You are freely allowed to hunt down and silk other players as long as you are wearing the robes.</p>
+		<p>Be aware: <span class='highlight'>other players may also attack you without escalation</span>.
+		Wearing the robes makes you a valid target for everyone.</p>
+		<p>You must <span class='highlight'>NOT kill other players before the 10 minute mark</span>.
+		Give them time to ready up before you start hunting.</p>
+	</div>
+
+	<div class='section'>
+		<h2>Round Removal</h2>
+		<p>You are <span class='highlight'>NEVER allowed</span> to permanently remove someone from the round.</p>
+		<p><span class='highlight'>Do NOT</span> throw away, eat, or otherwise destroy another player's head.
+		Their body must remain recoverable so they can be revived.</p>
+	</div>
+</body>
+</html>
+	"}
+
+	L << browse(html, "window=carnival_rules;size=600x500")

--- a/code/modules/jobs/job_types/city/carnival.dm
+++ b/code/modules/jobs/job_types/city/carnival.dm
@@ -32,7 +32,7 @@
 	ADD_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE, JOB_TRAIT)
 	H.set_species(/datum/species/synth/carnival)
 	job_important = "You are a Carnival member. Your goal is to gather silk by using the silkweaver on mobs and humans, then sell your woven armors.\n\
-			You MAY enter the Ruins to hunt mobs for silk, but you must NOT loot any weapons, armor, or ahn from the Backstreets.\n\
+			You MAY enter the Ruins to hunt mobs for silk, but you must NOT loot any weapons, armor, or ahn from the Ruins. You also must NOT loot or use gear from other roles.\n\
 			While wearing your Carnival Robes, you do NOT need to escalate — you may freely hunt and silk other players. Other players may also attack you without escalation.\n\
 			You must NOT kill other players before the 10 minute mark, to give them time to ready up.\n\
 			You must NEVER remove someone from the round. Do NOT throw away, eat, or otherwise destroy a player's head."
@@ -129,8 +129,10 @@
 	<div class='section'>
 		<h2>Ruins &amp; Looting</h2>
 		<p>You <span class='good'>ARE allowed</span> to enter the Ruins for the purpose of hunting down mobs for silk.</p>
-		<p>You are <span class='highlight'>NOT allowed</span> to loot any <span class='highlight'>weapons, armor, or ahn</span> from the Backstreets.
+		<p>You are <span class='highlight'>NOT allowed</span> to loot any <span class='highlight'>weapons, armor, or ahn</span> from the Ruins.
 		You are there to hunt, not to scavenge.</p>
+		<p>You are also <span class='highlight'>NOT allowed</span> to loot or use <span class='highlight'>gear from other roles</span>.
+		Stick to your own Carnival equipment.</p>
 	</div>
 
 	<div class='section'>


### PR DESCRIPTION
## About The Pull Request

- **Carnival Rules Overhaul**: Rewrote the Carnival's `job_important` text to be clearer and more structured, and added a "Carnival Rules" HUD action button (browser popup) so players can review their role's rules at any time during the round. Rules now clearly cover: entering Ruins for silk hunting only (no looting weapons/armor/ahn), no looting gear from other roles, free PvP while wearing Carnival Robes (both ways — other players can attack Carnival without escalation too), 10 minute grace period before killing players, and no round removal (don't destroy heads).
- **Silkweaver Head Preservation Fix**: Fixed `silkbutchering` so that when a human is silked, their head is detached and dropped on the ground before the body is gibbed. Previously the head was destroyed along with the body during `qdel`, making the victim unrevivable.

## Why It's Good For The Game

Carnival rules were vague and easy to misinterpret, leading to confusion about what Carnival players are and aren't allowed to do. The new rules popup makes expectations crystal clear, and the head preservation fix prevents Carnival from accidentally round-removing people through normal gameplay (silking).

### Did you test this PR?

* [ ] This PR compiles
* [ ] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

## Changelog
:cl:
fix: Silkweaving humans no longer destroys their head, allowing them to be revived.
tweak: Carnival rules have been rewritten and clarified. A new HUD button lets Carnival players review their rules at any time.
/:cl:
