### PR TITLE
Test Range Update Part 2: Threat Simulator, Alternate Arenas & More

### DIFF
--- a/ModularLobotomy/!extra_abnos/joke_abnormalities/aleph/sukuna.dm
+++ b/ModularLobotomy/!extra_abnos/joke_abnormalities/aleph/sukuna.dm
@@ -224,7 +224,7 @@
 		if(survivor.stat == DEAD || !survivor.ckey)
 			continue
 		var/area_check = get_area(src)
-		if(istype(area_check, /area/test_range))
+		if(istype(area_check, /area/test_range_arena))
 			return ..()
 		survivor.Apply_Gift(new /datum/ego_gifts/sukuna)
 		survivor.playsound_local(get_turf(survivor), 'sound/weapons/black_silence/snap.ogg', 50)

--- a/ModularLobotomy/associations/augments.dm
+++ b/ModularLobotomy/associations/augments.dm
@@ -1197,7 +1197,7 @@
 // 	return mutable_appearance(src.icon, src.overlay_icon_state, src.overlay_layer)
 
 /obj/item/augment/proc/CanUseAugment(mob/user)
-	if(user?.mind?.assigned_role in roles || SSmaptype.maptype == "office" || debug_use)
+	if((user?.mind?.assigned_role in roles) || (SSmaptype.maptype == "office") || (debug_use))
 		return TRUE
 	return FALSE
 

--- a/ModularLobotomy/associations/augments.dm
+++ b/ModularLobotomy/associations/augments.dm
@@ -1354,6 +1354,7 @@
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_POCKETS
 	w_class = WEIGHT_CLASS_SMALL
 	var/list/roles = list("Prosthetics Surgeon", "Office Director", "Office Fixer", "Doctor", "Workshop Attendant")
+	var/debug_use = FALSE
 
 /obj/item/augment_remover/attack(mob/M, mob/user)
 	if (!CanRemoveAugment(user))
@@ -1392,9 +1393,13 @@
 		to_chat(user, span_warning("No augment found within [H.name]!"))
 
 /obj/item/augment_remover/proc/CanRemoveAugment(mob/user)
-	if(user?.mind?.assigned_role in roles || SSmaptype.maptype == "office")
+	if((user?.mind?.assigned_role in roles) || (SSmaptype.maptype == "office") || (debug_use))
 		return TRUE
 	return FALSE
+
+/obj/item/augment_remover/debug
+	desc = "A device that can remove augments. It's jailbroken!"
+	debug_use = TRUE
 
 //--------------------------------------
 // Debug Augment Fabricator

--- a/ModularLobotomy/ego_weapons/melee/city/_cityweapons_datums.dm
+++ b/ModularLobotomy/ego_weapons/melee/city/_cityweapons_datums.dm
@@ -178,7 +178,7 @@ Association gear is mostly HE for grunts, low WAW for veterans and high WAW for 
 
 /* ------------------ 7 - Seven ------------------*/
 
-// | Seven South |
+// | Seven South Section 6: Old Gear |
 //
 // 'Analysis' weapons (need to hit the same target X amount of times to be able to view their health and gain extra damage against them)
 /// Seven South Blade
@@ -212,6 +212,42 @@ Association gear is mostly HE for grunts, low WAW for veterans and high WAW for 
 	item_path = /obj/item/ego_weapon/city/seven_fencing/dagger
 	cost = 90
 
+// | Seven South Section 4: Reworked Gear |
+//
+// 'Sidearm' weapons - used to build Rupture.
+/// Seven South Section 4 Fencing Foil
+/datum/ego_datum/weapon/city/seven_south_s4_foil
+	item_path = /obj/item/ego_weapon/city/seven_s4_foil
+	cost = 60
+	ego_tags = (EGO_TAG_DEBUFFER)
+/// Seven South Section 4 Veteran Fencing Foil
+/datum/ego_datum/weapon/city/seven_south_s4_foil/vet
+	item_path = /obj/item/ego_weapon/city/seven_s4_foil/vet
+	cost = 75
+/// Seven South Section 4 Fencing Dagger
+/datum/ego_datum/weapon/city/seven_south_s4_foil/dagger
+	item_path = /obj/item/ego_weapon/city/seven_s4_foil/dagger
+	cost = 90
+
+// 'Adaptive' weapons - change damtype to lowest resistance, but only if the target has enough Rupture.
+/// Seven South Section 4 Blade
+/datum/ego_datum/weapon/city/seven_south_s4_adaptive
+	item_path = /obj/item/ego_weapon/city/seven_s4_blade
+	cost = 60
+	ego_tags = (EGO_TAG_VERSATILE_DAMAGE)
+/// Seven South Section 4 Veteran Blade
+/datum/ego_datum/weapon/city/seven_south_s4_adaptive/vet
+	item_path = /obj/item/ego_weapon/city/seven_s4_blade/vet
+	cost = 75
+/// Seven South Section 4 Director Blade
+/datum/ego_datum/weapon/city/seven_south_s4_adaptive/director
+	item_path = /obj/item/ego_weapon/city/seven_s4_blade/director
+	cost = 90
+/// Seven South Section 4 Director Cane
+/datum/ego_datum/weapon/city/seven_south_s4_adaptive/cane
+	item_path = /obj/item/ego_weapon/city/seven_s4_blade/cane
+	cost = 90
+
 /* ------------------ 9 - Devyat ------------------*/
 
 // | Devyat North |
@@ -229,13 +265,37 @@ Association gear is mostly HE for grunts, low WAW for veterans and high WAW for 
 
 /* ------------------ 10 - Dieci ------------------*/
 
-// 'Combo' weapons (similar to Liu combo gloves, can do a very funny 20 hit combo)
-/// Dieci Gloves
-/datum/ego_datum/weapon/city/dieci_south
+// | Dieci South |
+//
+// 'Fist' weapons (WHITE damage, apply sinking, empower for self-shield + PALE damage attacks). They have different combos!
+/// Dieci Combat Gloves
+/datum/ego_datum/weapon/city/dieci_south_fist
 	item_path = /obj/item/ego_weapon/city/dieci
-	cost = 40
-	testrange_blacklisted = TRUE // This thing doesn't runtime or anything but the LLLH bug is still there and I don't think anyone should ever get to see or use this weapon while that bug exists
-	ego_tags = list(EGO_TAG_COMBO)
+	cost = 60
+	ego_tags = list(EGO_TAG_COMBO, EGO_TAG_SUSTAIN, EGO_TAG_DEBUFFER, EGO_TAG_AOE_RADIAL, EGO_TAG_KNOCKBACK)
+/// Dieci Veteran Gloves
+/datum/ego_datum/weapon/city/dieci_south_fist/vet
+	item_path = /obj/item/ego_weapon/city/dieci/vet
+	cost = 75
+/// Dieci Director Fists
+/datum/ego_datum/weapon/city/dieci_south_fist/director
+	item_path = /obj/item/ego_weapon/city/dieci/director
+	cost = 90
+
+// 'Key' weapons. Exact same as fists with the difference of you having to deploy them first + offense level instead of shields. Also just cooler tbh
+/// Dieci Ceremonial Key
+/datum/ego_datum/weapon/city/dieci_south_key
+	item_path = /obj/item/ego_weapon/city/dieci/key
+	cost = 60
+	ego_tags = list(EGO_TAG_COMBO, EGO_TAG_DEBUFFER, EGO_TAG_AOE_RADIAL, EGO_TAG_KNOCKBACK)
+/// Dieci Veteran Key
+/datum/ego_datum/weapon/city/dieci_south_key/vet
+	item_path = /obj/item/ego_weapon/city/dieci/key/vet
+	cost = 75
+/// Dieci Director Key
+/datum/ego_datum/weapon/city/dieci_south_key/director
+	item_path = /obj/item/ego_weapon/city/dieci/key/director
+	cost = 90
 /*
 ------------------ Fixers & Workshops ------------------
 */

--- a/_maps/map_files/generic/Test_Range.dmm
+++ b/_maps/map_files/generic/Test_Range.dmm
@@ -1,24 +1,453 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/turf/closed/indestructible/rock,
-/area/space)
-"l" = (
+"br" = (
+/obj/effect/turf_decal/siding{
+	color = "#440000";
+	dir = 6
+	},
+/turf/open/floor/carpet/red,
+/area/test_range_arena/ouroboros)
+"bY" = (
+/obj/effect/turf_decal/siding{
+	color = "#440000";
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/test_range_arena/ouroboros)
+"cf" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#545454";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"ci" = (
+/turf/closed/indestructible/reinforced,
+/area/test_range_arena/ouroboros)
+"dn" = (
+/obj/effect/turf_decal/siding/white/corner{
+	color = "#440000";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/test_range_arena/ouroboros)
+"dr" = (
 /turf/open/floor/facility,
-/area/test_range)
-"m" = (
-/turf/open/floor/facility/dark,
-/area/test_range)
-"p" = (
+/area/test_range_arena/classic)
+"ec" = (
+/obj/structure/bed/pod,
+/obj/item/bedsheet/black,
+/turf/open/floor/pod,
+/area/test_range_arena/battlefield)
+"ed" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/obj/structure/tubes,
+/turf/open/floor/pod,
+/area/test_range_arena/battlefield)
+"ek" = (
+/obj/effect/turf_decal/siding/yellow,
+/obj/structure/sign/departments/command{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/test_range_arena/ouroboros)
+"eN" = (
+/obj/effect/turf_decal/siding/white/corner{
+	color = "#440000"
+	},
+/turf/open/floor/plasteel,
+/area/test_range_arena/ouroboros)
+"eT" = (
+/turf/closed/indestructible/rock,
+/area/test_range_arena/ouroboros)
+"fZ" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 5;
+	color = "#555555"
+	},
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#AAAAAA";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"gx" = (
+/obj/effect/turf_decal/siding/white/corner{
+	color = "#440000";
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/test_range_arena/ouroboros)
+"gK" = (
+/obj/machinery/stasis/survival_pod,
+/turf/open/floor/pod,
+/area/test_range_arena/battlefield)
+"hk" = (
+/obj/effect/light_emitter{
+	light_power = 4;
+	light_range = 25;
+	set_cap = 7;
+	set_luminosity = 24;
+	light_color = "#FF8899"
+	},
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#8888AA";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"hn" = (
+/obj/effect/radiojammer{
+	range = 15
+	},
+/turf/closed/indestructible/rock,
+/area/test_range_arena/ouroboros)
+"hp" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#6666CC";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"hw" = (
+/obj/structure/sign/departments/discipline{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/siding{
+	color = "#440000";
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/test_range_arena/ouroboros)
+"hy" = (
+/obj/effect/turf_decal/siding{
+	color = "#440000";
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/test_range_arena/ouroboros)
+"hL" = (
+/obj/effect/turf_decal/siding/white/corner{
+	color = "#440000";
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
+/area/test_range_arena/ouroboros)
+"hP" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 10;
+	color = "#555555"
+	},
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#AAAAAA";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"id" = (
 /obj/machinery/quantumpad/warp{
 	teleport_cooldown = 40;
-	map_pad_id = "test_range_arena";
+	map_pad_id = "test_range_arena_Ouroboros";
 	map_pad_link_id = "test_range_lobby";
 	teleport_speed = 20;
 	resistance_flags = 64
 	},
 /turf/open/floor/facility,
-/area/test_range)
-"s" = (
+/area/test_range_arena/ouroboros)
+"ir" = (
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#666688";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"iE" = (
+/obj/machinery/regenerator/safety,
+/turf/open/floor/facility,
+/area/test_range_arena/classic)
+"iM" = (
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#AAAAAA";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"iS" = (
+/obj/effect/turf_decal/siding{
+	color = "#440000";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/test_range_arena/ouroboros)
+"jm" = (
+/obj/effect/turf_decal/siding/white/corner{
+	color = "#440000"
+	},
+/turf/open/floor/carpet/red,
+/area/test_range_arena/ouroboros)
+"jO" = (
+/turf/open/floor/plating/dirt/dark{
+	color = "#555555"
+	},
+/area/test_range_arena/battlefield)
+"kv" = (
+/obj/structure/mecha_wreckage/durand{
+	name = "\improper Rhino wreckage";
+	anchored = 1;
+	density = 0
+	},
+/turf/open/floor/plating/asteroid/basalt{
+	color = "#333333"
+	},
+/area/test_range_arena/battlefield)
+"kC" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/test_range_arena/ouroboros)
+"lh" = (
+/obj/machinery/door/airlock,
+/turf/open/floor/facility,
+/area/test_range_arena/classic)
+"ly" = (
+/obj/machinery/button/indestructible/test_range_cleanup,
+/turf/closed/indestructible/reinforced,
+/area/test_range_arena/ouroboros)
+"me" = (
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating/asteroid/basalt{
+	color = "#333333"
+	},
+/area/test_range_arena/battlefield)
+"mq" = (
+/obj/item/head_trophy/steel_head{
+	pixel_x = 1;
+	pixel_y = -2;
+	color = "#BBBBBB";
+	desc = "A head of an old manager, now laid to rest. It's rotting.";
+	name = "rotting g-corp manager head"
+	},
+/obj/effect/decal/cleanable/blood/gibs/old{
+	color = "#777777"
+	},
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#666666";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"mJ" = (
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#6666CC";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"nD" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8;
+	color = "#555555"
+	},
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#666666";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"nQ" = (
+/obj/machinery/quantumpad/warp{
+	teleport_cooldown = 40;
+	map_pad_id = "test_range_arena_Battlefield";
+	map_pad_link_id = "test_range_lobby";
+	teleport_speed = 20;
+	resistance_flags = 64
+	},
+/turf/open/floor/pod,
+/area/test_range_arena/battlefield)
+"nS" = (
+/obj/machinery/door/airlock/survival_pod,
+/turf/open/floor/pod,
+/area/test_range_arena/battlefield)
+"oD" = (
+/obj/effect/turf_decal/siding/yellow/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/yellow/corner,
+/turf/open/floor/facility,
+/area/test_range_arena/ouroboros)
+"pl" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	color = "#666666"
+	},
+/turf/open/floor/plating/dirt/dark{
+	color = "#555555"
+	},
+/area/test_range_arena/battlefield)
+"pI" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	color = "#666666"
+	},
+/turf/open/floor/plating/dirt/dark{
+	color = "#666666"
+	},
+/area/test_range_arena/battlefield)
+"pR" = (
+/obj/structure/sign/departments/discipline{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/siding{
+	color = "#440000";
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/test_range_arena/ouroboros)
+"qf" = (
+/obj/effect/turf_decal/siding/yellow,
+/turf/open/floor/plasteel,
+/area/test_range_arena/ouroboros)
+"rY" = (
+/obj/effect/turf_decal/siding/yellow/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/test_range_arena/ouroboros)
+"sA" = (
+/obj/effect/turf_decal/siding{
+	color = "#440000";
+	dir = 10
+	},
+/turf/open/floor/carpet/red,
+/area/test_range_arena/ouroboros)
+"sI" = (
+/obj/structure/firetree{
+	pixel_y = 0;
+	name = "scorched tree";
+	desc = "A burnt tree. It's a miracle it survived this fighting.";
+	density = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#6666CC";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"tf" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/facility/dark,
+/area/test_range_arena/ouroboros)
+"tQ" = (
+/obj/structure/sign/departments/discipline{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/siding{
+	color = "#440000";
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/test_range_arena/ouroboros)
+"tT" = (
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#666666";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"up" = (
+/obj/machinery/regenerator/safety,
+/turf/open/floor/pod,
+/area/test_range_arena/battlefield)
+"vp" = (
+/obj/machinery/door/airlock/highsecurity,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/turf/open/floor/facility,
+/area/test_range_arena/ouroboros)
+"vy" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#AAAAAA";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"vC" = (
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#444444";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"wa" = (
+/obj/structure/tubes{
+	icon = 'icons/obj/lavaland/pod_computer.dmi';
+	icon_state = "pod_computer";
+	pixel_y = -32
+	},
+/turf/open/floor/pod,
+/area/test_range_arena/battlefield)
+"wc" = (
+/obj/effect/turf_decal/siding{
+	color = "#440000";
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
+/area/test_range_arena/ouroboros)
+"xi" = (
+/obj/effect/decal/cleanable/blood/old{
+	color = "#777777"
+	},
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#444444";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"xX" = (
+/obj/effect/turf_decal/siding{
+	color = "#440000";
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/test_range_arena/ouroboros)
+"xY" = (
+/obj/effect/turf_decal/siding/white/corner{
+	color = "#440000";
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/test_range_arena/ouroboros)
+"yg" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#666688";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"yn" = (
+/obj/machinery/regenerator/safety,
+/turf/open/floor/facility,
+/area/test_range_arena/ouroboros)
+"yD" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/test_range_arena/ouroboros)
+"yR" = (
+/turf/open/floor/plating/dirt/dark{
+	color = "#666666"
+	},
+/area/test_range_arena/battlefield)
+"zb" = (
+/turf/closed/wall/mineral/titanium/survival/pod,
+/area/test_range_arena/battlefield)
+"ze" = (
+/obj/structure/flora/rock{
+	color = "#888888"
+	},
+/turf/open/floor/plating/dirt/dark{
+	color = "#555555"
+	},
+/area/test_range_arena/battlefield)
+"zW" = (
+/turf/open/floor/plating/asteroid/basalt{
+	color = "#333333"
+	},
+/area/test_range_arena/battlefield)
+"Ae" = (
 /obj/effect/light_emitter{
 	light_power = 4;
 	light_range = 25;
@@ -26,699 +455,4202 @@
 	set_luminosity = 24
 	},
 /turf/open/floor/facility,
-/area/test_range)
-"t" = (
-/mob/living/simple_animal/bot/cleanbot,
+/area/test_range_arena/classic)
+"Bh" = (
+/obj/structure/sign/departments/discipline{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/siding{
+	color = "#440000";
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/test_range_arena/ouroboros)
+"Bw" = (
+/obj/effect/light_emitter{
+	light_power = 4;
+	light_range = 25;
+	set_cap = 3;
+	set_luminosity = 24
+	},
+/turf/open/floor/facility/dark,
+/area/test_range_arena/ouroboros)
+"CF" = (
+/obj/machinery/door/airlock/highsecurity,
 /turf/open/floor/facility,
-/area/test_range)
-"z" = (
-/obj/machinery/door/airlock,
+/area/test_range_arena/ouroboros)
+"CH" = (
+/obj/item/stack/sheet/mineral/sandbags/fifty{
+	color = "#656565"
+	},
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#444444";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"CI" = (
+/obj/structure/tubes{
+	icon = 'icons/obj/lavaland/donkvendor.dmi';
+	icon_state = "donkvendor"
+	},
+/turf/open/floor/pod,
+/area/test_range_arena/battlefield)
+"CP" = (
+/obj/structure/mecha_wreckage/durand{
+	name = "\improper Rhino wreckage";
+	density = 0;
+	anchored = 1
+	},
+/turf/open/floor/plating/asteroid/basalt{
+	color = "#333333"
+	},
+/area/test_range_arena/battlefield)
+"CV" = (
+/obj/structure/firetree{
+	pixel_y = 0;
+	name = "scorched tree";
+	desc = "A burnt tree. It's a miracle it survived this fighting.";
+	density = 1
+	},
+/turf/open/floor/plating/dirt/dark{
+	color = "#666666"
+	},
+/area/test_range_arena/battlefield)
+"DM" = (
+/obj/effect/turf_decal/siding{
+	color = "#440000"
+	},
+/turf/open/floor/facility/dark,
+/area/test_range_arena/ouroboros)
+"DW" = (
 /turf/open/floor/facility,
-/area/test_range)
-"J" = (
-/turf/closed/indestructible/reinforced,
-/area/test_range)
-"X" = (
+/area/test_range_arena/ouroboros)
+"Ed" = (
+/turf/closed/indestructible/rock,
+/area/space)
+"Eu" = (
+/obj/structure/barricade/sandbags/grey,
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#8888AA";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"EJ" = (
+/obj/effect/light_emitter{
+	light_power = 4;
+	light_range = 25;
+	set_cap = 3;
+	set_luminosity = 24
+	},
+/turf/open/floor/facility,
+/area/test_range_arena/ouroboros)
+"ET" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/test_range_arena/ouroboros)
+"EY" = (
+/turf/open/floor/plasteel/dark,
+/area/test_range_arena/ouroboros)
+"Fi" = (
+/obj/effect/radiojammer{
+	range = 15
+	},
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#8888AA";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"FP" = (
+/obj/effect/light_emitter{
+	light_power = 4;
+	light_range = 25;
+	set_cap = 7;
+	set_luminosity = 24;
+	light_color = "#FF8899"
+	},
+/turf/open/floor/plating/dirt/dark{
+	color = "#555555"
+	},
+/area/test_range_arena/battlefield)
+"Gz" = (
+/obj/effect/turf_decal/siding{
+	color = "#440000";
+	dir = 1
+	},
+/obj/structure/sign/ordealmonitor{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/test_range_arena/ouroboros)
+"GC" = (
 /obj/effect/radiojammer,
 /turf/closed/indestructible/rock,
 /area/space)
-"Z" = (
-/obj/machinery/regenerator/safety,
+"Hx" = (
+/obj/effect/turf_decal/siding{
+	color = "#440000"
+	},
+/turf/open/floor/carpet/red,
+/area/test_range_arena/ouroboros)
+"Hz" = (
+/obj/effect/landmark/test_range_arena{
+	arena_name = "Classic"
+	},
+/turf/open/floor/facility/dark,
+/area/test_range_arena/classic)
+"HR" = (
+/obj/effect/decal/cleanable/blood/gibs/old{
+	color = "#444444"
+	},
+/obj/item/head_trophy/steel_head{
+	pixel_x = 1;
+	pixel_y = -2;
+	color = "#BBBBBB";
+	desc = "A head of an old manager, now laid to rest. It's rotting.";
+	name = "rotting g-corp manager head"
+	},
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#444444";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"Ii" = (
+/obj/item/banner/medical/mundane,
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#AAAAAA";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"Il" = (
+/obj/effect/landmark/test_range_arena{
+	arena_name = "Ouroboros";
+	camera_offset = list("x" = 0, "y" = -12)
+	},
+/turf/open/floor/facility/dark,
+/area/test_range_arena/ouroboros)
+"Ir" = (
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#777799";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"ID" = (
+/obj/effect/landmark/test_range_arena{
+	arena_name = "Battlefield";
+	camera_offset = list("x" = -7, "y" = 0)
+	},
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#6666CC";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"IY" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8;
+	color = "#555555"
+	},
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#AAAAAA";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"Ji" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 1;
+	color = "#555555"
+	},
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#AAAAAA";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"Kq" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#666666";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"LF" = (
+/turf/open/floor/pod,
+/area/test_range_arena/battlefield)
+"LI" = (
+/obj/effect/decal/cleanable/blood/gibs/old{
+	color = "#777777"
+	},
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#666666";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"LQ" = (
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#222222";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"LS" = (
+/obj/machinery/button/indestructible/test_range_cleanup,
+/turf/closed/indestructible/reinforced,
+/area/test_range_arena/battlefield)
+"Mf" = (
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#545454";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"ME" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/test_range_arena/ouroboros)
+"MR" = (
+/obj/effect/turf_decal/siding/white/corner{
+	color = "#440000";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	color = "#440000";
+	dir = 8
+	},
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_arena/ouroboros)
+"NG" = (
+/turf/closed/indestructible/reinforced,
+/area/test_range_arena/battlefield)
+"NP" = (
+/obj/effect/turf_decal/siding{
+	color = "#440000";
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/test_range_arena/ouroboros)
+"OF" = (
+/obj/structure/tubes{
+	icon_state = "fans"
+	},
+/turf/open/floor/pod,
+/area/test_range_arena/battlefield)
+"OG" = (
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#222222";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"OJ" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/test_range_arena/ouroboros)
+"OM" = (
+/obj/effect/turf_decal/siding{
+	color = "#440000";
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/test_range_arena/ouroboros)
+"Pn" = (
+/obj/machinery/door/airlock/highsecurity,
+/obj/effect/turf_decal/siding{
+	color = "#440000";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding{
+	color = "#440000"
+	},
+/turf/open/floor/facility,
+/area/test_range_arena/ouroboros)
+"Px" = (
+/obj/machinery/button/indestructible/test_range_cleanup,
+/turf/closed/indestructible/reinforced,
+/area/test_range_arena/classic)
+"Qk" = (
+/obj/machinery/quantumpad/warp{
+	teleport_cooldown = 40;
+	map_pad_id = "test_range_arena_Classic";
+	map_pad_link_id = "test_range_lobby";
+	teleport_speed = 20;
+	resistance_flags = 64
+	},
+/turf/open/floor/facility,
+/area/test_range_arena/classic)
+"Qs" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8;
+	color = "#555555"
+	},
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#888888";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"RG" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/dark,
+/area/test_range_arena/ouroboros)
+"Te" = (
+/turf/closed/indestructible/reinforced,
+/area/test_range_arena/classic)
+"Tf" = (
+/obj/effect/turf_decal/siding{
+	color = "#440000"
+	},
+/turf/open/floor/plasteel,
+/area/test_range_arena/ouroboros)
+"TR" = (
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#888888";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"TS" = (
+/obj/effect/turf_decal/siding{
+	color = "#440000";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/test_range_arena/ouroboros)
+"UP" = (
+/obj/effect/decal/cleanable/blood/gibs/old{
+	color = "#444444"
+	},
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#444444";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"Vn" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#8888AA";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"Vp" = (
+/obj/structure/flora/rock{
+	color = "#888888"
+	},
+/turf/open/floor/plating/dirt/dark{
+	color = "#666666"
+	},
+/area/test_range_arena/battlefield)
+"Vw" = (
+/obj/structure/sign/departments/welfare,
+/turf/closed/wall/mineral/titanium/survival/pod,
+/area/test_range_arena/battlefield)
+"VS" = (
+/obj/effect/light_emitter{
+	light_power = 4;
+	light_range = 25;
+	set_cap = 7;
+	set_luminosity = 24;
+	light_color = "#FF8899"
+	},
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#888888";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"Wh" = (
+/obj/structure/barricade/sandbags/grey,
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#666666";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"WH" = (
+/obj/effect/turf_decal/siding{
+	color = "#440000"
+	},
+/obj/structure/sign/ordealmonitor{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/red,
+/area/test_range_arena/ouroboros)
+"XE" = (
+/obj/structure/closet/body_bag,
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#AAAAAA";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"Yq" = (
+/obj/effect/turf_decal/siding/white/corner{
+	color = "#440000"
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	color = "#440000";
+	dir = 4
+	},
+/turf/open/floor/facility,
+/area/test_range_arena/ouroboros)
+"Yz" = (
+/obj/effect/light_emitter{
+	light_power = 4;
+	light_range = 25;
+	set_cap = 7;
+	set_luminosity = 24;
+	light_color = "#FF8899"
+	},
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#8888AA"
+	},
+/area/test_range_arena/battlefield)
+"YS" = (
+/turf/open/floor/carpet/red,
+/area/test_range_arena/ouroboros)
+"Zs" = (
+/obj/effect/turf_decal/siding/yellow/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/test_range_arena/ouroboros)
+"ZH" = (
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	color = "#8888AA";
+	slowdown = 0
+	},
+/area/test_range_arena/battlefield)
+"ZQ" = (
+/obj/effect/turf_decal/siding/yellow,
+/obj/structure/sign/ordealmonitor{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/test_range_arena/ouroboros)
 
 (1,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
 "}
 (2,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
 "}
 (3,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
 "}
 (4,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
 "}
 (5,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
 "}
 (6,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-X
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+zb
+zb
+zb
+zb
+zb
+XE
+XE
+XE
+XE
+VS
+tT
+tT
+tT
+tT
+tT
+tT
+tT
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+GC
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
 "}
 (7,1,1) = {"
-a
-a
-a
-a
-a
-J
-J
-J
-J
-J
-J
-J
-J
-J
-J
-J
-J
-J
-a
-a
-a
-a
-a
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+zb
+OF
+gK
+up
+Vw
+iM
+iM
+iM
+iM
+TR
+tT
+tT
+Kq
+tT
+tT
+Kq
+tT
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Te
+Te
+Te
+Te
+Te
+Te
+Te
+Te
+Te
+Te
+Te
+Te
+Te
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
 "}
 (8,1,1) = {"
-a
-a
-a
-a
-a
-J
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-J
-a
-a
-a
-a
-a
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+zb
+CI
+nQ
+LF
+nS
+vy
+Ji
+hP
+iM
+TR
+tT
+tT
+tT
+tT
+tT
+Kq
+tT
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Te
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+Te
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
 "}
 (9,1,1) = {"
-a
-a
-a
-a
-a
-J
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-J
-a
-a
-a
-a
-a
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+zb
+wa
+ec
+ed
+Vw
+Ii
+iM
+fZ
+hP
+TR
+tT
+LI
+tT
+tT
+tT
+tT
+tT
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Te
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+Te
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
 "}
 (10,1,1) = {"
-a
-a
-a
-a
-a
-J
-l
-l
-l
-l
-l
-t
-l
-l
-l
-l
-l
-J
-a
-a
-a
-a
-a
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+zb
+zb
+zb
+zb
+zb
+iM
+iM
+iM
+IY
+TR
+tT
+tT
+tT
+tT
+mq
+tT
+tT
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Te
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+Te
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
 "}
 (11,1,1) = {"
-a
-a
-a
-a
-a
-J
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-J
-J
-J
-J
-J
-J
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+TR
+TR
+TR
+TR
+TR
+TR
+TR
+TR
+Qs
+TR
+tT
+tT
+Kq
+tT
+tT
+tT
+tT
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Te
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+Te
+Te
+Te
+Te
+Te
+Te
+Ed
+Ed
 "}
 (12,1,1) = {"
-a
-a
-a
-a
-a
-J
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-J
-l
-l
-l
-l
-J
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+tT
+tT
+tT
+tT
+tT
+tT
+tT
+tT
+nD
+tT
+tT
+tT
+tT
+tT
+tT
+tT
+tT
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Te
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+Te
+dr
+dr
+dr
+dr
+Te
+Ed
+Ed
 "}
 (13,1,1) = {"
-a
-a
-a
-a
-a
-J
-l
-l
-s
-l
-l
-m
-l
-l
-s
-l
-l
-z
-l
-s
-p
-l
-J
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+CH
+xi
+vC
+HR
+vC
+vC
+xi
+vC
+xi
+vC
+vC
+vC
+vC
+vC
+vC
+xi
+vC
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Px
+dr
+dr
+Ae
+dr
+dr
+Hz
+dr
+dr
+Ae
+dr
+dr
+lh
+dr
+Ae
+Qk
+dr
+Te
+Ed
+Ed
 "}
 (14,1,1) = {"
-a
-a
-a
-a
-a
-J
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-J
-l
-l
-l
-Z
-J
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+CH
+vC
+vC
+vC
+vC
+vC
+vC
+vC
+vC
+vC
+xi
+vC
+UP
+vC
+vC
+vC
+vC
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Te
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+Te
+dr
+dr
+dr
+iE
+Te
+Ed
+Ed
 "}
 (15,1,1) = {"
-a
-a
-a
-a
-a
-J
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-J
-J
-J
-J
-J
-J
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+Wh
+tT
+tT
+tT
+tT
+Wh
+Wh
+Wh
+tT
+tT
+tT
+tT
+tT
+Wh
+Wh
+tT
+tT
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Te
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+Te
+Te
+Te
+Te
+Te
+Te
+Ed
+Ed
 "}
 (16,1,1) = {"
-a
-a
-a
-a
-a
-J
-l
-l
-l
-l
-l
-t
-l
-l
-l
-l
-l
-J
-a
-a
-a
-a
-a
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+Wh
+Wh
+tT
+tT
+Wh
+Wh
+Wh
+Wh
+tT
+tT
+tT
+tT
+Wh
+Wh
+Wh
+tT
+tT
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Te
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+Te
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
 "}
 (17,1,1) = {"
-a
-a
-a
-a
-a
-J
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-J
-a
-a
-a
-a
-a
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+LS
+hk
+Eu
+ZH
+Mf
+OG
+OG
+Mf
+ZH
+ZH
+ZH
+ZH
+ZH
+Ir
+Ir
+Wh
+Ir
+Yz
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Te
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+Te
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
 "}
 (18,1,1) = {"
-a
-a
-a
-a
-a
-J
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-l
-J
-a
-a
-a
-a
-a
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+ZH
+Vn
+Mf
+OG
+zW
+zW
+LQ
+cf
+Fi
+ZH
+ZH
+Ir
+tT
+tT
+tT
+tT
+Ir
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Te
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+Te
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
 "}
 (19,1,1) = {"
-a
-a
-a
-a
-a
-J
-J
-J
-J
-J
-J
-J
-J
-J
-J
-J
-J
-J
-a
-a
-a
-a
-a
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+ZH
+Mf
+LQ
+zW
+CP
+zW
+OG
+Mf
+ZH
+ZH
+ZH
+Ir
+tT
+OG
+LQ
+Ir
+ZH
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Te
+Te
+Te
+Te
+Te
+Te
+Te
+Te
+Te
+Te
+Te
+Te
+Te
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
 "}
 (20,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+ZH
+Mf
+OG
+zW
+me
+OG
+Mf
+ZH
+ZH
+ZH
+ZH
+ZH
+OG
+OG
+zW
+OG
+ZH
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
 "}
 (21,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+ZH
+ZH
+Mf
+OG
+OG
+Mf
+ir
+ir
+ir
+yg
+ir
+ir
+LQ
+kv
+me
+OG
+ir
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
 "}
 (22,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+ZH
+ZH
+ZH
+Mf
+Mf
+ir
+ir
+ir
+ir
+ir
+mJ
+mJ
+OG
+OG
+OG
+mJ
+mJ
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
 "}
 (23,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+mJ
+sI
+mJ
+mJ
+mJ
+hp
+mJ
+mJ
+ID
+mJ
+mJ
+mJ
+mJ
+yR
+yR
+yR
+yR
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
 "}
 (24,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+mJ
+mJ
+mJ
+mJ
+mJ
+mJ
+mJ
+mJ
+mJ
+mJ
+mJ
+sI
+yR
+yR
+yR
+jO
+pl
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
 "}
 (25,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+yR
+yR
+yR
+Vp
+yR
+yR
+yR
+yR
+yR
+yR
+yR
+yR
+yR
+yR
+jO
+jO
+jO
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(26,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+yR
+pI
+yR
+yR
+yR
+CV
+yR
+yR
+yR
+pI
+yR
+pI
+jO
+jO
+ze
+jO
+jO
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(27,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+jO
+jO
+jO
+pl
+jO
+jO
+jO
+pl
+jO
+jO
+jO
+jO
+jO
+jO
+jO
+jO
+pl
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(28,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+jO
+jO
+jO
+jO
+jO
+jO
+jO
+jO
+jO
+FP
+jO
+jO
+jO
+jO
+jO
+jO
+jO
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(29,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+NG
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(30,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(31,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(32,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(33,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(34,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+ci
+hy
+TS
+TS
+TS
+TS
+TS
+TS
+TS
+kC
+kC
+kC
+kC
+kC
+kC
+OJ
+ci
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(35,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+ci
+Gz
+EJ
+DW
+DW
+DW
+DW
+DW
+DW
+DW
+DW
+DW
+DW
+DW
+EJ
+ZQ
+ci
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(36,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+ci
+iS
+DW
+eN
+NP
+NP
+NP
+NP
+NP
+ME
+ME
+ME
+ME
+Zs
+DW
+qf
+ci
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(37,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+iS
+DW
+Tf
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ET
+DW
+qf
+ci
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(38,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+ci
+Hx
+RG
+RG
+RG
+OM
+ci
+pR
+Yq
+hw
+ci
+eT
+eT
+eT
+eT
+eT
+eT
+eT
+ci
+ET
+DW
+qf
+ci
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(39,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+ci
+hL
+wc
+wc
+wc
+gx
+ci
+ci
+Pn
+ci
+ci
+eT
+eT
+eT
+eT
+eT
+eT
+eT
+ci
+ET
+DW
+qf
+ci
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(40,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+ci
+YS
+jm
+xX
+xX
+xX
+xX
+br
+DM
+YS
+ci
+eT
+eT
+eT
+eT
+eT
+eT
+eT
+ci
+ET
+DW
+qf
+ci
+ci
+ci
+ci
+ci
+ci
+Ed
+Ed
+"}
+(41,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+ci
+jm
+br
+EY
+EY
+EY
+EY
+EY
+DM
+YS
+ci
+eT
+eT
+eT
+eT
+eT
+eT
+eT
+ci
+ET
+DW
+ek
+ci
+DW
+DW
+DW
+DW
+ci
+Ed
+Ed
+"}
+(42,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+ci
+WH
+Il
+Bw
+tf
+tf
+tf
+tf
+DM
+YS
+ci
+eT
+eT
+eT
+hn
+eT
+eT
+eT
+ly
+ET
+DW
+oD
+vp
+DW
+EJ
+id
+DW
+ci
+Ed
+Ed
+"}
+(43,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+ci
+hL
+sA
+EY
+EY
+EY
+EY
+EY
+DM
+YS
+ci
+eT
+eT
+eT
+eT
+eT
+eT
+eT
+ci
+ET
+DW
+ek
+ci
+DW
+DW
+DW
+yn
+ci
+Ed
+Ed
+"}
+(44,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+ci
+YS
+hL
+wc
+wc
+wc
+wc
+sA
+DM
+YS
+ci
+eT
+eT
+eT
+eT
+eT
+eT
+eT
+ci
+ET
+DW
+qf
+ci
+ci
+ci
+ci
+ci
+ci
+Ed
+Ed
+"}
+(45,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+ci
+jm
+xX
+xX
+xX
+xY
+ci
+ci
+CF
+ci
+ci
+eT
+eT
+eT
+eT
+eT
+eT
+eT
+ci
+ET
+DW
+qf
+ci
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(46,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+ci
+Hx
+RG
+RG
+RG
+OM
+ci
+tQ
+MR
+Bh
+ci
+eT
+eT
+eT
+eT
+eT
+eT
+eT
+ci
+ET
+DW
+qf
+ci
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(47,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+iS
+DW
+Tf
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ET
+DW
+qf
+ci
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(48,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+ci
+iS
+DW
+dn
+TS
+TS
+TS
+TS
+TS
+kC
+kC
+kC
+kC
+rY
+DW
+qf
+ci
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(49,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+ci
+Gz
+EJ
+DW
+DW
+DW
+DW
+DW
+DW
+DW
+DW
+DW
+DW
+DW
+EJ
+ZQ
+ci
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(50,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+ci
+bY
+NP
+NP
+NP
+NP
+NP
+NP
+NP
+ME
+ME
+ME
+ME
+ME
+ME
+yD
+ci
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(51,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+ci
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(52,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(53,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(54,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(55,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(56,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(57,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(58,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(59,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+"}
+(60,1,1) = {"
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
+Ed
 "}

--- a/_maps/map_files/generic/Tutorial_Zone.dmm
+++ b/_maps/map_files/generic/Tutorial_Zone.dmm
@@ -2,7 +2,7 @@
 "ap" = (
 /obj/machinery/smartfridge/extraction_storage/ego_weapon,
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_lobby)
 "au" = (
 /obj/machinery/computer/camera_advanced{
 	dir = 4
@@ -94,14 +94,18 @@
 /area/facility_hallway/human)
 "ck" = (
 /obj/structure/filingcabinet/zayininfo{
-	pixel_x = -10
+	pixel_x = -10;
+	resistance_flags = 243
 	},
-/obj/structure/filingcabinet/tethinfo,
+/obj/structure/filingcabinet/tethinfo{
+	resistance_flags = 243
+	},
 /obj/structure/filingcabinet/heinfo{
-	pixel_x = 10
+	pixel_x = 10;
+	resistance_flags = 243
 	},
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_lobby)
 "cl" = (
 /obj/structure/table/wood,
 /obj/item/paper/guides/jobs/teth{
@@ -149,7 +153,7 @@
 "dx" = (
 /obj/machinery/smartfridge/extraction_storage/ego_armor,
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_lobby)
 "dA" = (
 /obj/effect/portal/permanent/one_way{
 	id = "tutorial2"
@@ -172,7 +176,7 @@
 /area/facility_hallway/human)
 "eg" = (
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_lobby)
 "eo" = (
 /obj/structure/sign/departments/human{
 	pixel_x = -32
@@ -267,11 +271,11 @@
 "hp" = (
 /obj/structure/toolabnormality/bracelet,
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_lobby)
 "hw" = (
 /obj/machinery/computer/testrangespawner,
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_lobby)
 "hD" = (
 /obj/structure/table/reinforced,
 /obj/item/megaphone,
@@ -295,7 +299,7 @@
 /obj/effect/spawner/lootdrop/three_course_meal,
 /obj/effect/spawner/lootdrop/three_course_meal,
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_lobby)
 "ih" = (
 /obj/machinery/shower{
 	pixel_y = 15
@@ -310,7 +314,7 @@
 	set_luminosity = 24
 	},
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_lobby)
 "iO" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -415,7 +419,7 @@
 "mO" = (
 /obj/effect/mob_spawn/human/testrange,
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_lobby)
 "mQ" = (
 /obj/structure/sign/warning/firingrange,
 /turf/closed/indestructible/reinforced,
@@ -441,7 +445,7 @@
 /area/facility_hallway/human)
 "nf" = (
 /turf/closed/indestructible/reinforced,
-/area/test_range)
+/area/test_range_lobby)
 "nm" = (
 /obj/item/paper/fluff/info/tutorial/cube{
 	anchored = 1
@@ -461,14 +465,18 @@
 /area/department_main/human)
 "oe" = (
 /obj/structure/filingcabinet/wawinfo{
-	pixel_x = -10
+	pixel_x = -10;
+	resistance_flags = 243
 	},
-/obj/structure/filingcabinet/alephinfo,
+/obj/structure/filingcabinet/alephinfo{
+	resistance_flags = 243
+	},
 /obj/structure/filingcabinet/toolinfo{
-	pixel_x = 10
+	pixel_x = 10;
+	resistance_flags = 243
 	},
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_lobby)
 "or" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/scanner_gate/tutorialscanner{
@@ -556,11 +564,11 @@
 "rZ" = (
 /obj/structure/toolabnormality/dr_jekyll,
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_lobby)
 "sc" = (
 /obj/machinery/regenerator/safety,
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_lobby)
 "sn" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/ego_gear/freshman,
@@ -695,13 +703,13 @@
 "vX" = (
 /obj/machinery/quantumpad/warp{
 	map_pad_id = "test_range_lobby";
-	map_pad_link_id = "test_range_arena";
+	map_pad_link_id = "test_range_arena_classic";
 	resistance_flags = 64;
 	teleport_cooldown = 40;
 	teleport_speed = 20
 	},
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_lobby)
 "wb" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
@@ -724,7 +732,7 @@
 "wn" = (
 /obj/machinery/ego_printer,
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_lobby)
 "wy" = (
 /obj/effect/portal/permanent/one_way{
 	id = "tutorial2"
@@ -793,11 +801,17 @@
 /area/department_main/human)
 "zg" = (
 /obj/structure/table,
-/obj/item/scrying,
-/obj/item/scrying,
-/obj/item/scrying,
+/obj/item/scrying{
+	resistance_flags = 243
+	},
+/obj/item/scrying{
+	resistance_flags = 243
+	},
+/obj/item/scrying{
+	resistance_flags = 243
+	},
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_lobby)
 "zy" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Human Resources Department"
@@ -933,10 +947,14 @@
 /area/department_main/human)
 "Dh" = (
 /obj/structure/table,
-/obj/item/lc_debug/attribute_injector,
-/obj/item/lc_debug/attribute_injector,
+/obj/item/lc_debug/attribute_injector{
+	resistance_flags = 243
+	},
+/obj/item/lc_debug/attribute_injector{
+	resistance_flags = 243
+	},
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_lobby)
 "Di" = (
 /obj/structure/sign/poster/lobotomycorp/egoinfo{
 	pixel_y = 32
@@ -992,7 +1010,7 @@
 "Ex" = (
 /obj/structure/toolabnormality/you_happy,
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_lobby)
 "FC" = (
 /obj/machinery/holopad/tutorial{
 	proximity_cooldown_time = 1200
@@ -1149,9 +1167,11 @@
 /turf/open/floor/wood,
 /area/department_main/human)
 "IZ" = (
-/obj/machinery/augment_fabricator/debug,
+/obj/machinery/augment_fabricator/debug{
+	resistance_flags = 64
+	},
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_lobby)
 "Jr" = (
 /turf/open/floor/wood,
 /turf/open/floor/wood,
@@ -1321,7 +1341,7 @@
 "NI" = (
 /obj/structure/toolabnormality/aspiration,
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_lobby)
 "NP" = (
 /obj/machinery/holopad/tutorial,
 /obj/item/disk/holodisk/tutorial/works,
@@ -1330,7 +1350,7 @@
 "Om" = (
 /obj/structure/toolabnormality/behavior,
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_lobby)
 "Oz" = (
 /obj/machinery/regenerator/tutorial,
 /turf/open/floor/carpet/cyan,
@@ -1340,10 +1360,11 @@
 /area/department_main/human)
 "OY" = (
 /obj/machinery/augment_catalogue{
-	pixel_y = -32
+	pixel_y = -32;
+	resistance_flags = 64
 	},
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_lobby)
 "Pc" = (
 /obj/machinery/bookbinder,
 /turf/open/floor/wood,
@@ -1399,7 +1420,7 @@
 "Qi" = (
 /obj/structure/toolabnormality/fateloom,
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_lobby)
 "Ql" = (
 /turf/open/floor/carpet/cyan,
 /area/department_main/human)
@@ -1475,9 +1496,11 @@
 /turf/open/floor/wood,
 /area/department_main/human)
 "SV" = (
-/obj/structure/mirror/magic/lesser,
+/obj/structure/mirror/magic/lesser{
+	resistance_flags = 243
+	},
 /turf/closed/indestructible/reinforced,
-/area/test_range)
+/area/test_range_lobby)
 "Tu" = (
 /obj/machinery/light{
 	dir = 1
@@ -1603,10 +1626,11 @@
 /area/department_main/human)
 "WR" = (
 /obj/machinery/cryopod{
-	dir = 1
+	dir = 1;
+	resistance_flags = 243
 	},
 /turf/open/floor/facility,
-/area/test_range)
+/area/test_range_lobby)
 "WU" = (
 /obj/structure/railing{
 	dir = 1
@@ -1635,6 +1659,13 @@
 	},
 /turf/open/floor/wood,
 /area/department_main/human)
+"XK" = (
+/obj/machinery/button/indestructible/test_range_cleanup{
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/turf/open/floor/facility,
+/area/test_range_lobby)
 "XL" = (
 /turf/open/space/basic,
 /area/space)
@@ -7342,7 +7373,7 @@ XL
 XL
 XL
 nf
-eg
+XK
 eg
 eg
 eg

--- a/code/__DEFINES/cargo.dm
+++ b/code/__DEFINES/cargo.dm
@@ -58,5 +58,5 @@ GLOBAL_LIST_INIT(podstyles, list(\
 	list(POD_SHAPE_OTHER, FALSE,         FALSE,    FALSE,            FALSE,   RUBBLE_NONE,	    "\improper stealth pod", 	"A supply pod that, under normal circumstances, is completely invisible to conventional methods of detection. How are you even seeing this?"),\
 	list(POD_SHAPE_OTHER, "gondola",     FALSE, FALSE,			FALSE,   RUBBLE_NONE,	    "mystery abnormal", 							    "An abnormal yet peaceful creature, it appears to be here with a package for you."),\
 	list(POD_SHAPE_OTHER, FALSE,         FALSE,    FALSE,            FALSE,   RUBBLE_NONE,	        FALSE,      FALSE,      "rl_click", "give_po"),\
-	list(POD_SHAPE_NORML, "helix",      FALSE, FALSE,		"green",     RUBBLE_NORMAL,	"\improper protocol of contemplation", 		"Things are about to get heated.")\
+	list(POD_SHAPE_OTHER, "helix",      FALSE, FALSE,		FALSE,     RUBBLE_NORMAL,	"\improper protocol of contemplation", 		"Things are about to get heated.")\
 ))

--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -137,6 +137,11 @@ GLOBAL_VAR_INIT(cmp_field, "name")
 /proc/cmp_ego_cost_dsc(datum/ego_datum/a, datum/ego_datum/b)
 	return cmp_numeric_dsc(a.cost, b.cost)
 
+/proc/cmp_threat_difficulty_asc(datum/test_range_threat/a, datum/test_range_threat/b)
+	return cmp_numeric_asc(a.estimated_difficulty, b.estimated_difficulty)
+
+/proc/cmp_threat_difficulty_dsc(datum/test_range_threat/a, datum/test_range_threat/b)
+	return cmp_numeric_dsc(a.estimated_difficulty, b.estimated_difficulty)
 /**
  * Sorts crafting recipe requirements before the crafting recipe is inserted into GLOB.crafting_recipes
  *

--- a/code/controllers/subsystem/testrange.dm
+++ b/code/controllers/subsystem/testrange.dm
@@ -9,20 +9,62 @@ SUBSYSTEM_DEF(testrange)
 	var/static/list/ego_datum_paths = list()
 	/// Cache of EGO preview images (base64 strings).
 	var/static/list/ego_preview_icons_cache = list()
+	/// Cache of Threat preview images (base64 strings).
+	var/static/list/threat_preview_icons_cache = list()
 	var/static/list/linked_ego_printers = list()
+	var/static/list/linked_threat_simulators = list()
 	var/static/ego_datums_initialized = FALSE
 	var/static/ego_datums_initializing = FALSE
-
-// So, this subsystem currently exists primarily for the sake of EGO printers - I plan to keep updating the test range so this subsystem will likely be expanded upon
+	var/static/threat_datums_initialized = FALSE
+	var/static/threat_datums_initializing = FALSE
+	/// This is an associative list with two entries; "arenas", which is an associative list of key: arena_name, value: list(turfs in that arena); and "lobby", which is a list of turfs in the test range lobby.
+	var/static/list/test_range_turfs = list("arenas" = list(), "lobby" = list())
+	/// This is an associative list with two entries; "arenas", the value of which is a list of test range arena areas, and "lobby", the value of which which is the test range lobby area.
+	var/static/list/test_range_areas = list("arenas" = list(), "lobby" = null)
+	/// This is an associative list of key: arena_name, value: test range arena landmark.
+	var/static/list/test_range_arenas = list()
+	/// This is an associative list of key: arena_name OR "lobby", value: telepad corresponding to that place.
+	var/static/list/test_range_telepads = list()
+	/// List of the threat datums available for use in the test range.
+	var/static/list/test_range_threat_datums = list()
+	/// This is a list of living test range agents. They'll be taken off the list upon death, and every time the list is emptied out, all living test range threats will be despawned, also.
+	var/static/list/test_range_agents = list()
+	/// This is a list of living test range threats. Dead threats will be removed from the list, and anything in this list will be deleted once the test_range_agents list is empty.
+	var/static/list/test_range_living_threats = list()
 
 /datum/controller/subsystem/testrange/Initialize(start_timeofday)
 	ego_datums_initializing = TRUE
-	INVOKE_ASYNC(src, PROC_REF(InitializeDatums))
+	INVOKE_ASYNC(src, PROC_REF(InitializeEgoDatums))
+
+	threat_datums_initializing = TRUE
+	INVOKE_ASYNC(src, PROC_REF(InitializeThreatDatums))
+
+	// This is expensive (I think), but I'd rather do this once on initialize than many times per round.
+	for(var/area/A in world)
+		if(istype(A, /area/test_range_arena))
+			var/area/test_range_arena/A1 = A
+			test_range_areas["arenas"][A1.GetArenaName()] = A1
+		else if(istype(A, /area/test_range_lobby))
+			test_range_areas["lobby"] = A
+
+	// Caching turfs corresponding to the test range's areas.
+	for(var/arena_key in test_range_areas["arenas"])
+		test_range_turfs["arenas"][arena_key] = list()
+		for(var/turf/T in test_range_areas["arenas"][arena_key])
+			test_range_turfs["arenas"][arena_key] |= T
+			for(var/obj/machinery/quantumpad/warp/arena_telepad in T)
+				test_range_telepads[arena_key] = arena_telepad
+
+	for(var/turf/T2 in test_range_areas["lobby"])
+		test_range_turfs["lobby"] |= T2
+		for(var/obj/machinery/quantumpad/warp/lobby_telepad in T2)
+			test_range_telepads["lobby"] = lobby_telepad
+
 	return ..()
 
 // Evil proc that generates an ego datum for every EGO that isn't test range blacklisted and has a path, also generating a preview icon WHICH IS A BIT HEAVY ON DISK USAGE ! ! !
 // However, on my machine, this is actually only about as expensive on compute as someone firing Havana... I think that might say more about Havana though
-/datum/controller/subsystem/testrange/proc/InitializeDatums()
+/datum/controller/subsystem/testrange/proc/InitializeEgoDatums()
 	if(!ego_datums_initialized)
 		for(var/datumpath in subtypesof(/datum/ego_datum))
 			var/datum/ego_datum/ED = new datumpath
@@ -68,7 +110,7 @@ SUBSYSTEM_DEF(testrange)
 	return base64icon
 
 /// Extracts an item's icon state so we can use it as a preview. Looks jank if it has directionals (W Corp Armour Vest my beloathed)
-/datum/controller/subsystem/proc/GetEgoDatumItemIcon(obj/item/item_path)
+/datum/controller/subsystem/testrange/proc/GetEgoDatumItemIcon(obj/item/item_path)
 	if(!ispath(item_path))
 		return
 	var/item_icon = initial(item_path.icon)
@@ -77,3 +119,89 @@ SUBSYSTEM_DEF(testrange)
 		item_icon_state = "" // Some insidious datums have no icon state, like naked nest cure
 	var/icon/final_icon = icon(icon = item_icon, icon_state = item_icon_state, frame = 1)
 	return final_icon
+
+/datum/controller/subsystem/testrange/proc/InitializeThreatDatums()
+	if(!threat_datums_initialized)
+		for(var/datumpath in subtypesof(/datum/test_range_threat))
+			var/datum/test_range_threat/TD = new datumpath
+			if((TD.enabled) && (TD.mob_path))
+				test_range_threat_datums |= TD
+				GenerateThreatPreviewIcon(TD)
+			else
+				qdel(TD)
+
+			stoplag()
+
+		// The datums list is currently in the order that they were 'found' in the directory tree. Now we sort them from highest PE cost to lowest PE cost.
+		test_range_threat_datums = sortTim(test_range_threat_datums, cmp=GLOBAL_PROC_REF(cmp_threat_difficulty_asc))
+
+		for(var/obj/machinery/computer/testrangespawner/TRS in linked_threat_simulators)
+			TRS.current_arena = pick(test_range_arenas)
+
+			var/obj/machinery/quantumpad/warp/lobby_pad = test_range_telepads["lobby"]
+			lobby_pad.linked_pad = test_range_telepads[TRS.current_arena]
+
+			TRS.InitializeCamera()
+
+		threat_datums_initializing = FALSE
+		threat_datums_initialized = TRUE
+
+/datum/controller/subsystem/testrange/proc/GenerateThreatPreviewIcon(datum/test_range_threat/threat_datum)
+	if(!istype(threat_datum))
+		return
+
+	// Cached? Use that instead
+	var/wait_did_we_already_do_this = threat_preview_icons_cache[threat_datum.mob_path]
+	if(wait_did_we_already_do_this)
+		return wait_did_we_already_do_this
+
+	var/icon/final_icon = GetThreatDatumMobIcon(threat_datum.mob_path)
+	var/base64icon = null
+
+	if(final_icon)
+		base64icon = icon2base64(final_icon) // Icon is now a string we can pass into TGUI
+		ego_preview_icons_cache[threat_datum.mob_path] = base64icon // Add to cache
+
+	qdel(final_icon)
+	return base64icon
+
+/datum/controller/subsystem/testrange/proc/GetThreatDatumMobIcon(mob_path)
+	if(!ispath(mob_path, /mob/living/simple_animal))
+		return
+	var/mob/living/simple_animal/our_guy = mob_path
+	var/mob_icon = initial(our_guy.icon)
+	var/mob_icon_state = initial(our_guy.icon_state)
+	if(!(mob_icon_state in icon_states(icon(mob_icon))))
+		mob_icon_state = ""
+	var/icon/final_icon = icon(icon = mob_icon, icon_state = mob_icon_state, dir = SOUTH, frame = 1)
+	return final_icon
+
+// Stolen code from Claw Smite.
+/datum/controller/subsystem/testrange/proc/Despawn(mob/living/victim)
+	var/turf/origin = get_turf(victim)
+	var/list/all_turfs = origin.reachableAdjacentTurfs()
+	for(var/turf/T in all_turfs)
+		if(T == origin)
+			continue
+		new /obj/effect/temp_visual/dir_setting/claw_appears(T)
+		break
+	new /obj/effect/temp_visual/justitia_effect(origin)
+	qdel(victim)
+
+/datum/controller/subsystem/testrange/proc/CleanupCheck()
+	if(!length(test_range_agents))
+		// Cleanup will be started with a sliiiight delay to avoid some runtimes from null references from gibbing mobs and stuff...
+		addtimer(CALLBACK(src, PROC_REF(Cleanup)), 1 SECONDS)
+
+// This proc has sleeps in it because it looks cooler. Call it asynchronously
+/datum/controller/subsystem/testrange/proc/Cleanup()
+	for(var/mob/living/L in test_range_living_threats)
+		Despawn(L)
+		sleep(rand(1,2))
+
+	// Sadly, some mobs spawn byproducts that do not disappear when they are destroyed or killed (Judgement Bird), so we're gonna need to scan every turf of every arena for them... It's not THAT expensive....?
+	for(var/arena_key in test_range_turfs["arenas"])
+		for(var/turf/T in test_range_turfs["arenas"][arena_key])
+			for(var/mob/living/L2 in T)
+				Despawn(L2)
+				sleep(rand(1,2))

--- a/code/controllers/subsystem/testrange.dm
+++ b/code/controllers/subsystem/testrange.dm
@@ -37,7 +37,6 @@ SUBSYSTEM_DEF(testrange)
 	INVOKE_ASYNC(src, PROC_REF(InitializeEgoDatums))
 
 	threat_datums_initializing = TRUE
-	INVOKE_ASYNC(src, PROC_REF(InitializeThreatDatums))
 
 	// This is expensive (I think), but I'd rather do this once on initialize than many times per round.
 	for(var/area/A in world)
@@ -60,6 +59,7 @@ SUBSYSTEM_DEF(testrange)
 		for(var/obj/machinery/quantumpad/warp/lobby_telepad in T2)
 			test_range_telepads["lobby"] = lobby_telepad
 
+	INVOKE_ASYNC(src, PROC_REF(InitializeThreatDatums))
 	return ..()
 
 // Evil proc that generates an ego datum for every EGO that isn't test range blacklisted and has a path, also generating a preview icon WHICH IS A BIT HEAVY ON DISK USAGE ! ! !

--- a/code/datums/abnormality/_ego_datum/auxiliary.dm
+++ b/code/datums/abnormality/_ego_datum/auxiliary.dm
@@ -23,6 +23,13 @@ Oh please give these a nice name by the way
 	information["name"] = src.name ? src.name : E.name // Use datum name where possible, otherwise use item's name
 	information["description"] = E.desc
 
+// Medipen Kit
+/datum/ego_datum/auxiliary/medkit
+	cost = 20
+	item_category = "Medicine"
+	item_path = /obj/item/storage/firstaid/revival
+	well_enabled = FALSE
+
 // Bongbread
 /datum/ego_datum/auxiliary/bongbread
 	cost = 12

--- a/code/datums/abnormality/_ego_datum/auxiliary.dm
+++ b/code/datums/abnormality/_ego_datum/auxiliary.dm
@@ -56,6 +56,11 @@ Oh please give these a nice name by the way
 	item_path = /obj/item/lc_debug/attribute_injector
 	well_enabled = FALSE
 
+/datum/ego_datum/auxiliary/augment_remover
+	item_category = "Debug"
+	item_path = /obj/item/augment_remover/debug
+	well_enabled = FALSE
+
 // Naked Nest - Cure (Can also be bought from the Cargo Console)
 /datum/ego_datum/auxiliary/exuviae
 	name = "Naked Nest Cure"
@@ -98,7 +103,7 @@ Oh please give these a nice name by the way
 // Thumb South Grenade Kit
 
 // Thumb South Capo Grenadier Belt
-/datum/ego_datum/auxiliary/grenade_belt
+/datum/ego_datum/auxiliary/thumb_south_grenade_belt
 	name = "Thumb South Grenadier Belt"
 	origin = "City"
 	item_category = "Belt"
@@ -107,6 +112,7 @@ Oh please give these a nice name by the way
 	well_enabled = FALSE
 
 // Thumb South Capo Fragmentation Grenades
+/datum/ego_datum/auxiliary/thumb_south_grenade
 	name = "Thumb South Fragmentation Grenade"
 	origin = "City"
 	item_category = "Ordnance"

--- a/code/datums/abnormality/_ego_datum/auxiliary.dm
+++ b/code/datums/abnormality/_ego_datum/auxiliary.dm
@@ -23,6 +23,17 @@ Oh please give these a nice name by the way
 	information["name"] = src.name ? src.name : E.name // Use datum name where possible, otherwise use item's name
 	information["description"] = E.desc
 
+// Test Range Utilities - the ones that usually spawn on the table, in case we run out
+/datum/ego_datum/auxiliary/scrying
+	item_category = "Debug"
+	item_path = /obj/item/scrying
+	well_enabled = FALSE
+
+/datum/ego_datum/auxiliary/attributes
+	item_category = "Debug"
+	item_path = /obj/item/lc_debug/attribute_injector
+	well_enabled = FALSE
+
 // Naked Nest - Cure (Can also be bought from the Cargo Console)
 /datum/ego_datum/auxiliary/exuviae
 	name = "Naked Nest Cure"

--- a/code/datums/abnormality/_ego_datum/auxiliary.dm
+++ b/code/datums/abnormality/_ego_datum/auxiliary.dm
@@ -23,6 +23,28 @@ Oh please give these a nice name by the way
 	information["name"] = src.name ? src.name : E.name // Use datum name where possible, otherwise use item's name
 	information["description"] = E.desc
 
+// Bongbread
+/datum/ego_datum/auxiliary/bongbread
+	cost = 12
+	item_category = "Food"
+	item_path = /obj/item/food/bread/bongbread
+	well_enabled = FALSE
+
+// Small Arms EGO Belt
+/datum/ego_datum/auxiliary/ego_belt
+	cost = 12
+	item_category = "Belt"
+	item_path = /obj/item/storage/belt/ego
+	well_enabled = FALSE
+
+// DO's Anti-Abnormality Grenade Box
+/datum/ego_datum/auxiliary/lobotomygrenades
+	name = "Anti-Abnormality Grenade Box"
+	cost = 20
+	item_category = "Ordnance"
+	item_path = /obj/item/storage/box/lobotomygrenades
+	well_enabled = FALSE
+
 // Test Range Utilities - the ones that usually spawn on the table, in case we run out
 /datum/ego_datum/auxiliary/scrying
 	item_category = "Debug"
@@ -71,6 +93,25 @@ Oh please give these a nice name by the way
 	item_category = "Consumable"
 	item_path = /obj/item/nihil/club
 	cost = 150
+	well_enabled = FALSE
+
+// Thumb South Grenade Kit
+
+// Thumb South Capo Grenadier Belt
+/datum/ego_datum/auxiliary/grenade_belt
+	name = "Thumb South Grenadier Belt"
+	origin = "City"
+	item_category = "Belt"
+	item_path = /obj/item/storage/belt/grenade
+	cost = 12
+	well_enabled = FALSE
+
+// Thumb South Capo Fragmentation Grenades
+	name = "Thumb South Fragmentation Grenade"
+	origin = "City"
+	item_category = "Ordnance"
+	item_path = /obj/item/grenade/r_corp/thumb
+	cost = 35
 	well_enabled = FALSE
 
 // Thumb East Ammo Boxes

--- a/code/datums/test_range_threats.dm
+++ b/code/datums/test_range_threats.dm
@@ -51,6 +51,7 @@
 		if(desc == "Placeholder description.")
 			desc = L.desc
 
+/// Calls PreSpawn to check if we can spawn it; if we can, it calls Spawn then PostSpawn afterwards. The Test Range Threat Simulator will use this proc to spawn mobs.
 /datum/test_range_threat/proc/Start(turf/spawnpoint, tuning)
 	if(!PreSpawn(spawnpoint, tuning))
 		return FALSE
@@ -58,15 +59,18 @@
 	PostSpawn(L, tuning)
 	return TRUE
 
+/// Pre-spawn checks. You can put side effects here too I guess
 /datum/test_range_threat/proc/PreSpawn(turf/spawnpoint, tuning)
 	if(max_spawns && ((length(currently_spawned) + 1) > max_spawns))
 		to_chat(usr, span_warning("Maximum spawns for [src.name] already reached. Despawn or kill one."))
 		return FALSE
 	return TRUE
 
+/// Must create and return the threat's mob
 /datum/test_range_threat/proc/Spawn(turf/spawnpoint, tuning)
 	return new mob_path(spawnpoint)
 
+/// Sets important signals and adds the mob to the lists it should be in.
 // Always call ..() when overriding this. You'll probably need to override it in some cases that require BreachEffect or similar things.
 /datum/test_range_threat/proc/PostSpawn(mob/living/just_spawned, tuning)
 	SHOULD_CALL_PARENT(TRUE)
@@ -113,8 +117,6 @@
 /// Subtype for Abnormalities that should have BreachEffect called on them when spawned in the Test Range. Do not include Abnos which cause global effects, etc in their breach.
 // NOTE: If BreachEffect sleeps then spawning these threats will also be delayed. Maybe we can invoke async? I dunno, it should be fine
 /datum/test_range_threat/breacher
-	name = "Unknown Breaching Threat"
-
 /datum/test_range_threat/breacher/PostSpawn(mob/living/just_spawned, tuning)
 	. = ..()
 	var/mob/living/simple_animal/hostile/abnormality/breachy_guy = just_spawned
@@ -401,6 +403,7 @@
 	origin_detailed = D_ORIGIN_ABNORMALITY
 	estimated_difficulty = 4
 	mob_path = /mob/living/simple_animal/hostile/abnormality/nothing_there
+	max_spawns = 3
 	tuning_name = "Phase"
 	tuning_min = 1
 	tuning_limit = 3
@@ -429,6 +432,7 @@
 	origin_detailed = D_ORIGIN_ABNORMALITY
 	estimated_difficulty = 2
 	mob_path = /mob/living/simple_animal/hostile/abnormality/silentorchestra
+	max_spawns = 3
 
 /datum/test_range_threat/last_shot
 	name = "Til the Last Shot"
@@ -439,6 +443,7 @@
 	origin_detailed = D_ORIGIN_ABNORMALITY
 	estimated_difficulty = 3
 	mob_path = /mob/living/simple_animal/hostile/abnormality/last_shot
+	max_spawns = 3
 
 /datum/test_range_threat/distortedform
 	name = "Distorted Form"
@@ -452,6 +457,7 @@
 	origin_detailed = D_ORIGIN_ABNORMALITY
 	estimated_difficulty = 5
 	mob_path = /mob/living/simple_animal/hostile/abnormality/distortedform
+	max_spawns = 3
 
 
 #undef ORIGIN_LC13

--- a/code/datums/test_range_threats.dm
+++ b/code/datums/test_range_threats.dm
@@ -1,0 +1,466 @@
+#define ORIGIN_LC13 "Lobotomy Corporation"
+#define ORIGIN_B12 "Branch 12"
+#define ORIGIN_COL "City of Light"
+#define ORIGIN_RCE "R-Corp Expedition"
+#define ORIGIN_JOKE "Joke"
+
+#define D_ORIGIN_ABNORMALITY "Abnormality"
+#define D_ORIGIN_ORDEAL "Ordeal"
+#define D_ORIGIN_QUEST "Quest"
+#define D_ORIGIN_COMBATPAGE "Combat Page"
+
+/datum/test_range_threat
+	/// If not set manually, will take the name of the mob.
+	var/name = "Unknown Threat"
+	/// If not set manually, will take the desc of the mob.
+	var/desc = "Placeholder description."
+	/// Optional, tell players what they should do to defeat this mob.
+	var/battle_guide
+	/// Unimportant, see the defines above.
+	var/origin = ORIGIN_LC13
+	/// Unimportant, See the defines above.
+	var/origin_detailed = D_ORIGIN_ABNORMALITY
+	/// If this is FALSE, this threat won't show up in the Test Range.
+	var/enabled = TRUE
+	/// Roughly how difficult this threat is. It's subjective, but I personally rate them based on their difficulty with appropiate gear - TSO may be an ALEPH, but you're fighting it with WAW/ALEPH gear, and it's very easy then.
+	var/estimated_difficulty = 1
+
+	/// The path to the mob this threat should spawn. If null, this threat is disabled.
+	var/mob_path
+	/// List of current spawned instances of this threat.
+	var/list/currently_spawned = list()
+	/// No more than this amount of instances of this threat can exist at the same time.
+	var/max_spawns = 15
+
+	// Tuning: this allows you to customize the spawn a little bit... so, for example, you can let players spawn NT at different phases, or give Warden a certain amount of devoured bodies.
+	// Requires some overriding of procs to make this work.
+	/// What kind of tuning is this? Example: 'Souls' for Warden, 'Player Scaling' for Matriarch, 'Phase' for Nothing There. If null, it has no tuning.
+	var/tuning_name
+	/// Tuning starts at this value, and cannot go below it.
+	var/tuning_min = 0
+	/// Tuning cannot go above this value.
+	var/tuning_limit = 100
+
+
+/datum/test_range_threat/New()
+	. = ..()
+	if(ispath(mob_path, /mob/living))
+		var/mob/living/L = mob_path
+		if(name == "Unknown Threat")
+			name = L.name
+		if(desc == "Placeholder description.")
+			desc = L.desc
+
+/datum/test_range_threat/proc/Start(turf/spawnpoint, tuning)
+	if(!PreSpawn(spawnpoint, tuning))
+		return FALSE
+	var/mob/living/L = Spawn(spawnpoint, tuning)
+	PostSpawn(L, tuning)
+	return TRUE
+
+/datum/test_range_threat/proc/PreSpawn(turf/spawnpoint, tuning)
+	if(max_spawns && ((length(currently_spawned) + 1) > max_spawns))
+		to_chat(usr, span_warning("Maximum spawns for [src.name] already reached. Despawn or kill one."))
+		return FALSE
+	return TRUE
+
+/datum/test_range_threat/proc/Spawn(turf/spawnpoint, tuning)
+	return new mob_path(spawnpoint)
+
+// Always call ..() when overriding this. You'll probably need to override it in some cases that require BreachEffect or similar things.
+/datum/test_range_threat/proc/PostSpawn(mob/living/just_spawned, tuning)
+	SHOULD_CALL_PARENT(TRUE)
+
+	if(!istype(just_spawned, mob_path))
+		return FALSE
+	var/mob/living/our_guy = just_spawned
+	currently_spawned |= our_guy
+	SStestrange.test_range_living_threats |= our_guy
+	RegisterSignal(our_guy, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING), PROC_REF(OnDeath))
+	RegisterSignal(our_guy, COMSIG_AREA_ENTERED, PROC_REF(AreaCheck))
+
+	// Disable core drops for any Abnormality that spawns.
+	if(isabnormalitymob(our_guy))
+		var/mob/living/simple_animal/hostile/abnormality/our_abno = our_guy
+		our_abno.core_enabled = FALSE
+
+	return our_guy
+
+/datum/test_range_threat/proc/DespawnOne()
+	if(length(currently_spawned))
+		var/mob/living/L = pick(currently_spawned)
+		SStestrange.Despawn(L)
+		return TRUE
+	return FALSE
+
+/datum/test_range_threat/proc/DespawnAll()
+	for(var/mob/living/L in currently_spawned)
+		SStestrange.Despawn(L)
+
+/datum/test_range_threat/proc/OnDeath(mob/living/ded)
+	SIGNAL_HANDLER
+	UnregisterSignal(ded, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING, COMSIG_AREA_ENTERED))
+	currently_spawned -= ded
+	SStestrange.test_range_living_threats -= ded
+
+// Deletes anything that enters an area that isn't the Test Range fighting area.
+/datum/test_range_threat/proc/AreaCheck(mob/living/soon_to_be_ded, area/entered_area)
+	SIGNAL_HANDLER
+	if(istype(entered_area, /area/test_range_arena))
+		return
+	SStestrange.Despawn(soon_to_be_ded)
+
+/// Subtype for Abnormalities that should have BreachEffect called on them when spawned in the Test Range. Do not include Abnos which cause global effects, etc in their breach.
+// NOTE: If BreachEffect sleeps then spawning these threats will also be delayed. Maybe we can invoke async? I dunno, it should be fine
+/datum/test_range_threat/breacher
+	name = "Unknown Breaching Threat"
+
+/datum/test_range_threat/breacher/PostSpawn(mob/living/just_spawned, tuning)
+	. = ..()
+	var/mob/living/simple_animal/hostile/abnormality/breachy_guy = just_spawned
+	if(!istype(breachy_guy))
+		return
+	breachy_guy.BreachEffect()
+
+// ------------------ !!! ORDEALS !!! ------------------
+/datum/test_range_threat/peccatulum_sloth_2
+	name = "Peccatulum Acediae?"
+	battle_guide = "This enemy appears in the Brown Noon Ordeal. It is slow, but able to inflict TREMOR in a wide area. \n\n\
+	It has reach-2 autoattacks, and is able to perform a telegraphed leap with an extremely wide AoE, inflicting TREMOR and TREMOR BURST. It is best to bait this leap before attempting to engage. Very weak to BLACK damage."
+	origin = ORIGIN_LC13
+	origin_detailed = D_ORIGIN_ORDEAL
+	estimated_difficulty = 2
+
+	mob_path = /mob/living/simple_animal/hostile/ordeal/sin_sloth/noon
+
+/datum/test_range_threat/peccatulum_gluttony_2
+	name = "Peccatulum Gulae?"
+	battle_guide = "This enemy appears in the Brown Noon Ordeal. It is fragile, but fast, and able to devour you. \n\n\
+	Its damage output is not particularly high in normal circumstances, but if it manages to devour you, you must quickly deal enough damage to break out, or begin to take ramping damage. Very weak to BLACK damage."
+	origin = ORIGIN_LC13
+	origin_detailed = D_ORIGIN_ORDEAL
+	estimated_difficulty = 2
+
+	mob_path = /mob/living/simple_animal/hostile/ordeal/sin_gluttony/noon
+
+/datum/test_range_threat/peccatulum_gloom_2
+	name = "Peccatulum Morositatis?"
+	battle_guide = "This enemy appears in the Brown Noon Ordeal. It is fragile and unable to attack conventionally. \n\n\
+	It has only one attack - a telegraphed slam down that creates a large, radial AoE, dealing heavy WHITE damage. Easy to dodge. This enemy can be popped with ranged weapons from a safe distance, or bursted down with RED, BLACK or PALE damage."
+	origin = ORIGIN_LC13
+	origin_detailed = D_ORIGIN_ORDEAL
+	estimated_difficulty = 1
+
+	mob_path = /mob/living/simple_animal/hostile/ordeal/sin_gloom/noon
+
+/datum/test_range_threat/peccatulum_pride_2
+	name = "Peccatulum Superbiae?"
+	battle_guide = "This enemy appears in the Brown Noon Ordeal. It is extremely fragile, but fast, and able to deal heavy BLACK damage in a wide area. \n\n\
+	It attacks with fast autoattacks, or a telegraphed, extremely wide charge. Do not get hit by it. Any damage but BLACK damage works."
+	origin = ORIGIN_LC13
+	origin_detailed = D_ORIGIN_ORDEAL
+	estimated_difficulty = 2
+
+	mob_path = /mob/living/simple_animal/hostile/ordeal/sin_pride/noon
+
+/datum/test_range_threat/peccatulum_wrath_2
+	name = "Peccatulum Irae?"
+	battle_guide = "This enemy appears in the Brown Noon Ordeal. It is fragile, but deals heavy BLACK damage and is also able to inflict BURN. \n\n\
+	Attacks by charging then slamming down in an AoE, or with regular auto-attacks. It is best to burst it down with PALE or RED damage, or use a ranged weapon to kite it."
+	origin = ORIGIN_LC13
+	origin_detailed = D_ORIGIN_ORDEAL
+	estimated_difficulty = 2
+
+	mob_path = /mob/living/simple_animal/hostile/ordeal/sin_wrath/noon
+
+/datum/test_range_threat/peccatulum_lust_2
+	name = "Peccatulum Luxuriae?"
+	battle_guide = "This enemy appears in the Brown Noon Ordeal. It is slow, but extremely tanky and able to inflict BLEED at range, and knock back on hit. Deals a good amount of RED damage. \n\n\
+	Randomly blocks melee and ranged attacks. Frequently uses a telegraphed shotgun-like attack that inflicts BLEED. If you are hit by it, turning on walk-mode will stop you from proccing BLEED. Use PALE or WHITE damage."
+	origin = ORIGIN_LC13
+	origin_detailed = D_ORIGIN_ORDEAL
+	estimated_difficulty = 3
+
+	mob_path = /mob/living/simple_animal/hostile/ordeal/sin_lust/noon
+
+/* Can't quite add this one, apparently her death causes ALL handmaidens in the world to go enraged. Annoying as hell, I'll look at it later or something idk
+/datum/test_range_threat/gold_noon
+	name = "Lady of the Lake"
+	battle_guide = "This enemy appears in the Gold Noon Ordeal. She has a good amount of health, but is unable to attack conventionally. \n\n\
+	Her only two methods of attack are a forward AoE slash, and a radial AoE attack. This latter attack is typically used when surrounded or approaching a target. They are both dodgeable, but deal decent PALE damage if they land. \n\n\
+	The Lady of the Lake is often accompanied by Silent Handmaidens that are passive until provoked. It is a good idea to separate them and deal with them individually. These handmaidens deal PALE damage, and apply a debuff that deals additional WHITE damage when you take damage. \n\n\
+	Able to block ranged projectiles and melee attacks when she is not winding up an attack. Wait for the right moment to strike if your weapon has a low fire rate or swing speed."
+	origin = ORIGIN_LC13
+	origin_detailed = D_ORIGIN_ORDEAL
+	estimated_difficulty = 2
+
+	mob_path = /mob/living/simple_animal/hostile/ordeal/white_lake_corrosion
+*/
+
+/datum/test_range_threat/matriarch
+	name = "Sweeper Matriarch"
+	battle_guide = "This enemy appears in the Indigo Midnight Ordeal. She is physically powerful, and can regenerate large amounts of her health by feeding on dead bodies or landing her combat abilities. \n\n\
+	The Matriarch begins at Phase 1 and, as she loses health, will progress towards Phase 3. Every time she changes her phase, her maximum health will be reduced to the phase-change threshold - this means she can't heal back up to her original maximum health. \n\n\
+	As the Matriarch changes phases, she will lose damage output, but recover more health from her abilities, and attack and move faster, as well as unlock additional combat abilities. \n\n\
+	She begins with 3 random offensive skills out of a pool of 5, and each phase unlocks 1 more. The full set of skills is as follows: Dash (Sweep the Backstreets), Slam (Shockwave), Slash (Claw Swipe), Lunge (Trash Disposal) and Parry. \n\n\
+	The Matriarch may also summon allied sweepers to her side. Every time she summons them, the cooldown becomes longer - however, it is refreshed every time she changes phase. Amount and power of summoned sweepers decreases as she changes phases. \n\n\
+	She also has minor player scaling - the more people that are ready to fight her when the Ordeal begins, the more health she has, and past a certain threshold, she will be able to summon roving packs of Sweepers throughout the facility. \n\n\
+	The Matriarch will react with extreme aggression to being shot at by ranged weaponry - shoot her enough times and she will roar, dealing ramping BLACK damage in a colossal, undodgeable AoE, and increasing the amount of Sweepers she can summon. \n\n\
+	To beat her, you simply have to not get hit by her abilities, to avoid healing her. Usage of BLACK armour is heavily recommended - PALE and WHITE weapons are best."
+	origin = ORIGIN_LC13
+	origin_detailed = D_ORIGIN_ORDEAL
+	estimated_difficulty = 5
+
+	mob_path = /mob/living/simple_animal/hostile/ordeal/indigo_midnight/weak
+	max_spawns = 2
+	tuning_name = "Player Scaling"
+	tuning_min = 1
+	tuning_limit = 15
+
+/datum/test_range_threat/matriarch/Spawn(turf/spawnpoint, tuning = 1)
+	return new mob_path(spawnpoint, tuning)
+
+/datum/test_range_threat/helix
+	name = "Helix of the End"
+	battle_guide = "This enemy appears in the Green Midnight Ordeal. It is immobile, and unable to attack conventionally, but has one of the largest health pools of any enemy. Weak to BLACK damage. Heavily resists RED damage. \n\n\
+	Repeats the same cycle throughout its fight: \n\n\
+	1. Prepares, then fires, a large array of laser beams. These have an extremely long range and pierce walls, dealing a ton of BLACK damage for as long as you linger within them. Throughout these beams' active time, lesser lasers will rain down as AoEs. \n\n\
+	2. Stores the array of lasers, then, if it isn't at maximum minion capacity, fires drop-pods with Green Noon and Green Dawn allies to support it. \n\n\
+	3. Repeat. As the Helix's health lowers, more lasers will be fired and more minions will be summoned. \n\n\
+	Since the BLACK damage from this fight is entirely avoidable, it is recommended to armour yourself against the RED damage dealt by the minions spawned by this Ordeal. BLACK damage, especially BLACK AoE damage, is extremely valuable to have."
+	origin = ORIGIN_LC13
+	origin_detailed = D_ORIGIN_ORDEAL
+	estimated_difficulty = 4
+
+	mob_path = /mob/living/simple_animal/hostile/ordeal/green_midnight
+	max_spawns = 1
+	tuning_name = "Player Scaling"
+	tuning_min = 1
+	tuning_limit = 4
+
+/datum/test_range_threat/helix/Spawn(turf/spawnpoint, tuning = 1)
+	return new mob_path(spawnpoint, tuning)
+
+// ------------------ !!! QUEST MOBS !!! ------------------
+/datum/test_range_threat/sanguine_flame
+	name = "Echo Office Fixer: Sanguine Flame"
+	battle_guide = "A fixer from the Echo Office. Wields a spear which deals RED damage as well as applying BURN stacks. Weak to PALE damage, heavily resists RED and WHITE. \n\n\
+	Able to use several different combat abilities, but they are all pre-empted by him calling them out. The most important one is a PALE-damage counterattacking stance - do not hit it. \n\n\
+	This fixer can also fire a slow, homing projectile. If you can manage to crash it into him, it will stagger him, rendering him helpless and vulnerable."
+	origin = ORIGIN_COL
+	origin_detailed = D_ORIGIN_QUEST // Technically originally a combat page?
+	estimated_difficulty = 3
+
+	mob_path = /mob/living/simple_animal/hostile/humanoid/fixer/flame
+
+/datum/test_range_threat/memory_forger
+	name = "Echo Office Fixer: Memory Forger"
+	battle_guide = "A fixer from the Echo Office. Deals BLACK damage. Weak to PALE damage, heavily resists BLACK and RED. \n\n\
+	Has a few distinct combat abilities - his primary means of attack is firing spike projectiles which travel in a straight line and bounce several times. They are piercing, and will deal high damage to you while healing him on contact. \n\n\
+	Thus, it is best to fight this enemy while keeping him at a diagonal angle from you, and out of the path of any bouncing projectiles. \n\n\
+	Also able to perform a high damage, telegraphed radial AoE attack. \n\n\
+	Can spawn statues which heal him - if you manage to get him to hit his statues with the aforementioned AoE attack, it will stagger him, rendering him helpless and vulnerable."
+	origin = ORIGIN_COL
+	origin_detailed = D_ORIGIN_QUEST // Technically originally a combat page?
+	estimated_difficulty = 3
+
+	mob_path = /mob/living/simple_animal/hostile/humanoid/fixer/metal
+
+
+// add the other echo guys when ender's PR is merged
+
+
+/* Can't put this in 'cause the bomb it drops deletes turfs entirely.
+/datum/test_range_threat/denial_of_concept
+	name = "Denial of Concept"
+	battle_guide = "A large, immobile machine. It is unable to attack conventionally, but has great firepower regardless. Deals RED damage and is weak to BLACK. Heavily resists RED damage. \n\n\
+	Its primary, and most dangerous attack, is a telegraphed minigun barrage. It is nearly impossible to survive without the use of cover, but you are given ample time to flee from it. \n\n\
+	It will periodically fire napalm blasts in all cardinal and intercardinal directions, but this has a long cooldown. These napalm blasts leave a lingering fire trail that deals BURN damage and applies BURN stacks. \n\n\
+	If you get too close, it will perform a low-damage knockback AoE to push you away. \n\n\
+	When fought in its lair, it will summon Dawn of Green enemies to assist it. \n\n\
+	YOU ARE HEAVILY ENCOURAGED NOT TO SPAWN THIS IN THE CLASSIC ARENA."
+	origin = ORIGIN_COL // Technically also appears in LC13?
+	origin_detailed = D_ORIGIN_QUEST
+	estimated_difficulty = 4
+
+	mob_path = /mob/living/simple_animal/hostile/ordeal/grungeon_boss
+	max_spawns = 1
+*/
+
+// ------------------ !!! ABNORMALITIES !!! ------------------
+
+/datum/test_range_threat/breacher/forsaken_murderer
+	name = "Forsaken Murderer"
+	battle_guide = "A very weak TETH Abnormality, but regardless it is one of the first threats you'll encounter in a Lobotomy Corporation facility that could actually kill you. \n\n\
+	Higher level Agents can easily face-tank it, but it can outmatch lower level Agents in melee. It is relatively weak to ranged kiting. \n\n\
+	Its attacks deal RED damage and have knockback, so take care it does not knock you into an awkward position."
+	origin = ORIGIN_LC13
+	origin_detailed = D_ORIGIN_ABNORMALITY
+	estimated_difficulty = 1
+	mob_path = /mob/living/simple_animal/hostile/abnormality/forsaken_murderer
+
+/datum/test_range_threat/breacher/redblooded
+	name = "Red-Blooded American"
+	battle_guide = "A TETH-class Abnormality which is a hybrid melee-ranged fighter, using a shotgun as its weapon to deal RED damage. Fragile as far as Abnormalities go, but has a high damage output for its threat class.\n\n\
+	It must reload after firing six shells, but it is not a particularly long reload. It is usually best to try to burst it down quickly with WHITE damage."
+	origin = ORIGIN_LC13
+	origin_detailed = D_ORIGIN_ABNORMALITY
+	estimated_difficulty = 2
+	mob_path = /mob/living/simple_animal/hostile/abnormality/redblooded
+
+/datum/test_range_threat/breacher/pinocchio
+	name = "Pinocchio"
+	battle_guide = "A HE-class Abnormality which behaves much more like a Murder-insane Agent than an Abnormality or Ordeal. It has a relatively strong WHITE damage weapon, but can swap it out for other, more powerful weapons. \n\n\
+	It is immune to stuns, does not slow down from taking damage, and cannot be made to drop its weapon. Despite its meager health pool, it has wiped many facilities due to its ability to make use of powerful E.G.O. gear, and access to regenerators to replenish itself. \n\n\
+	Use RED damage, favour ranged weapons, and begin to flee earlier than you usually would when you get low on health - if you become slowed from your injuries, you will be unable to escape Pinocchio."
+	origin = ORIGIN_LC13
+	origin_detailed = D_ORIGIN_ABNORMALITY
+	estimated_difficulty = 3
+	mob_path = /mob/living/simple_animal/hostile/abnormality/pinocchio
+
+/datum/test_range_threat/funeral
+	name = "Funeral of the Dead Butterflies"
+	battle_guide = "A HE-class Abnormality with unconventional attack patterns. It deals WHITE damage, but will instantly kill anyone insaned by it. \n\n\
+	Able to attack with 'finger-guns' which can only be avoided by breaking line-of-sight, or with a coffin which creates a large, lingering, rectangular area of periodic damage in front of it. \n\n\
+	Relatively fragile against WHITE and PALE damage - higher level Agents can easily face-tank its attacks, but it is good practice for all Agents to fight Funeral near walls that can help you avoid its finger-guns."
+	origin = ORIGIN_LC13
+	origin_detailed = D_ORIGIN_ABNORMALITY
+	estimated_difficulty = 2
+	mob_path = /mob/living/simple_animal/hostile/abnormality/funeral
+
+/datum/test_range_threat/breacher/scarecrow
+	name = "Scarecrow Searching for Wisdom"
+	battle_guide = "A HE-class Abnormality that is able to replenish itself from its victims. Deals BLACK damage, and moves and attacks decently quick. It is not a substantial threat unless it is accompanied by other 'Oz' Abnormalities."
+	origin = ORIGIN_LC13
+	origin_detailed = D_ORIGIN_ABNORMALITY
+	estimated_difficulty = 2
+	mob_path = /mob/living/simple_animal/hostile/abnormality/scarecrow
+
+/datum/test_range_threat/blue_shepherd
+	name = "Blue Smocked Shepherd"
+	battle_guide = "A HE-class Abnormality with the ability to occassionally attack in a large area. Deals steady BLACK damage. Being caught in its wide slash hurts badly, but it is not too much of a threat unless it is accompanied by Reddened Buddy."
+	origin = ORIGIN_LC13
+	origin_detailed = D_ORIGIN_ABNORMALITY
+	estimated_difficulty = 3
+	mob_path = /mob/living/simple_animal/hostile/abnormality/blue_shepherd
+
+/datum/test_range_threat/ebony_queen
+	name = "Ebony Queen's Apple"
+	battle_guide = "A WAW-class Abnormality that attacks via BLACK-damage roots and thorns. Unlike most Abnormalities, it is unable to deal 'guaranteed' damage - all its attacks are dodgeable. \n\n\
+	Stay on the move and avoid using self-stunning weapons. It is weak to WHITE damage, and immune to BLACK damage."
+	origin = ORIGIN_LC13
+	origin_detailed = D_ORIGIN_ABNORMALITY
+	estimated_difficulty = 3
+	mob_path = /mob/living/simple_animal/hostile/abnormality/ebony_queen
+
+/datum/test_range_threat/breacher/judgement_bird
+	name = "Judgement Bird"
+	battle_guide = "A WAW-class Abnormality with only one attack - a periodic PALE pulse of damage. It has decently high health, but generally weak resistances, and is especially weak to PALE. \n\n\
+	The main threat this Abnormality poses are the Runaway Crows that it spawns. It spawns two when it first breaches, and one on every kill it scores (even on non-human mobs). \n\n\
+	These crows are pathetic in terms of health, and have low PALE damage, but they knock down their target on each hit, which causes Agents to drop their weapons. This makes them extremely dangerous - ranged weapons are their main counter."
+	origin = ORIGIN_LC13
+	origin_detailed = D_ORIGIN_ABNORMALITY
+	estimated_difficulty = 3
+	mob_path = /mob/living/simple_animal/hostile/abnormality/judgement_bird
+	max_spawns = 3 // You're not Him you can't kill 50 runaway crows unless you frame 1 AoE them
+
+/datum/test_range_threat/warden
+	name = "The Warden"
+	battle_guide = "A WAW-class Abnormality that consumes its victims' souls, becoming faster but dealing less damage overall (only its lower bound lowers - it can still 'crit', in a sense). \n\n\
+	Notably, it is immune to projectiles. It is tanky, and deals BLACK damage, but otherwise unremarkable until it is well-fed. WHITE and PALE damage are strong, and if it is too fast to run away from, you should consider shields."
+	origin = ORIGIN_LC13
+	origin_detailed = D_ORIGIN_ABNORMALITY
+	estimated_difficulty = 3
+	mob_path = /mob/living/simple_animal/hostile/abnormality/warden
+	tuning_name = "Souls"
+	tuning_limit = 4
+
+// Has non-combat-map-tuning.
+/datum/test_range_threat/warden/PostSpawn(mob/living/just_spawned, tuning)
+	. = ..()
+	var/mob/living/simple_animal/hostile/abnormality/warden/our_gal = just_spawned
+	var/souls_we_should_have = clamp(tuning, tuning_min, tuning_limit)
+	if(souls_we_should_have && souls_we_should_have > 0)
+		for(var/i in 1 to souls_we_should_have)
+			if(our_gal.move_to_delay > 1)
+				our_gal.ChangeMoveToDelayBy(0.75, TRUE)
+				if(our_gal.melee_damage_lower > 30)
+					our_gal.melee_damage_lower -= our_gal.damage_down
+
+/datum/test_range_threat/nothing_there
+	name = "Nothing There"
+	battle_guide = "An ALEPH-class Abnormality that evolves if not suppressed quickly, progressing from Phase 1 to an eventual Phase 3. In all its phases, it deals RED damage, and is weakest to PALE. \n\n\
+	Its first phase is a simple, quadrupedal form that is only able to perform melee autoattacks. This is when the Abnormality is at its most vulnerable, but after 30-40 seconds, it will fully heal and move to Phase 2. \n\n\
+	Phase 2 is an immobile ovoid form. It cannot attack, and becomes invulnerable to RED damage. After 10-25 seconds, it fully heals and moves to Phase 3. \n\n\
+	Phase 3 is a bipedal form that has high resistances all around, including invulnerability to RED damage. It gains two attacks - 'Hello' and 'Goodbye', and will also regenerate if not in active combat. \n\n\
+	'Hello' is a frequently-used ranged line AoE attack. It is telegraphed by Nothing There kneeling. The windup for this attack is extremely short to the point of being unreactable if you are far from it, but if you are at point-blank range, it is more forgiving. \n\n\
+	It is unlikely that you can dodge it if you are not constantly on the move, and it is able to hit around corners. \n\n\
+	'Goodbye' is used less frequently, and is telegraphed by Nothing There transforming its arm into a scythe. The windup for this attack is generous, and the AoE of the attack hits a square of radius 2 from Nothing There's position. \n\n\
+	It is nearly guaranteed to kill anyone without heavy RED resistance, so avoid being hit at all."
+	origin = ORIGIN_LC13
+	origin_detailed = D_ORIGIN_ABNORMALITY
+	estimated_difficulty = 4
+	mob_path = /mob/living/simple_animal/hostile/abnormality/nothing_there
+	tuning_name = "Phase"
+	tuning_min = 1
+	tuning_limit = 3
+
+/datum/test_range_threat/nothing_there/PostSpawn(mob/living/just_spawned, tuning = 0)
+	. = ..()
+	var/mob/living/simple_animal/hostile/abnormality/nothing_there/meat_puppy = just_spawned
+	var/phase_we_want = clamp(tuning, tuning_min, tuning_limit)
+	switch(phase_we_want)
+		if(3)
+			meat_puppy.current_stage = 2
+			meat_puppy.next_stage()
+		if(2)
+			meat_puppy.current_stage = 1
+			meat_puppy.next_stage()
+		else
+			meat_puppy.next_transform = world.time + rand(30 SECONDS, 40 SECONDS)
+
+/datum/test_range_threat/silentorchestra
+	name = "The Silent Orchestra"
+	battle_guide = "An ALEPH-class Abnormality which deals periodic WHITE damage as it progresses through its Movements. It is unable to move or attack conventionally. \n\n\
+	Its resistances change as it performs; first, it is immune to all but PALE damage, then to all but BLACK, then WHITE, then RED, and then it becomes invunlerable. \n\n\
+	At the end of its performance, it will execute anyone in range who is below 50% of their max Sanity. \n\n\
+	As far as ALEPHs go, it is a pushover, so long as you have at least two types of damage and can locate it quickly enough."
+	origin = ORIGIN_LC13
+	origin_detailed = D_ORIGIN_ABNORMALITY
+	estimated_difficulty = 2
+	mob_path = /mob/living/simple_animal/hostile/abnormality/silentorchestra
+
+/datum/test_range_threat/last_shot
+	name = "Til the Last Shot"
+	battle_guide = "An ALEPH-class Abnormality which does not move or attack conventionally. Instead, it spreads meat vines and barricades to impede any attempt to reach it, and summons meat soldiers to fight for it. \n\n\
+	Meat soldiers use distinct weaponry - assault rifles that fire in bursts, shotguns that fire a spread of bullets, and snipers that fire powerful, telegraphed shots. They all deal RED damage, and both the soldiers and core are weak to BLACK and fatal to PALE. \n\n\
+	Wide AoE weaponry is effective against the soldiers, but it is generally best to rush down and kill the vulnerable core of the Abnormality, which will banish all of its influence. Reach weaponry saves time on destroying the final layer of barricades."
+	origin = ORIGIN_LC13
+	origin_detailed = D_ORIGIN_ABNORMALITY
+	estimated_difficulty = 3
+	mob_path = /mob/living/simple_animal/hostile/abnormality/last_shot
+
+/datum/test_range_threat/distortedform
+	name = "Distorted Form"
+	battle_guide = "Often considered by Agents as a Super-ALEPH or ALEPH+ Abnormality. Extremely high health. It cycles through many different other Abnormalities as it fights, shapeshifting into them and using their attacks and resistances. \n\n\
+	Attempting to leave vision range of Distorted Form will result in it using Ranged Abnormalities, including the ability to breach more Abnormalities in its Siren form. \n\n\
+	It also has access to transform into enemies that cannot be fought elsewhere - its 'Halberd Apostle' is a combination of White Night's Spear and Guardian apostles, for example, and it can also transform into a special version of Bloodbath or Price of Silence. \n\n\
+	If Distorted Form is engaging multiple targets, it unlocks new attacks in its normal form; a 'spread' attack that places blue markers on all of its targets, and a 'stack' attack that paralyzes a single target and places a large white marker on them. \n\n\
+	When faced with the 'spread' attack, do not linger near other people; keep at least 2 tiles of distance from them until you see acid splash down on each of you. \n\n\
+	When faced with the 'stack' attack, find the paralyzed person and remain next to them until a beam crashes down on you. If taking the beam alone, it will instantly kill you with high PALE damage, but when it is shared, it deals trivial amounts of damage."
+	origin = ORIGIN_LC13
+	origin_detailed = D_ORIGIN_ABNORMALITY
+	estimated_difficulty = 5
+	mob_path = /mob/living/simple_animal/hostile/abnormality/distortedform
+
+
+#undef ORIGIN_LC13
+#undef ORIGIN_B12
+#undef ORIGIN_COL
+#undef ORIGIN_RCE
+#undef ORIGIN_JOKE
+
+#undef D_ORIGIN_ABNORMALITY
+#undef D_ORIGIN_ORDEAL
+#undef D_ORIGIN_QUEST
+#undef D_ORIGIN_COMBATPAGE

--- a/code/datums/test_range_threats.dm
+++ b/code/datums/test_range_threats.dm
@@ -77,7 +77,7 @@
 	currently_spawned |= our_guy
 	SStestrange.test_range_living_threats |= our_guy
 	RegisterSignal(our_guy, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING), PROC_REF(OnDeath))
-	RegisterSignal(our_guy, COMSIG_AREA_ENTERED, PROC_REF(AreaCheck))
+	RegisterSignal(our_guy, COMSIG_ENTER_AREA, PROC_REF(AreaCheck))
 
 	// Disable core drops for any Abnormality that spawns.
 	if(isabnormalitymob(our_guy))
@@ -99,7 +99,7 @@
 
 /datum/test_range_threat/proc/OnDeath(mob/living/ded)
 	SIGNAL_HANDLER
-	UnregisterSignal(ded, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING, COMSIG_AREA_ENTERED))
+	UnregisterSignal(ded, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING, COMSIG_ENTER_AREA))
 	currently_spawned -= ded
 	SStestrange.test_range_living_threats -= ded
 

--- a/code/game/area/areas/lobotomy_corp.dm
+++ b/code/game/area/areas/lobotomy_corp.dm
@@ -505,12 +505,32 @@
 	sound_environment = SOUND_ENVIRONMENT_CAVE
 	dynamic_lighting = DYNAMIC_LIGHTING_FORCED
 
-/area/test_range
-	name = "Test Range"
+/area/test_range_arena
+	name = "Test Range Arena - Undefined"
 	requires_power = FALSE
 	has_gravity = STANDARD_GRAVITY
 	sound_environment = SOUND_ENVIRONMENT_CAVE
-	dynamic_lighting = DYNAMIC_LIGHTING_FORCED
+	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
+
+/area/test_range_arena/proc/GetArenaName()
+	var/sliced_text = splicetext_char(name, 1, 20, "")
+	return sliced_text
+
+/area/test_range_arena/classic
+	name = "Test Range Arena - Classic"
+
+/area/test_range_arena/battlefield
+	name = "Test Range Arena - Battlefield"
+
+/area/test_range_arena/ouroboros
+	name = "Test Range Arena - Ouroboros"
+
+/area/test_range_lobby
+	name = "Test Range Lobby"
+	requires_power = FALSE
+	has_gravity = STANDARD_GRAVITY
+	sound_environment = SOUND_ENVIRONMENT_CAVE
+	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
 
 /area/tinkerer_factory
 	name = "Tinkerer's Factory"

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -1069,6 +1069,16 @@
 
 	back = /obj/item/storage/backpack
 
+/// Copies our character prefs to our Test Range agent.
+// Sloppy way to do it, but we can't do this in an equip override, since it doesn't allow us to access the client at that point.
+/obj/effect/mob_spawn/human/testrange/create(ckey, newname)
+	. = ..()
+	var/mob/H = get_mob_by_ckey(ckey)
+	if(!H || !H.client || !H.client.prefs)
+		return
+	var/datum/preferences/prefs = H.client.prefs
+	prefs.copy_to(H, roundstart_checks = FALSE)
+
 //Supplypod Mobspawner
 /obj/effect/mob_spawn/human/supplypod
 	invisibility = 49

--- a/code/game/objects/structures/test_range.dm
+++ b/code/game/objects/structures/test_range.dm
@@ -365,7 +365,7 @@
 		var/datum/test_range_threat/found_datum = locate(chosen_threat) in SStestrange.test_range_threat_datums
 		if(found_datum && istype(found_datum))
 			SpawnThreat(found_datum, SStestrange.test_range_arenas[current_arena], tuning)
-		return TRUE
+		return FALSE
 
 	if(action == "change_camera")
 		var/chosen_arena = params["arena"]

--- a/code/game/objects/structures/test_range.dm
+++ b/code/game/objects/structures/test_range.dm
@@ -205,43 +205,464 @@
 		return
 	DispenseEgo(user, chosen_ego)
 
-//Abnormality Spawner
+/*
+* ABNORMALITY SPAWNER
+*
+*
+*
+*/
 /obj/machinery/computer/testrangespawner
-	name = "Abnormality Spawner"
-	desc = "This device is used to spawn an abnormality to fight"
+	name = "Threat Simulator"
+	desc = "This device is used to spawn hostiles to fight against."
 	resistance_flags = INDESTRUCTIBLE
-	var/list/whitelist = list(
-		/mob/living/simple_animal/hostile/abnormality/forsaken_murderer,
-		/mob/living/simple_animal/hostile/abnormality/redblooded,
-		/mob/living/simple_animal/hostile/abnormality/pinocchio,
-		/mob/living/simple_animal/hostile/abnormality/funeral,
-		/mob/living/simple_animal/hostile/abnormality/scarecrow,
-		/mob/living/simple_animal/hostile/abnormality/blue_shepherd,
-		/mob/living/simple_animal/hostile/abnormality/ebony_queen,
-		/mob/living/simple_animal/hostile/abnormality/judgement_bird,
-		/mob/living/simple_animal/hostile/abnormality/warden,
-		/mob/living/simple_animal/hostile/abnormality/nothing_there,
-		/mob/living/simple_animal/hostile/abnormality/silentorchestra,
-		/mob/living/simple_animal/hostile/abnormality/last_shot,
-		/mob/living/simple_animal/hostile/abnormality/distortedform,
+	// Holds the string corresponding to the arena we're currently using. Randomly set by SStestrange on its Initialize.
+	var/current_arena
+	var/arena_change_cooldown_duration = 5 SECONDS
+	var/arena_change_cooldown
+
+	// Camera implementation studied and 'borrowed' from CentcomPodLauncher and CameraConsole.
+	// Stuff needed to render the map
+	var/map_name
+	var/atom/movable/screen/map_view/cam_screen
+	/// All the plane masters that need to be applied.
+	var/list/cam_plane_masters
+	var/atom/movable/screen/background/cam_background
+	var/camera_range = 15
+
+/obj/machinery/computer/testrangespawner/Initialize(mapload)
+	. = ..()
+	SStestrange.linked_threat_simulators += src // Important: This happens before SStestrange initializes, at least for the instances of this type already on the map.
+
+// Tell the players to shove off if we're not done initializing yet
+/obj/machinery/computer/testrangespawner/proc/CheckInitializedDatums(mob/living/user)
+	if(SStestrange.threat_datums_initializing || !(SStestrange.threat_datums_initialized))
+		var/not_ready_message = "System is still initializing. Please wait. [SStestrange.test_range_threat_datums ? length(SStestrange.test_range_threat_datums) : "0"] threats currently loaded."
+		if(istype(user) && user.stat < DEAD)
+			say(not_ready_message)
+			playsound(get_turf(src), 'sound/machines/synth_no.ogg', 40, TRUE)
+		else
+			to_chat(user, span_warning(not_ready_message))
+		return FALSE
+	return TRUE
+
+// Sets up camera feed to the arena.
+/obj/machinery/computer/testrangespawner/proc/InitializeCamera()
+	map_name = "testrangespawner_[REF(src)]_map"
+
+	cam_screen = new
+	cam_screen.name = "screen"
+	cam_screen.assigned_map = map_name
+	cam_screen.del_on_map_removal = FALSE
+	cam_screen.screen_loc = "[map_name]:1,1"
+	cam_plane_masters = list()
+
+	for(var/plane in subtypesof(/atom/movable/screen/plane_master))
+		var/atom/movable/screen/instance = new plane()
+		instance.assigned_map = map_name
+		instance.del_on_map_removal = FALSE
+		instance.screen_loc = "[map_name]:CENTER"
+		cam_plane_masters += instance
+
+	cam_background = new
+	cam_background.assigned_map = map_name
+	cam_background.del_on_map_removal = FALSE
+
+	UpdateCameraView()
+
+// Called every time we need to update our arena camfeed.
+/obj/machinery/computer/testrangespawner/proc/UpdateCameraView()
+	var/list/visible_turfs = list()
+
+	var/obj/effect/landmark/test_range_arena/landmark_thingy = SStestrange.test_range_arenas[current_arena]
+	var/turf/camera_center = get_turf(landmark_thingy)
+	var/x_offset = landmark_thingy.camera_offset["x"]
+	var/y_offset = landmark_thingy.camera_offset["y"]
+	camera_center = locate((camera_center.x + x_offset), (camera_center.y + y_offset), (camera_center.z))
+
+	var/list/visible_things = range(camera_range, camera_center)
+
+	for(var/turf/visible_turf in visible_things)
+		visible_turfs += visible_turf
+
+	var/list/bbox = get_bbox_of_atoms(visible_turfs)
+	var/size_x = bbox[3] - bbox[1] + 1
+	var/size_y = bbox[4] - bbox[2] + 1
+
+	cam_screen.vis_contents = visible_turfs
+	cam_background.icon_state = "clear"
+	cam_background.fill_rect(1, 1, size_x, size_y)
+
+/obj/machinery/computer/testrangespawner/ui_interact(mob/user, datum/tgui/ui)
+	if(!CheckInitializedDatums(user))
+		return
+
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		user.client.register_map_obj(cam_screen)
+		for(var/plane in cam_plane_masters)
+			user.client.register_map_obj(plane)
+		user.client.register_map_obj(cam_background)
+
+		ui = new(user, src, "TestRangeThreatSimulator", "Threat Simulator")
+		ui.set_autoupdate(FALSE)
+		ui.open()
+
+// Dynamic data sent to TGUI.
+/obj/machinery/computer/testrangespawner/ui_data(mob/user)
+	var/list/data = list()
+	data["threats"] = list() // The only reason this is dynamic is because current_spawns can change. In theory I can probably find a way to separate it, and make this static data?
+	data["current_arena"] = current_arena
+
+	for(var/datum/test_range_threat/TD in SStestrange.test_range_threat_datums)
+		var/list/datum_data = list(
+			"name" = TD.name,
+			"icon" = SStestrange.GenerateThreatPreviewIcon(TD), // This is cached
+			"desc" = TD.desc,
+			"origin" = TD.origin,
+			"origin_detailed" = TD.origin_detailed,
+			"battle_guide" = TD.battle_guide,
+			"difficulty" = TD.estimated_difficulty,
+			"mob_path" = TD.mob_path,
+			"current_spawns" = length(TD.currently_spawned),
+			"max_spawns" = TD.max_spawns,
+			"tuning_name" = TD.tuning_name,
+			"tuning_min" = TD.tuning_min,
+			"tuning_limit" = TD.tuning_limit,
+			"reference" = REF(TD)
+			)
+
+		data["threats"] += list(datum_data)
+	return data
+
+// Unchanging data sent to TGUI. I mean, they CAN change if admins mess with them, but they really shouldn't
+/obj/machinery/computer/testrangespawner/ui_static_data(mob/user)
+	var/list/data = list()
+	data["map_ref"] = map_name
+	data["arenas"] = list()
+	for(var/A in SStestrange.test_range_arenas)
+		data["arenas"] += A
+
+	return data
+
+/obj/machinery/computer/testrangespawner/proc/ArenaChangeReady()
+	if(arena_change_cooldown > world.time)
+		to_chat(usr, span_danger("Arena switching is on cooldown. Wait a few seconds and try again."))
+		playsound(get_turf(src), 'sound/machines/synth_no.ogg', 40, TRUE)
+		return FALSE
+
+	return TRUE
+
+/obj/machinery/computer/testrangespawner/ui_act(action, list/params)
+	. = ..()
+	if(.)
+		return
+
+	var/mob/living/user = usr
+
+	if(action == "spawn_threat")
+		var/chosen_threat = params["chosen_threat"]
+		var/tuning = params["tuning"]
+		var/datum/test_range_threat/found_datum = locate(chosen_threat) in SStestrange.test_range_threat_datums
+		if(found_datum && istype(found_datum))
+			SpawnThreat(found_datum, SStestrange.test_range_arenas[current_arena], tuning)
+		return TRUE
+
+	if(action == "change_camera")
+		var/chosen_arena = params["arena"]
+		if(!chosen_arena)
+			return FALSE
+		var/obj/effect/landmark/test_range_arena/TRA = SStestrange.test_range_arenas[chosen_arena]
+		if(!TRA)
+			return FALSE
+
+		if(!ArenaChangeReady())
+			return FALSE
+		current_arena = chosen_arena
+
+
+		var/obj/machinery/quantumpad/warp/lobby_pad = SStestrange.test_range_telepads["lobby"]
+		lobby_pad.linked_pad = SStestrange.test_range_telepads[current_arena]
+
+		arena_change_cooldown = arena_change_cooldown_duration + world.time
+
+		UpdateCameraView()
+		return TRUE
+
+	if(action == "despawn_one")
+		var/chosen_threat = params["chosen_threat"]
+		var/datum/test_range_threat/found_datum = locate(chosen_threat) in SStestrange.test_range_threat_datums
+		if(found_datum && istype(found_datum))
+			if(found_datum.DespawnOne())
+				say("[user] ([user.ckey]) despawned 1 instance of [most_perilous_challenge.name].")
+				playsound(get_turf(src), 'sound/machines/terminal_success.ogg', 40, FALSE)
+			else
+				say("Error: there are no instances of [most_perilous_challenge.name] to despawn.")
+				playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 40, FALSE)
+		return TRUE
+
+	if(action == "despawn_all") // Refers to despawning all of a certain type of threat, not all threats ever spawned by this machine.
+		var/chosen_threat = params["chosen_threat"]
+		var/datum/test_range_threat/found_datum = locate(chosen_threat) in SStestrange.test_range_threat_datums
+		if(found_datum && istype(found_datum))
+			found_datum.DespawnAll()
+			say("[user] ([user.ckey]) despawned ALL [most_perilous_challenge.name] instances.")
+			playsound(get_turf(src), 'sound/machines/triple_beep.ogg', 40, FALSE)
+		return TRUE
+
+// Most logic for actual spawning of threats is handled in test_range_threat's procs.
+/obj/machinery/computer/testrangespawner/proc/SpawnThreat(datum/test_range_threat/most_perilous_challenge, obj/effect/landmark/test_range_arena/arena, list/tuning)
+	if(!istype(most_perilous_challenge) || !istype(arena))
+		return
+	var/turf/T = get_turf(arena)
+
+	if(most_perilous_challenge.Start(T, tuning))
+		say("[user] ([user.ckey]) spawned [most_perilous_challenge.name] in the [arena.arena_name] Arena.")
+		// Maybe add logging for this? Not sure
+		playsound(get_turf(src), 'sound/machines/terminal_success.ogg', 40, FALSE)
+	else
+		say("Failed to spawn [most_perilous_challenge.name]!")
+		playsound(get_turf(src), 'sound/machines/triple_beep.ogg', 40, FALSE)
+
+
+/*
+* TEST RANGE SLEEPER (SPAWN POINT)
+* This thing is actually defined in \code\game\objects\structures\ghost_role_spawners.dm
+* We just need to override the spawning process to add a few signals to our test range agents.
+* Also a couple signal handler procs.
+*/
+
+/obj/effect/mob_spawn/human/testrange/equip(mob/living/carbon/human/H)
+	. = ..()
+	SStestrange.test_range_agents |= H
+	RegisterSignal(H, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING), PROC_REF(ProcessAgentDeath))
+	RegisterSignal(H, COMSIG_HUMAN_INSANE, PROC_REF(MurderInsanityProtection)) // We don't want fort insanes in the lobby
+
+// Might as well put the signal handler procs here for clarity.
+/obj/effect/mob_spawn/human/testrange/proc/ProcessAgentDeath(mob/living/carbon/human/dead_test_range_agent)
+	SIGNAL_HANDLER
+	UnregisterSignal(dead_test_range_agent, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING, COMSIG_HUMAN_INSANE))
+	SStestrange.test_range_agents -= dead_test_range_agent
+	SStestrange.CleanupCheck() // Check to see if this was the last living Test Range Agent.
+
+// When someone goes insane, if they go murder insane/jekyll insane, check their area. If it's the lobby, kill them instantly. If it's not, add a signal that checks for them changing area, and then kill them if they enter the lobby.
+/obj/effect/mob_spawn/human/testrange/proc/MurderInsanityProtection(mob/living/carbon/human/insane_agent, attribute)
+	SIGNAL_HANDLER
+	if(!(attribute == FORTITUDE_ATTRIBUTE || (insane_agent.has_status_effect(/datum/status_effect/display/hyde)) || (insane_agent.has_status_effect(/datum/status_effect/display/dr_jekyll))))
+		return
+	var/area/agent_area = get_area(insane_agent)
+	if(!istype(agent_area, /area/test_range_arena))
+		QDEL_NULL(insane_agent.ai_controller)
+		SStestrange.Despawn(insane_agent)
+	else
+		RegisterSignal(insane_agent, COMSIG_AREA_ENTERED, PROC_REF(AreaCheck))
+
+// Kills the insane person we're listening to if they enter the test range lobby.
+/obj/effect/mob_spawn/human/testrange/proc/AreaCheck(mob/living/soon_to_be_ded, area/entered_area)
+	SIGNAL_HANDLER
+	if(istype(entered_area, /area/test_range_arena))
+		return
+	QDEL_NULL(soon_to_be_ded.ai_controller)
+	SStestrange.Despawn(soon_to_be_ded)
+
+/*
+* TEST RANGE LANDMARK (SPAWN POINT)
+* Supplies the name for the arena, as well as the camera viewpoint and the mob spawn location.
+*
+*
+*/
+
+/obj/effect/landmark/test_range_arena
+	name = "Test Range Arena"
+	var/arena_name = "Placeholder Arena Name"
+	var/camera_offset = list("x" = 0, "y" = 0)
+
+/obj/effect/landmark/test_range_arena/Initialize(mapload)
+	. = ..()
+	SStestrange.test_range_arenas[arena_name] = src
+
+/*
+* TEST RANGE CLEANER (BUTTON)
+* Spawns a /obj/effect/test_range_cleaner to sweep up garbage in the lobby/arenas.
+*
+*
+*/
+/obj/machinery/button/indestructible/test_range_cleanup
+	name = "Test Range Cleaner"
+	desc = "A small button labeled \"cl e a n\". You suppose it will clean the room. \n\
+	Alt-click to disable animation."
+	var/cooldown
+	var/cooldown_duration = 15 SECONDS
+	var/fancy = TRUE
+	var/cleaning_radius = 20
+
+/obj/machinery/button/indestructible/test_range_cleanup/AltClick(mob/user)
+	. = ..()
+	fancy = !fancy
+	to_chat(user, fancy ? span_notice("[src] will now play an animation.") : span_notice("[src] will no longer play an animation."))
+
+/obj/machinery/button/indestructible/test_range_cleanup/attack_hand(mob/user)
+	if(cooldown > world.time)
+		to_chat(user, span_danger("The Janitor is resting. Wait a moment and try again."))
+		return
+	. = ..()
+	cooldown = cooldown_duration + world.time
+	new /obj/effect/test_range_cleaner(get_turf(user), fancy, cleaning_radius, TRUE)
+
+/*
+* TEST RANGE SLEEPER (EFFECT)
+* Can actually be spawned independently if you want.
+* Will delete EVERYTHING that matches one of things_to_remove in the area&radius it spawns in.
+* Also deletes dead living mobs.
+*/
+/obj/effect/test_range_cleaner
+	name = "The Janitor"
+	desc = "!!!! OVERWHELMED !!!!"
+	icon = 'icons/mob/aibots.dmi'
+	icon_state = "cleanbot0"
+	alpha = 0
+	pixel_z = 256
+	movement_type = PHASING | FLYING
+	var/area/area_to_clean
+	var/list/turfs_to_check = list()
+	var/radius = 20
+	var/list/things_to_remove = list(
+		/obj/effect/decal/cleanable,
+		/obj/item/bodypart,
+		/obj/item/organ,
+		/obj/item/ego_weapon,
+		/obj/item/clothing,
+		/obj/item/storage/backpack,
+		/obj/item/card,
+		/obj/item/radio,
+		/obj/item/pda,
+		/obj/item/stack/thumb_east_ammo,
+		/obj/item/ammo_casing,
+		/obj/structure/abno_core,
+		/obj/structure/meatfloor,
+		/obj/structure/barricade/meatbags,
+		/obj/item/food/meat/slab,
 	)
 
-/obj/machinery/computer/testrangespawner/attack_hand(mob/living/user)
+/obj/effect/test_range_cleaner/Initialize(mapload, fancy = TRUE, radius_override, being_used_in_test_range = FALSE)
 	. = ..()
-	var/arena_z = z + 3
-	var/mob/living/simple_animal/hostile/abnormality/chosen_abno = tgui_input_list(user,"Choose which Abnormality to fight.","Select Abnormality", whitelist)
-	var/turf/location = locate(13,14,arena_z) //Might not be the best way to set it up right now but it works.
-	if(chosen_abno)
-		var/mob/living/simple_animal/hostile/abnormality/abnospawned = new chosen_abno(location)
-		abnospawned.core_enabled = FALSE
-		if(istype(abnospawned, /mob/living/simple_animal/hostile/abnormality/pinocchio)) //To check if BreachEffect() is needed for the abno to work properly
-			abnospawned.BreachEffect()
+	if(radius_override && radius_override > 0)
+		src.radius = radius_override
 
-/obj/machinery/computer/testrangespawner/process()
-	var/area/A = get_area(src) // cataclysmic world iteration, remove when reworking this (if you iterate over an area you are iterating over the entire world)
-	for(var/mob/living/carbon/human/H in A)
-		if(H.stat != DEAD)
-			return
-	for(var/mob/M in A)
-		if(M.stat != DEAD)
-			qdel(M)
+	var/turf/own_turf = get_turf(src)
+	if(!own_turf)
+		qdel(src)
+		return
+
+	area_to_clean = get_area(own_turf)
+	if(!area_to_clean)
+		qdel(src)
+		return
+
+	for(var/turf/T in RANGE_TURFS(radius, own_turf))
+		if(!(get_area(T) == area_to_clean))
+			continue
+		turfs_to_check |= T
+
+	// Play an animation if 'fancy' is TRUE.
+	if(fancy)
+		transform *= 2
+		playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 50, TRUE)
+		RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(MovementEffect))
+		animate(src, time = 1.2 SECONDS, alpha = 255, pixel_z = 0, easing = QUAD_EASING)
+		addtimer(CALLBACK(src, PROC_REF(DoCleaningAnimation)), 1.6 SECONDS)
+	// Or just instantly clean things around us.
+	else
+		ActuallyClean()
+
+/obj/effect/test_range_cleaner/Destroy(force)
+	area_to_clean = null
+	turfs_to_check = null
+	things_to_remove = null
+	return ..()
+
+// Entirely scripted animation. Will early cancel and just do a fast cleanup if we're using this somewhere weird that would cause an error.
+/obj/effect/test_range_cleaner/proc/DoCleaningAnimation()
+	var/turf/T1 = get_ranged_target_turf(src, SOUTHWEST, radius*0.4)
+	if(!T1)
+		ActuallyClean()
+		return
+	var/turf/T2 = get_ranged_target_turf(T1, EAST, radius*0.5)
+	if(!T2)
+		ActuallyClean()
+		return
+	var/turf/T3 = get_ranged_target_turf(T2, NORTHWEST, radius*0.4)
+	if(!T3)
+		ActuallyClean()
+		return
+	var/turf/T4 = get_ranged_target_turf(T3, NORTHEAST, radius*0.3)
+	if(!T4)
+		ActuallyClean()
+		return
+	var/turf/T5 = get_ranged_target_turf(T4, SOUTH, radius*0.8)
+	if(!T5)
+		ActuallyClean()
+		return
+
+	setDir(SOUTHWEST)
+	walk_towards(src, T1, 0)
+	sleep(5)
+	setDir(EAST)
+	walk_towards(src, T2, 0)
+	sleep(6)
+	setDir(NORTHWEST)
+	walk_towards(src, T3, 0)
+	sleep(5)
+	setDir(NORTHEAST)
+	walk_towards(src, T4, 0)
+	sleep(4)
+	setDir(SOUTH)
+	walk_towards(src, T5, 0)
+	sleep(13)
+	walk(src, 0)
+	animate(src, time = 1.2 SECONDS, pixel_z = 256, alpha = 0)
+
+	UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
+	addtimer(CALLBACK(src, PROC_REF(ActuallyClean)), 0.2 SECONDS)
+
+// Actually takes care of removing anything found in turfs_to_check that has a type which is included in the things_to_remove list.
+/obj/effect/test_range_cleaner/proc/ActuallyClean()
+	for(var/turf/T in turfs_to_check)
+		for(var/atom/thing in T)
+			if(isliving(thing))
+				var/mob/living/this_is_a_mob = thing
+				if(this_is_a_mob.stat >= DEAD)
+					qdel(this_is_a_mob)
+					continue
+			for(var/type_of_thing in things_to_remove)
+				if(istype(thing, type_of_thing))
+					qdel(thing)
+					break
+
+	qdel(src)
+
+// Funny little effects for when the animation happens.
+/obj/effect/test_range_cleaner/proc/MovementEffect(datum/source, OldLoc, Dir, Forced)
+	SIGNAL_HANDLER
+	var/obj/effect/test_range_cleaner/owner = source
+	if(!istype(owner))
+		return
+	var/obj/effect/temp_visual/decoy/D = new /obj/effect/temp_visual/decoy(OldLoc, owner)
+	D.alpha = 190
+	animate(D, alpha = 0, time = 5)
+	for(var/turf/T in RANGE_TURFS(1, owner))
+		new /obj/effect/temp_visual/dir_setting/slash(T, owner.dir)
+	playsound(get_turf(src), 'sound/weapons/fwoosh.ogg', 70, TRUE)
+
+/obj/effect/test_range_cleaner/Destroy(force)
+	UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
+	return ..()
+
+// If you wanna spawn one to clean up corpses, blood, gibs, limbs, but not potentially gameplay relevant items.
+/obj/effect/test_range_cleaner/bio_only
+	name = "The Janitor (Merciful)"
+	things_to_remove = list(
+		/obj/effect/decal/cleanable,
+		/obj/item/bodypart,
+		/obj/item/organ,
+		/obj/item/food/meat/slab,
+	)

--- a/code/game/objects/structures/test_range.dm
+++ b/code/game/objects/structures/test_range.dm
@@ -19,10 +19,8 @@
 	/// Holds ckeys that have disabled the new TGUI version of the interface.
 	var/list/disabled_tgui = list()
 	/// Anything in this list will be rejected if you try to shred it in the EGO printer.
-	var/static/blacklisted_shred_items = list(
-		/obj/item/lc_debug/attribute_injector,
-		/obj/item/scrying,
-	)
+	// As of Test Range Update 2, you can now print Attribute Injectors & Scrying Orbs, so there's nothing to put in this blacklist ATM
+	var/static/blacklisted_shred_items = list()
 
 /* ---------- Shared TGUI/Old EGO printer stuff ---------- */
 
@@ -296,6 +294,8 @@
 	if(!CheckInitializedDatums(user))
 		return
 
+	UpdateCameraView()
+
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		user.client.register_map_obj(cam_screen)
@@ -393,10 +393,10 @@
 		var/datum/test_range_threat/found_datum = locate(chosen_threat) in SStestrange.test_range_threat_datums
 		if(found_datum && istype(found_datum))
 			if(found_datum.DespawnOne())
-				say("[user] ([user.ckey]) despawned 1 instance of [most_perilous_challenge.name].")
+				say("[user] ([user.ckey]) despawned 1 instance of [found_datum.name].")
 				playsound(get_turf(src), 'sound/machines/terminal_success.ogg', 40, FALSE)
 			else
-				say("Error: there are no instances of [most_perilous_challenge.name] to despawn.")
+				say("Error: there are no instances of [found_datum.name] to despawn.")
 				playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 40, FALSE)
 		return TRUE
 
@@ -405,7 +405,7 @@
 		var/datum/test_range_threat/found_datum = locate(chosen_threat) in SStestrange.test_range_threat_datums
 		if(found_datum && istype(found_datum))
 			found_datum.DespawnAll()
-			say("[user] ([user.ckey]) despawned ALL [most_perilous_challenge.name] instances.")
+			say("[user] ([user.ckey]) despawned ALL [found_datum.name] instances.")
 			playsound(get_turf(src), 'sound/machines/triple_beep.ogg', 40, FALSE)
 		return TRUE
 
@@ -414,6 +414,7 @@
 	if(!istype(most_perilous_challenge) || !istype(arena))
 		return
 	var/turf/T = get_turf(arena)
+	var/mob/living/user = usr
 
 	if(most_perilous_challenge.Start(T, tuning))
 		say("[user] ([user.ckey]) spawned [most_perilous_challenge.name] in the [arena.arena_name] Arena.")
@@ -440,7 +441,7 @@
 // Might as well put the signal handler procs here for clarity.
 /obj/effect/mob_spawn/human/testrange/proc/ProcessAgentDeath(mob/living/carbon/human/dead_test_range_agent)
 	SIGNAL_HANDLER
-	UnregisterSignal(dead_test_range_agent, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING, COMSIG_HUMAN_INSANE))
+	UnregisterSignal(dead_test_range_agent, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING, COMSIG_HUMAN_INSANE, COMSIG_ENTER_AREA))
 	SStestrange.test_range_agents -= dead_test_range_agent
 	SStestrange.CleanupCheck() // Check to see if this was the last living Test Range Agent.
 
@@ -452,9 +453,9 @@
 	var/area/agent_area = get_area(insane_agent)
 	if(!istype(agent_area, /area/test_range_arena))
 		QDEL_NULL(insane_agent.ai_controller)
-		SStestrange.Despawn(insane_agent)
+		addtimer(CALLBACK(SStestrange, TYPE_PROC_REF(/datum/controller/subsystem/testrange, Despawn), insane_agent), rand(5, 10))
 	else
-		RegisterSignal(insane_agent, COMSIG_AREA_ENTERED, PROC_REF(AreaCheck))
+		RegisterSignal(insane_agent, COMSIG_ENTER_AREA, PROC_REF(AreaCheck))
 
 // Kills the insane person we're listening to if they enter the test range lobby.
 /obj/effect/mob_spawn/human/testrange/proc/AreaCheck(mob/living/soon_to_be_ded, area/entered_area)

--- a/code/game/objects/structures/test_range.dm
+++ b/code/game/objects/structures/test_range.dm
@@ -537,6 +537,7 @@
 		/obj/item/radio,
 		/obj/item/pda,
 		/obj/item/stack/thumb_east_ammo,
+		/obj/item/storage/box,
 		/obj/item/ammo_casing,
 		/obj/structure/abno_core,
 		/obj/structure/meatfloor,

--- a/code/modules/clothing/suits/ego_gear/non_abnormality/_cityarmor_datums.dm
+++ b/code/modules/clothing/suits/ego_gear/non_abnormality/_cityarmor_datums.dm
@@ -163,24 +163,41 @@ Association gear is mostly HE for grunts, low WAW for veterans and high WAW for 
 
 /* ------------------ 7 - Seven ------------------*/
 
-// | Seven South |
-/// Seven South Armour
-/datum/ego_datum/armor/city/seven_south
+// | Seven South Section 6: Old Gear|
+/// Seven South Section 6 Armour
+/datum/ego_datum/armor/city/seven_south_s6
 	item_path = /obj/item/clothing/suit/armor/ego_gear/city/seven
 	cost = 40
-/// Seven South Recon Armour
-/datum/ego_datum/armor/city/seven_south/recon
+/// Seven South Section 6 Recon Armour
+/datum/ego_datum/armor/city/seven_south_s6/recon
 	item_path = /obj/item/clothing/suit/armor/ego_gear/city/sevenrecon
-/// Seven South Veteran Armour
-/datum/ego_datum/armor/city/seven_south/vet
+/// Seven South Section 6 Veteran Armour
+/datum/ego_datum/armor/city/seven_south_s6/vet
 	item_path = /obj/item/clothing/suit/armor/ego_gear/city/sevenvet
 	cost = 60
-/// Seven South Intel Armour
-/datum/ego_datum/armor/city/seven_south/vet/intel
+/// Seven South Section 6 Intel Armour
+/datum/ego_datum/armor/city/seven_south_s6/vet/intel
 	item_path = /obj/item/clothing/suit/armor/ego_gear/city/sevenvet/intel
-/// Seven South Director Armour
-/datum/ego_datum/armor/city/seven_south/director
+/// Seven South Section 6 Director Armour
+/datum/ego_datum/armor/city/seven_south_s6/director
 	item_path = /obj/item/clothing/suit/armor/ego_gear/city/sevendirector
+	cost = 75
+
+// | Seven South Section 4: Reworked Gear|
+/// Seven South Section 4 Armour
+/datum/ego_datum/armor/city/seven_south_s4
+	item_path = /obj/item/clothing/suit/armor/ego_gear/city/seven_s4
+	cost = 40
+/// Seven South Section 4 Recon Armour
+/datum/ego_datum/armor/city/seven_south_s4/recon
+	item_path = /obj/item/clothing/suit/armor/ego_gear/city/seven_s4/recon
+/// Seven South Section 4 Veteran Armour
+/datum/ego_datum/armor/city/seven_south/vet
+	item_path = /obj/item/clothing/suit/armor/ego_gear/city/seven_s4/vet
+	cost = 60
+/// Seven South Section 4 Director Armour
+/datum/ego_datum/armor/city/seven_south/director
+	item_path = /obj/item/clothing/suit/armor/ego_gear/city/seven_s4/director
 	cost = 75
 
 /* ------------------ 9 - Devyat ------------------*/
@@ -196,10 +213,18 @@ Association gear is mostly HE for grunts, low WAW for veterans and high WAW for 
 
 /* ------------------ 10 - Dieci ------------------*/
 
-/// Dieci Veteran Gear
+/// Dieci Association Gear
 /datum/ego_datum/armor/city/dieci
 	item_path = /obj/item/clothing/suit/armor/ego_gear/city/dieci
+	cost = 40
+/// Dieci Association Veteran Gear
+/datum/ego_datum/armor/city/dieci/vet
+	item_path = /obj/item/clothing/suit/armor/ego_gear/city/dieci/vet
 	cost = 60
+/// Dieci Association Director Gear
+/datum/ego_datum/armor/city/dieci/director
+	item_path = /obj/item/clothing/suit/armor/ego_gear/city/dieci/director
+	cost = 75
 
 /*
 ------------------ Fixers & Workshops ------------------

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -57,6 +57,8 @@
 	var/list/misc = list()
 	var/list/npcs = list()
 	var/list/abnormalities = list() // LOBOTOMYCORPORATION ADDITION -- Abnormalities
+	var/list/testrange = list() // LOBOTOMYCORPORATION ADDITION -- Test Range Agents & Threats
+	var/list/testrange_comparison_list = SStestrange.test_range_living_threats + SStestrange.test_range_agents
 
 	var/list/pois = getpois(skip_mindless = TRUE, specify_dead_role = FALSE)
 	for (var/name in pois)
@@ -74,6 +76,9 @@
 				if (number_of_orbiters)
 					serialized["orbiters"] = number_of_orbiters
 				ghosts += list(serialized)
+
+			else if (M in testrange_comparison_list) // LOBOTOMYCORPORATION ADDITION -- Test Range Agents & Threats
+				testrange += list(serialized)
 
 			else if (isabnormalitymob(M)) // LOBOTOMYCORPORATION ADDITION -- Abnormalities
 				var/mob/living/simple_animal/hostile/abnormality/abno = M
@@ -116,6 +121,7 @@
 	data["ghosts"] = ghosts
 	data["misc"] = misc
 	data["npcs"] = npcs
+	data["testrange"] = testrange
 	return data
 
 /datum/orbit_menu/ui_assets()

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
@@ -355,7 +355,7 @@
 		if(survivor.stat == DEAD || !survivor.ckey)
 			continue
 		var/area_check = get_area(src)
-		if(istype(area_check, /area/test_range))
+		if(istype(area_check, /area/test_range_arena))
 			return ..()
 		survivor.Apply_Gift(new /datum/ego_gifts/fervor)
 		survivor.playsound_local(get_turf(survivor), 'sound/weapons/black_silence/snap.ogg', 50)

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/green/midnight.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/green/midnight.dm
@@ -64,7 +64,7 @@
 	/// This variable holds the last location of the Helix. It's so we can check if it has moved since the last time it fired its lasers and update target turfs if so.
 	var/entrenched_at
 
-/mob/living/simple_animal/hostile/ordeal/green_midnight/Initialize()
+/mob/living/simple_animal/hostile/ordeal/green_midnight/Initialize(mapload, scaling_override)
 	. = ..()
 	left_shell = new(get_turf(src))
 	right_shell = new(get_turf(src))
@@ -72,7 +72,7 @@
 	next_health_mark = maxHealth * 0.9
 	laserloop = new(list(src), FALSE)
 	addtimer(CALLBACK(src, PROC_REF(OpenShell)), 5 SECONDS)
-	HandleScaling()
+	HandleScaling(scaling_override)
 	/// The below proc populates those turf lists in lines 59-62.
 	CheckIfMoved()
 
@@ -410,11 +410,13 @@
 
 // This proc handles the scaling for this mob according to active agent+suppression agent count. The normal methods for handling scaling don't really work here
 // AND Ordeals normally scale off of GLOB.clients which is... unideal
-/mob/living/simple_animal/hostile/ordeal/green_midnight/proc/HandleScaling()
+/mob/living/simple_animal/hostile/ordeal/green_midnight/proc/HandleScaling(scaling_override)
+
 	//This list should count all living Agents and ERAs + DO. This will need to be changed when CRAs are added, probably.
 	//This also doesn't account for nefarious RO/EO/Clerks that might want to "help", but I don't consider it a huge issue. AvailableAgentCount() is an alternative that
 	//counts dead Agents as well.
-	var/list/meaningful_enemies = AllLivingAgents(TRUE)
+	var/list/important_people = AllLivingAgents(TRUE)
+	var/meaningful_enemies = (scaling_override && scaling_override > 0) ? scaling_override : length(important_people)
 	//These are our "base values" but bear in mind that, if we have any agents alive as it initializes, which we should have at least 1, it will apply scaling to it.
 	base_squad_size = 4
 	maximum_squad_size = 9
@@ -429,12 +431,11 @@
 	/// 4 Agents: 10 initial bots / 20 maximum bots / +2 bots per 10% hp missing / 21s laser CD
 	/// Do remember that not all bots spawned are Noons.
 
-	if(meaningful_enemies)
-		for(var/gremlin in meaningful_enemies)
-			base_squad_size += 2
-			maximum_squad_size += 3
-			squad_size_increase_step += 0.34
-			laser_cooldown_time -= 1 SECONDS
+	for(var/i in 1 to meaningful_enemies)
+		base_squad_size += 2
+		maximum_squad_size += 3
+		squad_size_increase_step += 0.34
+		laser_cooldown_time -= 1 SECONDS
 
 		base_squad_size = min(base_squad_size, 10)
 		maximum_squad_size = min(maximum_squad_size, 20)

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/indigo/midnight.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/indigo/midnight.dm
@@ -52,6 +52,9 @@
 	projectiletype = null
 	simple_mob_flags = SILENCE_RANGED_MESSAGE
 
+	/// Test-range variant Matriarch has this set to TRUE, it disables her more disruptive elements.
+	var/weakened = FALSE
+
 	/// How many non-sweeper corpses has she eaten? Boosts attack speed and movespeed.
 	var/belly = 0
 
@@ -236,12 +239,15 @@ Some other overrides like AttackingTarget() are in the Combat section instead.
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 */
 
+/mob/living/simple_animal/hostile/ordeal/indigo_midnight/weak
+	weakened = TRUE
+
 /mob/living/simple_animal/hostile/ordeal/indigo_midnight/Destroy()
 	dash_hitlist = null
 	dash_hitlist_turfs = null
 	return ..()
 
-/mob/living/simple_animal/hostile/ordeal/indigo_midnight/Initialize(mapload)
+/mob/living/simple_animal/hostile/ordeal/indigo_midnight/Initialize(mapload, scaling_override)
 	. = ..()
 	// Follow me if you want to live. All Sweeper types will be included in our Leadership component.
 	var/units_to_add = list(
@@ -256,7 +262,7 @@ Some other overrides like AttackingTarget() are in the Combat section instead.
 		)
 	AddComponent(/datum/component/ai_leadership/matriarch, units_to_add, 50) // This leadership component has some special behaviour. Check near the bottom of the file to find it.
 	nitb_cooldown = world.time + (nitb_cooldown_duration * 0.33)
-	HandlePlayerScaling()
+	HandlePlayerScaling(scaling_override)
 
 	// Give us three combat abilities and Summon Sweepers to begin with. We begin with half their cooldown ticked down.
 	for(var/i in 1 to 3)
@@ -266,8 +272,8 @@ Some other overrides like AttackingTarget() are in the Combat section instead.
 	available_abilities[SUPPORT_ABILITY_SUMMON] = world.time + ability_cooldown_durations[SUPPORT_ABILITY_SUMMON] * 0.5
 
 // Called on Initialize() to update our stuff to right values for amount of players we're facing. Please never call this ever again
-/mob/living/simple_animal/hostile/ordeal/indigo_midnight/proc/HandlePlayerScaling()
-	var/amount_of_dangerous_fuel = length(AllLivingAgents(TRUE))
+/mob/living/simple_animal/hostile/ordeal/indigo_midnight/proc/HandlePlayerScaling(scaling_override)
+	var/amount_of_dangerous_fuel = (scaling_override && scaling_override > 0) ? scaling_override : length(AllLivingAgents(TRUE))
 	player_scaling = amount_of_dangerous_fuel
 
 	// Health scaling
@@ -295,7 +301,8 @@ Some other overrides like AttackingTarget() are in the Combat section instead.
 		LosePatience() // She can, sometimes, have a target while idle but far away from her target, causing her to not patrol towards them.
 
 	AttemptUseSupportAbility() // Try to use a support ability every once in a while. The proc we're calling checks if any are ready.
-	NightInTheBackstreets() // This has a cooldown, don't worry. It will also only trigger if the player scaling's hit a certain amount.
+	if(!weakened)
+		NightInTheBackstreets() // This has a cooldown, don't worry. It will also only trigger if the player scaling's hit a certain amount.
 
 /mob/living/simple_animal/hostile/ordeal/indigo_midnight/PostDamageReaction(damage_amount, damage_type, source, attack_type)
 	. = ..()
@@ -447,7 +454,8 @@ This is all code relating to handling incoming damage.
 	var/pulse_scaled_damage = pulse_base_damage + (frustration_procced * 25) // This becomes a facility-wiping obliteration nuke if you spam ranged on her
 
 	var/sound/sfx = sound('sound/weapons/resonator_blast.ogg')
-	for(var/mob/living/L in urange(90, src))
+	var/radius_of_howl = weakened ? 10 : 90
+	for(var/mob/living/L in urange(radius_of_howl, src))
 		if(faction_check_mob(L, TRUE))
 			continue
 		SEND_SOUND(L, sfx)
@@ -1218,7 +1226,7 @@ This is all code relating to Matriarch's support abilities and sweeper summoning
 
 /// Only called if we meet player_scaling_nitb_threshold
 /mob/living/simple_animal/hostile/ordeal/indigo_midnight/proc/NightInTheBackstreets()
-	if(player_scaling < player_scaling_nitb_threshold || nitb_cooldown > world.time)
+	if(player_scaling < player_scaling_nitb_threshold || nitb_cooldown > world.time || weakened)
 		return FALSE
 
 	// Stop her from trying to do NitB if she's not on the facility Z Level
@@ -1414,7 +1422,7 @@ This is all code relating to Matriarch's support abilities and sweeper summoning
 		memory_of_a_matriarch = WEAKREF(mother)
 		var/mob/living/simple_animal/hostile/ordeal/indigo_midnight/matriarch = ReturnMatriarch()
 		her_divine_right_to_rule_all_sweepers = matriarch.GetComponent(/datum/component/ai_leadership/matriarch)
-		if(matriarch.ordeal_reference)
+		if(matriarch.ordeal_reference && (!matriarch.weakened))
 			matriarch_ordeal_reference = matriarch.ordeal_reference
 		should_bind_to_matriarch = retinue
 	addtimer(CALLBACK(src, PROC_REF(SpawnSweeper), type), 1 SECONDS)

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -448,6 +448,7 @@
 #include "code\datums\saymode.dm"
 #include "code\datums\shuttles.dm"
 #include "code\datums\spawners_menu.dm"
+#include "code\datums\test_range_threats.dm"
 #include "code\datums\tgs_event_handler.dm"
 #include "code\datums\verbs.dm"
 #include "code\datums\view.dm"

--- a/tgui/packages/tgui/interfaces/Orbit.js
+++ b/tgui/packages/tgui/interfaces/Orbit.js
@@ -88,6 +88,7 @@ export const Orbit = (props, context) => {
     ghosts,
     misc,
     npcs,
+    testrange, // LOBOTOMYCORPORATION ADDITION -- Test Range Threats & Agents
   } = data;
 
   const [searchText, setSearchText] = useLocalState(context, "searchText", "");
@@ -207,6 +208,12 @@ export const Orbit = (props, context) => {
                 thing={thing} />
             ))}
         </Section>
+
+        <BasicSection // LOBOTOMYCORPORATION ADDITION -- Test Range Threats & Agents
+          title="Test Range"
+          source={testrange}
+          searchText={searchText}
+        />
 
         <Section title={`Ghosts - (${ghosts.length})`}>
           {ghosts

--- a/tgui/packages/tgui/interfaces/Orbit.js
+++ b/tgui/packages/tgui/interfaces/Orbit.js
@@ -209,7 +209,7 @@ export const Orbit = (props, context) => {
             ))}
         </Section>
 
-        <BasicSection // LOBOTOMYCORPORATION ADDITION -- Test Range Threats & Agents
+        <BasicSection // LC13 ADDITION -- Test Range Threats & Agents
           title="Test Range"
           source={testrange}
           searchText={searchText}

--- a/tgui/packages/tgui/interfaces/TestRangeThreatSimulator.js
+++ b/tgui/packages/tgui/interfaces/TestRangeThreatSimulator.js
@@ -31,7 +31,7 @@ export const TestRangeThreatSimulator = (props, context) => {
         step={1}
         stepPixelSize={(250 / datum.tuning_limit)}
         onChange={(e, value) => { SetDatumTuning(datum.reference, value); }} />
-      );
+    );
   };
 
   // 1-5 star icons to denote difficulty, colour depends on how many.
@@ -80,33 +80,36 @@ export const TestRangeThreatSimulator = (props, context) => {
           Currently spawned: {datum.max_spawns ? datum.current_spawns + "/" + datum.max_spawns : datum.current_spawns}
         </Flex.Item>
 
-        {datum.tuning_name && (<Flex.Item my={3}>
+        {datum.tuning_name &&
+        (<Flex.Item my={3}>
           <Section title="Tuning">
             {datum.tuning_name + ":"}
             {GetDatumTuningSlider(datum)}
 
           </Section>
-        </Flex.Item>)
-        }
+        </Flex.Item>)}
 
         <Flex.Item mt={2}>
           <Button color="green"
             onClick={() => act('spawn_threat',
               { chosen_threat: datum.reference,
-              tuning: tuningSliders[datum.reference]
-              })}>Spawn</Button>
+              tuning: tuningSliders[datum.reference],
+              })}>Spawn
+            </Button>
         </Flex.Item>
         <Flex.Item mt={2}>
           <Button color="red"
             onClick={() => act('despawn_one',
-              { chosen_threat: datum.reference
-              })}>Despawn One</Button>
+              { chosen_threat: datum.reference,
+              })}>Despawn One
+              </Button>
         </Flex.Item>
         <Flex.Item mt={1}>
-         <Button color="red"
+          <Button color="red"
             onClick={() => act('despawn_all',
-              { chosen_threat: datum.reference
-              })}>Despawn All</Button>
+              { chosen_threat: datum.reference,
+              })}>Despawn All
+              </Button>
         </Flex.Item>
       </Flex>
 
@@ -134,8 +137,8 @@ export const TestRangeThreatSimulator = (props, context) => {
     return (
       <Section scrollable fill title="Threat Details">
         {currentlyDetailedThreat !== null
-        ? <SelectedThreatDetails datum={currentlyDetailedThreat} />
-        : <EmptyThreatDetails />}
+          ? <SelectedThreatDetails datum={currentlyDetailedThreat} />
+          : <EmptyThreatDetails />}
       </Section>
     );
 
@@ -212,9 +215,10 @@ export const TestRangeThreatSimulator = (props, context) => {
   const ThreatsList = (props, context) => {
 
     return (
-        <Flex direction="column">
-          {threats?.map(threat => <ThreatDatumEntry datum={threat} key={threat.reference} />)}
-        </Flex>
+      <Flex direction="column">
+        {threats?.map(threat =>
+        <ThreatDatumEntry datum={threat} key={threat.reference} />)}
+      </Flex>
 
     );
 
@@ -256,7 +260,7 @@ export const TestRangeThreatSimulator = (props, context) => {
       <Flex direction="column" fill>
         <Section title="Available Arenas" fill>
 
-          {arenas.map(string => (<Flex.Item key={string} my={1}><Button align="center" fluid content={string} onClick={() => {act('change_camera', { arena: string, })} }></Button></Flex.Item>) )}
+          {arenas.map(string => (<Button key={string} align="center" fluid content={string} onClick={() => { act('change_camera', { arena: string }); } }></Button>))}
 
         </Section>
       </Flex>

--- a/tgui/packages/tgui/interfaces/TestRangeThreatSimulator.js
+++ b/tgui/packages/tgui/interfaces/TestRangeThreatSimulator.js
@@ -80,36 +80,38 @@ export const TestRangeThreatSimulator = (props, context) => {
           Currently spawned: {datum.max_spawns ? datum.current_spawns + "/" + datum.max_spawns : datum.current_spawns}
         </Flex.Item>
 
-        {datum.tuning_name &&
-        (<Flex.Item my={3}>
+        {datum.tuning_name
+        && (
+        <Flex.Item my={3}>
           <Section title="Tuning">
             {datum.tuning_name + ":"}
             {GetDatumTuningSlider(datum)}
 
           </Section>
-        </Flex.Item>)}
+        </Flex.Item>
+        )}
 
         <Flex.Item mt={2}>
           <Button color="green"
             onClick={() => act('spawn_threat',
               { chosen_threat: datum.reference,
-              tuning: tuningSliders[datum.reference],
+                tuning: tuningSliders[datum.reference],
               })}>Spawn
-            </Button>
+          </Button>
         </Flex.Item>
         <Flex.Item mt={2}>
           <Button color="red"
             onClick={() => act('despawn_one',
               { chosen_threat: datum.reference,
               })}>Despawn One
-              </Button>
+          </Button>
         </Flex.Item>
         <Flex.Item mt={1}>
           <Button color="red"
             onClick={() => act('despawn_all',
               { chosen_threat: datum.reference,
               })}>Despawn All
-              </Button>
+          </Button>
         </Flex.Item>
       </Flex>
 
@@ -217,7 +219,7 @@ export const TestRangeThreatSimulator = (props, context) => {
     return (
       <Flex direction="column">
         {threats?.map(threat =>
-        <ThreatDatumEntry datum={threat} key={threat.reference} />)}
+          <ThreatDatumEntry datum={threat} key={threat.reference} />)}
       </Flex>
 
     );
@@ -260,7 +262,7 @@ export const TestRangeThreatSimulator = (props, context) => {
       <Flex direction="column" fill>
         <Section title="Available Arenas" fill>
 
-          {arenas.map(string => (<Button key={string} align="center" fluid content={string} onClick={() => { act('change_camera', { arena: string }); } }></Button>))}
+          {arenas.map(string => (<Button key={string} align="center" fluid content={string} onClick={() => { act('change_camera', { arena: string }); }} />))}
 
         </Section>
       </Flex>

--- a/tgui/packages/tgui/interfaces/TestRangeThreatSimulator.js
+++ b/tgui/packages/tgui/interfaces/TestRangeThreatSimulator.js
@@ -4,14 +4,16 @@ import { FlexItem } from '../components/Flex';
 import { Window } from '../layouts';
 
 export const TestRangeThreatSimulator = (props, context) => {
-	const { act, data } = useBackend(context);
-	const { threats, arenas, map_ref, current_arena } = data;
+  const { act, data } = useBackend(context);
+  const { threats, arenas, map_ref, current_arena } = data;
 
   const [currentlyDetailedThreat, setCurrentlyDetailedThreat] = useLocalState(context, "currentlyDetailedThreat", null);
   const [mainTab, setMainTab] = useLocalState(context, "mainTab", 1);
   const [tuningSliders, setTuningSliders] = useLocalState(context, "tuningSliders", {});
 
-  /// Returns a slider for the datum's tuning parameter, using its minimum and maximum values.
+  /* Returns a slider for the datum's tuning parameter,
+  using its minimum and maximum values.
+  */
   const GetDatumTuningSlider = datum => {
 
     const SetDatumTuning = (ref, val) => {
@@ -21,27 +23,28 @@ export const TestRangeThreatSimulator = (props, context) => {
     };
 
     return (
-    <Slider
-      value={(tuningSliders[datum.reference] ? tuningSliders[datum.reference] : datum.tuning_min)}
-      minValue={datum.tuning_min}
-      maxValue={datum.tuning_limit}
-      step={1}
-      stepPixelSize={(250 / datum.tuning_limit)}
-      onChange={(e, value) => { SetDatumTuning(datum.reference, value); }} />
-    );
+      <Slider
+        value={(tuningSliders[datum.reference]
+          ? tuningSliders[datum.reference] : datum.tuning_min)}
+        minValue={datum.tuning_min}
+        maxValue={datum.tuning_limit}
+        step={1}
+        stepPixelSize={(250 / datum.tuning_limit)}
+        onChange={(e, value) => { SetDatumTuning(datum.reference, value); }} />
+      );
   };
 
-  /// 1-5 star icons to denote difficulty, colour depends on how many.
+  // 1-5 star icons to denote difficulty, colour depends on how many.
   const GetDifficultyStarIcons = difficulty => {
-    let appropiate_color = (difficulty > 3 ? "red" : difficulty > 2 ? "orange" : difficulty > 1 ? "yellow" : "green")
-    let icons = []
+    let appropiate_color = (difficulty > 3 ? "red" : difficulty > 2 ? "orange" : difficulty > 1 ? "yellow" : "green");
+    let icons = [];
     for (let i = 0; i < difficulty; i++) {
-      icons.push(<Icon name="star" color={appropiate_color} />)
+      icons.push(<Icon name="star" color={appropiate_color} />);
     }
     return (icons);
   };
 
-  /// Functional component: details of a selected threat.
+  // Functional component: details of a selected threat.
   const SelectedThreatDetails = (props, context) => {
     const { datum } = props;
 
@@ -67,7 +70,7 @@ export const TestRangeThreatSimulator = (props, context) => {
 
         <Flex.Item my={1} grow>
           <Collapsible content="View Battle Guide">
-            <BlockQuote inline style={{'white-space': 'pre-wrap'}}>
+            <BlockQuote inline style={{ 'white-space': 'pre-wrap' }}>
               {datum.battle_guide}
             </BlockQuote>
           </Collapsible>
@@ -83,25 +86,27 @@ export const TestRangeThreatSimulator = (props, context) => {
             {GetDatumTuningSlider(datum)}
 
           </Section>
-        </Flex.Item>)}
-
-        <Flex.Item my={3}>
-        </Flex.Item>
+        </Flex.Item>)
+        }
 
         <Flex.Item mt={2}>
           <Button color="green"
             onClick={() => act('spawn_threat',
-            {chosen_threat: datum.reference, tuning: tuningSliders[datum.reference] })}>Spawn</Button>
+              { chosen_threat: datum.reference,
+              tuning: tuningSliders[datum.reference]
+              })}>Spawn</Button>
         </Flex.Item>
         <Flex.Item mt={2}>
           <Button color="red"
             onClick={() => act('despawn_one',
-            {chosen_threat: datum.reference})}>Despawn One</Button>
+              { chosen_threat: datum.reference
+              })}>Despawn One</Button>
         </Flex.Item>
         <Flex.Item mt={1}>
          <Button color="red"
             onClick={() => act('despawn_all',
-            {chosen_threat: datum.reference})}>Despawn All</Button>
+              { chosen_threat: datum.reference
+              })}>Despawn All</Button>
         </Flex.Item>
       </Flex>
 
@@ -109,23 +114,27 @@ export const TestRangeThreatSimulator = (props, context) => {
 
   };
 
-  /// Functional component: shows up when no threat is selected.
+  // Functional component: shows up when no threat is selected.
   const EmptyThreatDetails = (props, context) => {
     return (
       <Flex>
         <BlockQuote>
-          Please select a threat to view more information, adjust threat tuning (where applicable) or despawn existing instances.
+          Please select a threat to view more information,
+          adjust threat tuning (where applicable) or despawn existing instances.
         </BlockQuote>
 
       </Flex>
-   );
+    );
   };
 
-  /// Functional component: returns EmptyThreatDetails/SelectedThreatDetails as appropiate.
+  /* Functional component: returns
+  EmptyThreatDetails/SelectedThreatDetails as appropiate.
+  */
   const ThreatDetails = (props, context) => {
     return (
       <Section scrollable fill title="Threat Details">
-        {currentlyDetailedThreat !== null ?  <SelectedThreatDetails datum={currentlyDetailedThreat} />
+        {currentlyDetailedThreat !== null
+        ? <SelectedThreatDetails datum={currentlyDetailedThreat} />
         : <EmptyThreatDetails />}
       </Section>
     );
@@ -133,87 +142,83 @@ export const TestRangeThreatSimulator = (props, context) => {
   };
 
 
-  /// Functional component: threat entry in our list.
+  // Functional component: threat entry in our list.
   const ThreatDatumEntry = (props, context) => {
     const { datum } = props;
 
-      return (
-        <Flex.Item grow={1}>
-          <Divider />
+    return (
+      <Flex.Item grow={1}>
+        <Divider />
 
-          <Flex>
-            <Flex.Item>
-              <Box
-                as="img"
-                mb={1}
-                src={`data:image/jpeg;base64,${datum.icon}`}
-                height="72px"
-                width="72px"
-                style={{
-                  '-ms-interpolation-mode': 'nearest-neighbor',
-                }} />
-            </Flex.Item>
+        <Flex>
+          <Flex.Item>
+            <Box
+              as="img"
+              mb={1}
+              src={`data:image/jpeg;base64,${datum.icon}`}
+              height="72px"
+              width="72px"
+              style={{
+                '-ms-interpolation-mode': 'nearest-neighbor',
+              }} />
+          </Flex.Item>
 
-            <Flex.Item>
-              <Divider vertical />
-            </Flex.Item>
+          <Flex.Item>
+            <Divider vertical />
+          </Flex.Item>
 
-            <Flex.Item align="center" minWidth="28rem">
-              <Flex direction="column">
-                <Flex.Item textAlign="left" align="left">
-                  {datum.name}
-                </Flex.Item>
-                <Flex.Item align="left" textAlign="left">
-                  Difficulty: {GetDifficultyStarIcons(datum.difficulty)}
-                </Flex.Item>
-              </Flex>
-            </Flex.Item>
+          <Flex.Item align="center" minWidth="28rem">
+            <Flex direction="column">
+              <Flex.Item textAlign="left" align="left">
+                {datum.name}
+              </Flex.Item>
+              <Flex.Item align="left" textAlign="left">
+                Difficulty: {GetDifficultyStarIcons(datum.difficulty)}
+              </Flex.Item>
+            </Flex>
+          </Flex.Item>
 
-            <Flex.Item grow>
+          <Flex.Item>
+            <Divider vertical />
+          </Flex.Item>
 
-            </Flex.Item>
+          <Flex.Item align="center">
 
-            <Flex.Item>
-              <Divider vertical />
-            </Flex.Item>
+            <Flex direction="column">
+              <Flex.Item my={1}>
+                <Button fluid align="center"
+                  content="View Details"
+                  onClick={() => setCurrentlyDetailedThreat(datum)} />
+              </Flex.Item>
 
-            <Flex.Item align="center">
+              <Flex.Item>
+                <Button fluid align="center"
+                  content="Spawn"
+                  color="green"
+                  onClick={() => act('spawn_threat', { chosen_threat: datum.reference, tuning: tuningSliders[datum.reference] })} />
+              </Flex.Item>
 
-              <Flex direction="column">
-                <Flex.Item my={1}>
-                  <Button fluid align="center"
-                    content="View Details"
-                    onClick={() => setCurrentlyDetailedThreat(datum)} />
-                </Flex.Item>
+            </Flex>
+          </Flex.Item>
 
-                  <Flex.Item>
-                    <Button fluid align="center"
-                      content="Spawn"
-                      color="green"
-                      onClick={() => act('spawn_threat', { chosen_threat: datum.reference, tuning: tuningSliders[datum.reference]})} />
-                  </Flex.Item>
+        </Flex>
+      </Flex.Item>
 
-               </Flex>
-            </Flex.Item>
+    );
 
-          </Flex>
-        </Flex.Item>
+  };
 
-      );
-
-    };
-
-  /// Functional component: our list of threats.
+  // Functional component: our list of threats.
   const ThreatsList = (props, context) => {
 
-      return (
-          <Flex direction="column">
-            {threats?.map(threat => <ThreatDatumEntry datum={threat} />)}
-          </Flex>
+    return (
+        <Flex direction="column">
+          {threats?.map(threat => <ThreatDatumEntry datum={threat} key={threat.reference} />)}
+        </Flex>
 
-      );
+    );
 
-    };
+  };
 
   /* Functional component: window content, including tabs,
   threat list (left) and threat details (right).
@@ -222,36 +227,36 @@ export const TestRangeThreatSimulator = (props, context) => {
 
     return (
 
-        <Window.Content scrollable>
-          <MainTabs />
-          <Flex minHeight="100%">
-            <Flex.Item grow={3}>
-              <Section scrollable fill minHeight="100%" minWidth="100%">
-                <ThreatsList />
-              </Section>
+      <Window.Content scrollable>
+        <MainTabs />
+        <Flex minHeight="100%">
+          <Flex.Item grow={3}>
+            <Section scrollable fill minHeight="100%" minWidth="100%">
+              <ThreatsList />
+            </Section>
 
-            </Flex.Item>
-            <Flex.Item>
-              <Divider vertical />
-            </Flex.Item>
-            <Flex.Item grow={2}>
-              <ThreatDetails />
-            </Flex.Item>
-          </Flex>
-        </Window.Content>
+          </Flex.Item>
+          <Flex.Item>
+            <Divider vertical />
+          </Flex.Item>
+          <Flex.Item grow={2}>
+            <ThreatDetails />
+          </Flex.Item>
+        </Flex>
+      </Window.Content>
     );
 
   };
 
 
-  /// Functional component: our list of arenas.
+  // Functional component: our list of arenas.
   const ArenasList = (props, context) => {
 
     return (
       <Flex direction="column" fill>
         <Section title="Available Arenas" fill>
 
-          {arenas.map(string => (<Flex.Item my={1}><Button align="center" fluid content={string} onClick={() => {act('change_camera', { arena: string, })} }></Button></Flex.Item>) )}
+          {arenas.map(string => (<Flex.Item key={string} my={1}><Button align="center" fluid content={string} onClick={() => {act('change_camera', { arena: string, })} }></Button></Flex.Item>) )}
 
         </Section>
       </Flex>
@@ -260,7 +265,7 @@ export const TestRangeThreatSimulator = (props, context) => {
 
   };
 
-  /// Functional component: roughly emulates the CameraConsole.js layout.
+  // Functional component: roughly emulates the CameraConsole.js layout.
   const ArenasWindow = (props, context) => {
 
     return (
@@ -283,13 +288,13 @@ export const TestRangeThreatSimulator = (props, context) => {
               id: map_ref,
               type: 'map',
             }} />
-          </div>
+        </div>
 
       </Window.Content>
     );
   };
 
-  /// Functional component: list of tabs (threats, arenas)
+  // Functional component: list of tabs (threats, arenas)
   const MainTabs = (props, context) => {
 
     return (
@@ -305,7 +310,7 @@ export const TestRangeThreatSimulator = (props, context) => {
   };
 
 
-  /// The actual return of TestRangeThreatSimulator.js
+  // The actual return of TestRangeThreatSimulator.js
   return (
     <Window
       width={1100}

--- a/tgui/packages/tgui/interfaces/TestRangeThreatSimulator.js
+++ b/tgui/packages/tgui/interfaces/TestRangeThreatSimulator.js
@@ -1,0 +1,297 @@
+import { useBackend, useLocalState } from '../backend';
+import { Button, Divider, LabeledList, Section, Flex, Tabs, Stack, Box, Icon, Collapsible, BlockQuote, ByondUi, Slider } from '../components';
+import { FlexItem } from '../components/Flex';
+import { Window } from '../layouts';
+
+export const TestRangeThreatSimulator = (props, context) => {
+	const { act, data } = useBackend(context);
+	const { threats, arenas, map_ref, current_arena } = data;
+
+  const [currentlyDetailedThreat, setCurrentlyDetailedThreat] = useLocalState(context, "currentlyDetailedThreat", null);
+  const [mainTab, setMainTab] = useLocalState(context, "mainTab", 1);
+  const [tuningSliders, setTuningSliders] = useLocalState(context, "tuningSliders", {});
+
+  const GetDatumTuningSlider = datum => {
+
+    const SetDatumTuning = (ref, val) => {
+      let newSliders = { ...tuningSliders };
+      newSliders[ref] = val;
+      setTuningSliders(newSliders);
+    };
+
+    return (
+    <Slider
+      value={(tuningSliders[datum.reference] ? tuningSliders[datum.reference] : datum.tuning_min)}
+      minValue={datum.tuning_min}
+      maxValue={datum.tuning_limit}
+      step={1}
+      stepPixelSize={(250 / datum.tuning_limit)}
+      onChange={(e, value) => { SetDatumTuning(datum.reference, value); }} />
+    );
+  };
+
+  const GetDifficultyStarIcons = difficulty => {
+    let appropiate_color = (difficulty > 3 ? "red" : difficulty > 2 ? "orange" : difficulty > 1 ? "yellow" : "green")
+    let icons = []
+    for (let i = 0; i < difficulty; i++) {
+      icons.push(<Icon name="star" color={appropiate_color} />)
+    }
+    return (icons);
+  };
+
+  const SelectedThreatDetails = (props, context) => {
+    const { datum } = props;
+
+    return (
+      <Flex direction="column">
+        <Flex.Item>
+          Name: {datum.name}
+        </Flex.Item>
+        <Flex.Item>
+          Origin: {datum.origin} - {datum.origin_detailed}
+        </Flex.Item>
+        <Flex.Item>
+          Estimated Difficulty: {GetDifficultyStarIcons(datum.difficulty)}
+        </Flex.Item>
+        <Divider />
+        <Flex.Item>
+          Description:
+          <BlockQuote my={1}>
+            {datum.desc}
+          </BlockQuote>
+
+        </Flex.Item>
+        <Flex.Item my={1} grow>
+          <Collapsible content="View Battle Guide">
+            <BlockQuote inline style={{'white-space': 'pre-wrap'}}>
+              {datum.battle_guide}
+            </BlockQuote>
+
+
+
+          </Collapsible>
+        </Flex.Item>
+        <Flex.Item>
+          Currently spawned: {datum.max_spawns ? datum.current_spawns + "/" + datum.max_spawns : datum.current_spawns}
+        </Flex.Item>
+        {datum.tuning_name && (<Flex.Item my={3}>
+          <Section title="Tuning">
+            {datum.tuning_name + ":"}
+            {GetDatumTuningSlider(datum)}
+
+          </Section>
+        </Flex.Item>)}
+        <Flex.Item my={3}>
+        </Flex.Item>
+        <Flex.Item mt={2}>
+          <Button color="green"
+            onClick={() => act('spawn_threat',
+            {chosen_threat: datum.reference, tuning: tuningSliders[datum.reference] })}>Spawn</Button>
+        </Flex.Item>
+        <Flex.Item mt={2}>
+          <Button color="red"
+            onClick={() => act('despawn_one',
+            {chosen_threat: datum.reference})}>Despawn One</Button>
+        </Flex.Item>
+        <Flex.Item mt={1}>
+         <Button color="red"
+            onClick={() => act('despawn_all',
+            {chosen_threat: datum.reference})}>Despawn All</Button>
+        </Flex.Item>
+      </Flex>
+
+    );
+
+  };
+
+  const EmptyThreatDetails = (props, context) => {
+    return (
+      <Flex>
+        <BlockQuote>
+          Please select a threat to view more information, adjust threat tuning (where applicable) or despawn existing instances.
+        </BlockQuote>
+
+      </Flex>
+   );
+  };
+
+  const ThreatDetails = (props, context) => {
+    return (
+      <Section scrollable fill title="Threat Details">
+        {currentlyDetailedThreat !== null ?  <SelectedThreatDetails datum={currentlyDetailedThreat} />
+        : <EmptyThreatDetails />}
+      </Section>
+    );
+
+  };
+
+
+  const ThreatDatumEntry = (props, context) => {
+    const { datum } = props;
+
+      return (
+        <Flex.Item grow={1}>
+          <Divider />
+          <Flex>
+            <Flex.Item>
+              <Box
+                as="img"
+                mb={1}
+                src={`data:image/jpeg;base64,${datum.icon}`}
+                height="72px"
+                width="72px"
+                style={{
+                  '-ms-interpolation-mode': 'nearest-neighbor',
+                }} />
+            </Flex.Item>
+            <Flex.Item>
+              <Divider vertical />
+            </Flex.Item>
+            <Flex.Item align="center" minWidth="28rem">
+              <Flex direction="column">
+                <Flex.Item textAlign="left" align="left">
+                  {datum.name}
+                </Flex.Item>
+                <Flex.Item align="left" textAlign="left">
+                  Difficulty: {GetDifficultyStarIcons(datum.difficulty)}
+                </Flex.Item>
+              </Flex>
+            </Flex.Item>
+            <Flex.Item grow>
+
+            </Flex.Item>
+            <Flex.Item>
+              <Divider vertical />
+            </Flex.Item>
+
+            <Flex.Item align="center">
+              <Flex direction="column">
+                 <Flex.Item my={1}>
+                    <Button fluid align="center"
+                      content="View Details"
+                      onClick={() => setCurrentlyDetailedThreat(datum)} />
+                  </Flex.Item>
+                  <Flex.Item>
+                    <Button fluid align="center"
+                      content="Spawn"
+                      color="green"
+                      onClick={() => act('spawn_threat', { chosen_threat: datum.reference, tuning: tuningSliders[datum.reference]})} />
+                  </Flex.Item>
+               </Flex>
+              </Flex.Item>
+
+          </Flex>
+        </Flex.Item>
+
+      );
+
+    };
+
+  const ThreatsList = (props, context) => {
+
+      return (
+          <Flex direction="column">
+            {threats?.map(threat => <ThreatDatumEntry datum={threat} />)}
+          </Flex>
+
+      );
+
+    };
+
+  const ThreatsWindow = (props, context) => {
+
+    return (
+
+        <Window.Content scrollable>
+          <MainTabs />
+          <Flex minHeight="100%">
+            <Flex.Item grow={3}>
+              <Section scrollable fill minHeight="100%" minWidth="100%">
+                <ThreatsList />
+              </Section>
+
+            </Flex.Item>
+            <Flex.Item>
+              <Divider vertical />
+            </Flex.Item>
+            <Flex.Item grow={2}>
+              <ThreatDetails />
+            </Flex.Item>
+          </Flex>
+        </Window.Content>
+    );
+
+  };
+
+
+  const ArenasList = (props, context) => {
+
+    return (
+      <Flex direction="column" fill>
+        <Section title="Available Arenas" fill>
+
+          {arenas.map(string => (<Flex.Item my={1}><Button align="center" fluid content={string} onClick={() => {act('change_camera', { arena: string, })} }></Button></Flex.Item>) )}
+
+        </Section>
+      </Flex>
+
+    );
+
+  };
+
+  const ArenasWindow = (props, context) => {
+
+    return (
+      <Window
+        width={1100}
+        height={900}
+        >
+          <div className="CameraConsole__left">
+              <Window.Content scrollable>
+                <MainTabs />
+                <ArenasList />
+              </Window.Content>
+            </div>
+            <div className="CameraConsole__right">
+              <div className="CameraConsole__toolbar">
+                <b>Arena: </b>
+                {current_arena
+                  || '—'}
+              </div>
+              <ByondUi
+                className="CameraConsole__map"
+                params={{
+                  id: map_ref,
+                  type: 'map',
+                }} />
+              </div>
+        </Window>
+
+
+    );
+
+  };
+
+  const MainTabs = (props, context) => {
+
+    return (
+      <Tabs>
+        <Tabs.Tab selected={mainTab === 1} onClick={() => setMainTab(1)}>
+          Threats
+        </Tabs.Tab>
+        <Tabs.Tab selected={mainTab === 2} onClick={() => setMainTab(2)}>
+          Arenas
+        </Tabs.Tab>
+      </Tabs>
+    );
+  };
+
+ return (
+		<Window
+      width={1100}
+      height={900}>
+      { mainTab === 1 ? <ThreatsWindow /> : <ArenasWindow /> }
+		</Window>
+	);
+
+};

--- a/tgui/packages/tgui/interfaces/TestRangeThreatSimulator.js
+++ b/tgui/packages/tgui/interfaces/TestRangeThreatSimulator.js
@@ -11,6 +11,7 @@ export const TestRangeThreatSimulator = (props, context) => {
   const [mainTab, setMainTab] = useLocalState(context, "mainTab", 1);
   const [tuningSliders, setTuningSliders] = useLocalState(context, "tuningSliders", {});
 
+  /// Returns a slider for the datum's tuning parameter, using its minimum and maximum values.
   const GetDatumTuningSlider = datum => {
 
     const SetDatumTuning = (ref, val) => {
@@ -30,6 +31,7 @@ export const TestRangeThreatSimulator = (props, context) => {
     );
   };
 
+  /// 1-5 star icons to denote difficulty, colour depends on how many.
   const GetDifficultyStarIcons = difficulty => {
     let appropiate_color = (difficulty > 3 ? "red" : difficulty > 2 ? "orange" : difficulty > 1 ? "yellow" : "green")
     let icons = []
@@ -39,6 +41,7 @@ export const TestRangeThreatSimulator = (props, context) => {
     return (icons);
   };
 
+  /// Functional component: details of a selected threat.
   const SelectedThreatDetails = (props, context) => {
     const { datum } = props;
 
@@ -61,19 +64,19 @@ export const TestRangeThreatSimulator = (props, context) => {
           </BlockQuote>
 
         </Flex.Item>
+
         <Flex.Item my={1} grow>
           <Collapsible content="View Battle Guide">
             <BlockQuote inline style={{'white-space': 'pre-wrap'}}>
               {datum.battle_guide}
             </BlockQuote>
-
-
-
           </Collapsible>
         </Flex.Item>
+
         <Flex.Item>
           Currently spawned: {datum.max_spawns ? datum.current_spawns + "/" + datum.max_spawns : datum.current_spawns}
         </Flex.Item>
+
         {datum.tuning_name && (<Flex.Item my={3}>
           <Section title="Tuning">
             {datum.tuning_name + ":"}
@@ -81,8 +84,10 @@ export const TestRangeThreatSimulator = (props, context) => {
 
           </Section>
         </Flex.Item>)}
+
         <Flex.Item my={3}>
         </Flex.Item>
+
         <Flex.Item mt={2}>
           <Button color="green"
             onClick={() => act('spawn_threat',
@@ -104,6 +109,7 @@ export const TestRangeThreatSimulator = (props, context) => {
 
   };
 
+  /// Functional component: shows up when no threat is selected.
   const EmptyThreatDetails = (props, context) => {
     return (
       <Flex>
@@ -115,6 +121,7 @@ export const TestRangeThreatSimulator = (props, context) => {
    );
   };
 
+  /// Functional component: returns EmptyThreatDetails/SelectedThreatDetails as appropiate.
   const ThreatDetails = (props, context) => {
     return (
       <Section scrollable fill title="Threat Details">
@@ -126,12 +133,14 @@ export const TestRangeThreatSimulator = (props, context) => {
   };
 
 
+  /// Functional component: threat entry in our list.
   const ThreatDatumEntry = (props, context) => {
     const { datum } = props;
 
       return (
         <Flex.Item grow={1}>
           <Divider />
+
           <Flex>
             <Flex.Item>
               <Box
@@ -144,9 +153,11 @@ export const TestRangeThreatSimulator = (props, context) => {
                   '-ms-interpolation-mode': 'nearest-neighbor',
                 }} />
             </Flex.Item>
+
             <Flex.Item>
               <Divider vertical />
             </Flex.Item>
+
             <Flex.Item align="center" minWidth="28rem">
               <Flex direction="column">
                 <Flex.Item textAlign="left" align="left">
@@ -157,28 +168,33 @@ export const TestRangeThreatSimulator = (props, context) => {
                 </Flex.Item>
               </Flex>
             </Flex.Item>
+
             <Flex.Item grow>
 
             </Flex.Item>
+
             <Flex.Item>
               <Divider vertical />
             </Flex.Item>
 
             <Flex.Item align="center">
+
               <Flex direction="column">
-                 <Flex.Item my={1}>
-                    <Button fluid align="center"
-                      content="View Details"
-                      onClick={() => setCurrentlyDetailedThreat(datum)} />
-                  </Flex.Item>
+                <Flex.Item my={1}>
+                  <Button fluid align="center"
+                    content="View Details"
+                    onClick={() => setCurrentlyDetailedThreat(datum)} />
+                </Flex.Item>
+
                   <Flex.Item>
                     <Button fluid align="center"
                       content="Spawn"
                       color="green"
                       onClick={() => act('spawn_threat', { chosen_threat: datum.reference, tuning: tuningSliders[datum.reference]})} />
                   </Flex.Item>
+
                </Flex>
-              </Flex.Item>
+            </Flex.Item>
 
           </Flex>
         </Flex.Item>
@@ -187,6 +203,7 @@ export const TestRangeThreatSimulator = (props, context) => {
 
     };
 
+  /// Functional component: our list of threats.
   const ThreatsList = (props, context) => {
 
       return (
@@ -198,6 +215,9 @@ export const TestRangeThreatSimulator = (props, context) => {
 
     };
 
+  /* Functional component: window content, including tabs,
+  threat list (left) and threat details (right).
+  */
   const ThreatsWindow = (props, context) => {
 
     return (
@@ -224,6 +244,7 @@ export const TestRangeThreatSimulator = (props, context) => {
   };
 
 
+  /// Functional component: our list of arenas.
   const ArenasList = (props, context) => {
 
     return (
@@ -239,39 +260,36 @@ export const TestRangeThreatSimulator = (props, context) => {
 
   };
 
+  /// Functional component: roughly emulates the CameraConsole.js layout.
   const ArenasWindow = (props, context) => {
 
     return (
-      <Window
-        width={1100}
-        height={900}
-        >
-          <div className="CameraConsole__left">
-              <Window.Content scrollable>
-                <MainTabs />
-                <ArenasList />
-              </Window.Content>
-            </div>
-            <div className="CameraConsole__right">
-              <div className="CameraConsole__toolbar">
-                <b>Arena: </b>
-                {current_arena
-                  || '—'}
-              </div>
-              <ByondUi
-                className="CameraConsole__map"
-                params={{
-                  id: map_ref,
-                  type: 'map',
-                }} />
-              </div>
-        </Window>
+      <Window.Content scrollable>
 
+        <div className="CameraConsole__left">
+          <MainTabs />
+          <ArenasList />
+        </div>
 
+        <div className="CameraConsole__right">
+          <div className="CameraConsole__toolbar">
+            <b>Arena: </b>
+            {current_arena || '—'}
+          </div>
+
+          <ByondUi
+            className="CameraConsole__map"
+            params={{
+              id: map_ref,
+              type: 'map',
+            }} />
+          </div>
+
+      </Window.Content>
     );
-
   };
 
+  /// Functional component: list of tabs (threats, arenas)
   const MainTabs = (props, context) => {
 
     return (
@@ -286,12 +304,14 @@ export const TestRangeThreatSimulator = (props, context) => {
     );
   };
 
- return (
-		<Window
+
+  /// The actual return of TestRangeThreatSimulator.js
+  return (
+    <Window
       width={1100}
       height={900}>
       { mainTab === 1 ? <ThreatsWindow /> : <ArenasWindow /> }
-		</Window>
-	);
+    </Window>
+  );
 
 };

--- a/tgui/packages/tgui/interfaces/TestRangeThreatSimulator.js
+++ b/tgui/packages/tgui/interfaces/TestRangeThreatSimulator.js
@@ -82,13 +82,13 @@ export const TestRangeThreatSimulator = (props, context) => {
 
         {datum.tuning_name
         && (
-        <Flex.Item my={3}>
-          <Section title="Tuning">
-            {datum.tuning_name + ":"}
-            {GetDatumTuningSlider(datum)}
+          <Flex.Item my={3}>
+            <Section title="Tuning">
+              {datum.tuning_name + ":"}
+              {GetDatumTuningSlider(datum)}
 
-          </Section>
-        </Flex.Item>
+            </Section>
+          </Flex.Item>
         )}
 
         <Flex.Item mt={2}>


### PR DESCRIPTION
## About The Pull Request
The second part of the Test Range update (a continuation of #283).
Adds a few more enemies to the Test Range, fixes some issues they had, adds extra arenas to use in the Test Range, and a bit of QoL.

Full list of changes:

# Threat Simulator
Reworks the Abnormality Spawner console; it is no longer limited to only Abnormalities, and can now spawn Ordeals and some other mobs. Also now uses a new modern TGUI interface.

List of added mobs:
- All stage 2 Peccatulum
- Indigo Midnight (weaker version; ranged retaliation is lower range, no NitB on high scaling)
- Green Midnight (this WILL wallbang the entire Test Range Arena Z Level, you have been warned but I think it's funny)
- Sanguine Flame
- Memory Forger

Some mobs that were previously being spawned without BreachEffect have been made to use it, where safe. This means that Forsaken Murderer will have its knockback and waddling animation, RBA will use the correct sprite, etc.

Also there's a limit on spawned mobs now. Just in case.

### Tuning
A few select mobs have little sliders in the Threat Simulator that lets you adjust some specific property of theirs. For example, you can now spawn Nothing There starting at any of its phases, or spawn Warden with a set amount of devoured corpses for its scaling, or you can set Matriarch's player scaling to 15 players.

# Printable Attribute Injectors & Scrying Orbs
What it says on the tin. They're in the Auxiliary tab. You can also shred ones you're not using anymore now. 

# New Arenas
You can now use two new arenas aside from the old one, for a total of three. They can actually be used in parallel.
- Classic: The old test range you know and love.
- Battlefield: A wide, open field with some preset sandbags and a stacks of some more you can place. I tried to give it red lighting to make it feel like the Smoke War but I'm a bit lazy at the moment
- Ouroboros: A standard facility loop, with the standard test range arrival room at the south and a mini-department center at the north. 

# Test Range Cleaner
The lobby and all the arenas have a button you can press to summon The Janitor to clean up all unwanted residue. You can alt-click to disable the very cool animation it has.

Staff can also manually spawn the cleaner effect wherever they want, but please be mindful that it is very aggressive with what it deletes. Check its `things_to_remove` list in the code.

# Murder Insanity Protection
Anyone who goes Fortitude insane or insane while using Dr. Jekyll's Formula will be instantly killed if they are in the Test Range Lobby. This is to prevent any more 'Shibuya Incidents' with the funny Sukuna weapon to happen anymore

# Babyproof Test Range Lobby
Everything important in the lobby is now indestructible.

# Fixed Augment Printer
You can now use the debug augment printer in the lobby (it had a lack-of-parenthesis issue because of `in` usage)

# New section in the Orbit menu
Agents and Abnormalities from the Test Range are now put into their own section in the Orbit menu to avoid contaminating sections with things that are actually in the round.

# Spawn as your preset character
What it says on the tin, you still have the mirror if you want to change afterwards.

# Unrelated changes I have to document for the sake of transparency
- Had to remove /area/test_range, so we can now distinguish between each different area of the test range: the lobby, and each separate arena.
- Changed Sukuna and DF to account for the above
- Changed Indigo Midnight code to allow for scaling override, and a weakened variant for use in the test range
- Changed Green Midnight code to allow for scaling override
- Changed Green Midnight's drop pod to not have the annoying glow overlay on it
- Added a bunch of auxiliary items people asked for: food, grenades, debug augment remover, belts.
- Added a debug variant of the augment remover so people can take their augments out without needing to meet the role requirements.


<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Helps us test more enemies in the Test Range, gives people options for more diverse battlefields to test loadouts/enemies in. It will help us find runtimes with enemies in different situations. People also just generally like hanging out in the Test Range so this solves some pain points of that experience.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here
[Streamable Link](https://streamable.com/bqgh9v)
<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes - **WARNING: I ticked this but have found many runtimes in my testing, not coming directly from the new types or procs, but from things that happen within the Test Range. Most of them are related to null references**
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
add: Test Range Arenas "Battlefield" and "Ouroboros".
tweak: Added new mobs to the Test Range.
tweak: Added Murder Insanity "Protection" (see: instant execution) to the Test Range Lobby.
refactor: Test Range Abnormality Spawner reworked into the Threat Simulator; method of spawning mobs changed to use new /datum/test_range_threat type and its procs. Can now perform tuning and some more advanced logic on spawned threats. Also uses new UI.
tweak: Orbit menu now shows mobs from the Test Range in a new section.
tweak: Spawning as a Test Range Agent will load your character preferences onto them (appearance, flavour and so on).
code: Test Range cleanup logic changed: previously, it searched constantly for living Test Range Agents, and if it found none, it deleted every mob it found in its area. Now, it will perform checks when each Test Range Agent dies instead, and avoids iterating over the world (apparently iterating over an area searches the entire world. We are checking cached lists of turfs/mobs now).
fix: Debug Augment Fabricator now allows printing correctly.

/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
