### PR TITLE
Fixes the Map Change In-Round Maptype Bug

### DIFF
--- a/code/_globalvars/game_modes.dm
+++ b/code/_globalvars/game_modes.dm
@@ -14,3 +14,12 @@ GLOBAL_DATUM(cult_narsie, /obj/narsie)
 
 ///We want reality_smash_tracker to exist only once and be accesable from anywhere.
 GLOBAL_DATUM_INIT(reality_smash_track, /datum/reality_smash_tracker, new)
+
+GLOBAL_DATUM_INIT(map_config_global, /datum/map_config, HACK_load_map_config())
+
+/proc/HACK_load_map_config()
+#ifdef FORCE_MAP
+        . = load_map_config(FORCE_MAP)
+#else
+        . = load_map_config(error_if_missing = FALSE)
+#endif

--- a/code/_globalvars/game_modes.dm
+++ b/code/_globalvars/game_modes.dm
@@ -19,7 +19,7 @@ GLOBAL_DATUM_INIT(map_config_global, /datum/map_config, HACK_load_map_config())
 
 /proc/HACK_load_map_config()
 #ifdef FORCE_MAP
-        . = load_map_config(FORCE_MAP)
+	. = load_map_config(FORCE_MAP)
 #else
-        . = load_map_config(error_if_missing = FALSE)
+	. = load_map_config(error_if_missing = FALSE)
 #endif

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -60,7 +60,7 @@ SUBSYSTEM_DEF(mapping)
 #endif
 
 /datum/controller/subsystem/mapping/Initialize(timeofday)
-	HACK_LoadMapConfig()
+	config = GLOB.map_config_global
 	if(initialized)
 		return
 	if(config.defaulted)
@@ -402,12 +402,12 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 		return
 
 	next_map_config = VM
-	
+
 	// If this map has submaps and no specific one was selected, initiate a submap vote
 	if(VM.has_submaps && VM.available_submaps.len > 1 && islist(VM.map_file))
 		addtimer(CALLBACK(SSvote, /datum/controller/subsystem/vote/proc/initiate_vote, "submap", "automatic submap selection"), 5 SECONDS)
 		to_chat(world, span_boldannounce("The selected map has multiple variants. A vote will start shortly to choose which one to play!"))
-	
+
 	return TRUE
 
 /datum/controller/subsystem/mapping/proc/preloadTemplates(path = "_maps/templates/") //see master controller setup

--- a/code/controllers/subsystem/maptype.dm
+++ b/code/controllers/subsystem/maptype.dm
@@ -72,7 +72,9 @@ SUBSYSTEM_DEF(maptype)
 
 /datum/controller/subsystem/maptype/Initialize()
 	..()
-	if(SSmaptype.maptype in SSmaptype.lc_maps)
+	maptype = GLOB.map_config_global.maptype
+
+	if(maptype in SSmaptype.lc_maps)
 		if(!CONFIG_GET(flag/enabletraits))
 			message_admins("Notice! Station Traits are disabled!")
 			return
@@ -91,7 +93,7 @@ SUBSYSTEM_DEF(maptype)
 					SSlobotomy_corp.enable_possession = TRUE
 
 	//Badda Bing Badda Da. This makes the latejoin menu cleaner
-	switch(SSmaptype.maptype)
+	switch(maptype)
 		if("wonderlabs")
 			departments = list("Command", "Fixers", "Security", "Service")
 		if("city")

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -17,6 +17,7 @@
 	var/map_name = "Facility A-098 ALPHA"
 	var/map_path = "map_files/Alpha"
 	var/map_file = "alphacorp.dmm"
+	var/maptype = "standard"
 
 	var/traits = null
 	var/space_ruin_levels = 0
@@ -34,7 +35,7 @@
 
 	/// Dictionary of job sub-typepath to template changes dictionary
 	var/job_changes = list()
-	
+
 	/// If this map has multiple submaps to choose from
 	var/has_submaps = FALSE
 	/// List of available submaps if pick_one was set
@@ -89,6 +90,8 @@
 	map_name = json["map_name"]
 	CHECK_EXISTS("map_path")
 	map_path = json["map_path"]
+	CHECK_EXISTS("maptype")
+	maptype = json["maptype"]
 
 	map_file = json["map_file"]
 	// "map_file": "MetaStation.dmm"
@@ -111,7 +114,7 @@
 		var/list/L = map_file
 		available_submaps = L.Copy()
 		// Don't pick yet - will be decided by vote
-		
+
 		// Load custom display names if provided
 		if(json["submap_names"] && islist(json["submap_names"]))
 			var/list/names = json["submap_names"]
@@ -157,7 +160,7 @@
 		minetype = json["minetype"]
 
 	if("faction" in json)
-		SSmapping.faction = json["faction"]
+		faction = json["faction"]
 
 	allow_custom_shuttles = json["allow_custom_shuttles"] != FALSE
 
@@ -168,7 +171,7 @@
 		job_changes = json["job_changes"]
 
 	if("maptype" in json)
-		SSmaptype.maptype = json["maptype"]
+		maptype = json["maptype"]
 
 	defaulted = FALSE
 	return TRUE
@@ -195,20 +198,20 @@
 			"space_empty_levels" = space_empty_levels,
 			"minetype" = minetype
 		)
-		
+
 		if(faction)
 			json_value["faction"] = faction
 		if(job_changes && length(job_changes))
 			json_value["job_changes"] = job_changes
-		if(SSmaptype?.maptype)
-			json_value["maptype"] = SSmaptype.maptype
-			
+		if(maptype)
+			json_value["maptype"] = maptype
+
 		// Remove old file and write new one
 		if(fexists("data/next_map.json"))
 			fdel("data/next_map.json")
 		text2file(json_encode(json_value), "data/next_map.json")
 		return TRUE
-		
+
 	// Default behavior - just copy the file
 	return config_filename == "data/next_map.json" || fcopy(config_filename, "data/next_map.json")
 


### PR DESCRIPTION
## About The Pull Request
So basically, when you set the next map within a round, the change to the maptype subsystem's maptype would happen INSTANTLY, which has effects on certain things in the game (most obvious example: lootcrates take time to open in CoL but not in Facility mode, but there were far worse bugs caused by this).

Now maptype will be correctly contained within its round. This required some changes to the mapping and maptype subsystems. The next_map json file is now read for maptype, and a global variable pointing at the current map config is used by SSmaptype to get its maptype on initialize.
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugs bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution
@Cupax3 handled basically all of this PR, I just wrote it for him
<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
fix: SSmaptype's maptype no longer changes when setting the next map.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
