### PR TITLE
Ambient Danger and Pygmalion Attack [DONE?]

### DIFF
--- a/ModularLobotomy/lc13_effects.dm
+++ b/ModularLobotomy/lc13_effects.dm
@@ -159,3 +159,109 @@
 /obj/effect/decal/cleanable/crayon/cognito/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/cognitohazard_visual, _cognitohazard_visual_effect=inflicted_effect, obvious=TRUE)
+
+/*-------------------------\
+|Ambient Danger Projectiles|
+\-------------------------*/
+/obj/effect/ambient_danger
+	icon_state = "impact_laser"
+	icon = 'icons/effects/effects.dmi'
+	density = FALSE
+	layer = ABOVE_MOB_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
+	movement_type = FLYING
+	var/speed = 1 SECONDS
+	var/steps = 20
+	var/damage = 60
+	var/damage_type = RED_DAMAGE
+	var/move_cycle
+	var/list/ignore_faction = list()
+	/*
+	* Works on Turf Tags
+	* the xy of the mob is written into
+	* a text string as "x,y" and we check for
+	* that text string in the move_pattern
+	* hopefully attached to that text string
+	* is the direction we are supposed to move.
+	* If the effect somehow wanders off the
+	* path they will enter walk_rand.
+	*/
+	var/list/move_pattern = list()
+
+/obj/effect/ambient_danger/Initialize(mapload, list/ally_factions = list(), list/ordered_pattern = list())
+	if(length(ally_factions))
+		ignore_faction = ally_factions.Copy()
+	if(length(ordered_pattern))
+		move_pattern = ordered_pattern.Copy()
+	. = ..()
+	StartMovement()
+
+/obj/effect/ambient_danger/Move()
+	. = ..()
+	steps--
+	if(steps < 1)
+		qdel(src)
+	if(!QDELETED(src) && isturf(loc))
+		var/attack_tries = 5
+		/*
+		* Im apprehensive about this.
+		* If there is 12 mobs on one
+		* tile then only 5 of them will be checked.
+		* -IP
+		*/
+		for(var/mob/living/pain_mobs in loc)
+			if(QDELETED(src))
+				break
+			attack_tries--
+			if(attack_tries < 1)
+				break
+			if(Suffer(pain_mobs))
+				break
+
+/obj/effect/ambient_danger/Crossed(atom/movable/AM)
+	. = ..()
+	Suffer(AM)
+
+/obj/effect/ambient_danger/Bump(atom/A)
+	. = ..()
+	Suffer(A)
+
+/obj/effect/ambient_danger/Bumped(atom/movable/AM)
+	. = ..()
+	Suffer(AM)
+
+/obj/effect/ambient_danger/Destroy()
+	if(move_cycle)
+		deltimer(move_cycle)
+		move_cycle = null
+	return ..()
+
+/obj/effect/ambient_danger/proc/StartMovement()
+	if(length(move_pattern))
+		MovePattern()
+
+/obj/effect/ambient_danger/proc/MovePattern()
+	if(QDELETED(src))
+		return
+	if(move_cycle)
+		deltimer(move_cycle)
+		move_cycle = null
+	var/our_turf_tag = "[x],[y]"
+	if(length(move_pattern))
+		if(our_turf_tag in move_pattern)
+			if(step(src,move_pattern[our_turf_tag],speed) && !move_cycle)
+				move_cycle = addtimer(CALLBACK(src, PROC_REF(MovePattern)), speed, TIMER_STOPPABLE)
+				return
+	//We lost the pattern, go nuts.
+	walk_rand(src,speed,speed)
+
+/obj/effect/ambient_danger/proc/Suffer(atom/A)
+	if(isliving(A))
+		var/mob/living/L = A
+		if(faction_check(L.faction, ignore_faction, FALSE) || !L.density)
+			return
+		L.deal_damage(damage, damage_type, src, attack_type = (ATTACK_TYPE_SPECIAL))
+		qdel(src)
+		return TRUE
+	return FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/pygmalion.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/pygmalion.dm
@@ -58,6 +58,16 @@
 	var/protect_cooldown
 	var/retaliation = 10
 	var/PRUDENCE_CAP = 60
+	var/unfocused_talent_cooldown = 0
+	var/unfocused_talent_delay = 10 SECONDS
+
+/mob/living/simple_animal/hostile/abnormality/pygmalion/handle_automated_action()
+	. = ..()
+	if(IsContained() || stat == DEAD)
+		return
+
+	if(unfocused_talent_cooldown <= world.time)
+		UnfocusedTalent()
 
 /mob/living/simple_animal/hostile/abnormality/pygmalion/CanAllowThrough(atom/movable/mover, turf/target)
 	if(sculptor && ishuman(mover))
@@ -152,7 +162,7 @@
 		sculptor.remove_status_effect(STATUS_EFFECT_SCULPTOR)
 	if (missing_prudence)
 		restorePrudence()
-	faction = list()
+	faction = list("mob_[tag]")
 	sculptor = null
 	swap_area_index(MOB_ABNORMALITY_INDEX)
 	if(client)
@@ -191,16 +201,19 @@
 	missing_prudence = null
 	to_chat(sculptor, span_nicegreen("As soon as Pygmalion has fallen, You feel like your mind is back on track."))
 
-/mob/living/simple_animal/hostile/abnormality/pygmalion/death(gibbed)
+/mob/living/simple_animal/hostile/abnormality/pygmalion/Destroy()
 	swap_area_index(MOB_ABNORMALITY_INDEX) // Return to normal.
 	if (sculptor)
 		sculptor.remove_status_effect(STATUS_EFFECT_SCULPTOR)
 		if (missing_prudence)
 			restorePrudence()
+	return ..()
+
+/mob/living/simple_animal/hostile/abnormality/pygmalion/death(gibbed)
 	density = FALSE
 	animate(src, alpha = 0, time = 5 SECONDS)
 	QDEL_IN(src, 5 SECONDS)
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/pygmalion/PostDamageReaction(damage_amount, damage_type, source, attack_type)
 	. = ..()
@@ -212,6 +225,78 @@
 	if (attacker == sculptor)
 		attacker.deal_damage(retaliation, PALE_DAMAGE, src, attack_type = (ATTACK_TYPE_COUNTER))
 		to_chat(attacker, span_userdanger("You feel your heart break!"))
+
+/mob/living/simple_animal/hostile/abnormality/pygmalion/proc/UnfocusedTalent()
+	var/our_turf = get_turf(src)
+	unfocused_talent_cooldown = world.time + unfocused_talent_delay
+	if(!our_turf)
+		return
+	var/list/directions = GLOB.cardinals.Copy()
+	directions -= dir
+	var/direction_pattern = FormatPattern()
+	for(var/i = 1 to 3)
+		var/turf/deploy = get_step(our_turf, pop(directions))
+		if(deploy.density)
+			continue
+		var/obj/effect/ambient_danger/pyg/P = new(deploy, faction, direction_pattern)
+		if(!("neutral" in faction))
+			P.color = "red"
+	return direction_pattern
+
+/mob/living/simple_animal/hostile/abnormality/pygmalion/proc/FormatPattern()
+	var/list/return_list = list()
+	//Gimme our cords. We arnt going to check anything on the turfs so just cords.
+	var/originx = x
+	var/originy = y
+	for(var/cycle = 1 to 4)
+		var/offsetx = 0
+		var/offsety = 0
+		var/turn_rate = 0
+		var/initial_direction = NORTH
+		switch(cycle)
+			//South
+			if(2)
+				initial_direction = SOUTH
+				offsety = -1
+			//East
+			if(3)
+				initial_direction = EAST
+				offsetx = 1
+			//West
+			if(4)
+				initial_direction = WEST
+				offsetx = -1
+			//North
+			else
+				offsety = 1
+		var/path_direction = initial_direction
+		for(var/iteration = 1 to 5)
+			var/x_tag = originx + offsetx
+			var/y_tag = originy + offsety
+			var/turf_tag = "[x_tag],[y_tag]"
+			return_list += turf_tag
+			turn_rate = turn_rate + 45
+			path_direction = turn(initial_direction,turn_rate)
+			new /obj/effect/temp_visual/dir_setting/bloodsplatter(locate(x_tag,y_tag,z), path_direction)
+			return_list[turf_tag] = path_direction
+			if(path_direction == NORTH || path_direction == NORTHWEST  || path_direction ==  NORTHEAST)
+				offsety++
+			if(path_direction == SOUTH  || path_direction ==  SOUTHWEST  || path_direction ==  SOUTHEAST)
+				offsety--
+			if(path_direction == EAST  || path_direction ==  NORTHEAST  || path_direction ==  SOUTHEAST)
+				offsetx++
+			if(path_direction == WEST  || path_direction ==  NORTHWEST  || path_direction ==  SOUTHWEST)
+				offsetx--
+
+	return return_list
+
+/obj/effect/ambient_danger/pyg
+	name = "pygmalion mote"
+	icon = 'icons/obj/projectiles.dmi'
+	icon_state = "bride_bolt"
+	//Double that of the normal projectile due to the avoidability.
+	damage = 50
+	damage_type = WHITE_DAMAGE
 
 /datum/status_effect/sculptor
 	id = "Sculptor"


### PR DESCRIPTION
## About The Pull Request
Creates ambient danger effect. A object that will move randomly or follow a predefined direction path.
Pyg now has a new strange attack that produces orbs that cause damage to anyone who crosses their path. If they cannot follow the path they wish then they will move randomly.

## Why It's Good For The Game
Creates a new projectile esque entity that can deal damage to people. Gives pygmalion a new attack.
There is a chance that projectiles already fill the niche im trying to make with these effects but i havent figured out how to make projectiles act the way i want.

### Put your cool images here
Pygmalion in a open area.
https://github.com/user-attachments/assets/6a5712bd-2c87-4396-995c-d93ab717062d

Pygmalion in a hallway.
https://github.com/user-attachments/assets/9edb256b-4f8d-413d-8201-6fdedb84fc0c

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [x] This PR compiles
* [x] This PR runs fine in a local test
* [x] This PR does not produce runtimes
* [x] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
code: CHANGEME
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
