### PR TITLE
Hostile Code Optimization [DONE]

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1606,3 +1606,25 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	if(W || D || V || G)
 		return FALSE
 	return TRUE
+
+/*
+* A way of recognizing entities without
+* having to keep their refrences.
+*/
+/proc/AddIdentifier(atom/whazzit)
+	if(isturf(whazzit))
+		var/turf/U = whazzit
+		return "[U.x],[U.y],[U.z]"
+	if(isliving(whazzit))
+		var/mob/living/dude = whazzit
+		return dude.tag
+	if(isvehicle(whazzit))
+		var/obj/vehicle/ride = whazzit
+		var/following_ident = "[ride.x],[ride.y],[ride.z]"
+		var/driver = ride.return_drivers()
+		if(isliving(driver))
+			var/mob/living/guy = driver
+			following_ident = "[guy.tag]"
+
+		//Only identify by the driver
+		return "[ride]:[following_ident]"

--- a/code/modules/mob/living/simple_animal/abnormality/he/better_memories.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/better_memories.dm
@@ -208,11 +208,11 @@
 	if(patrol_path.len)
 		if(!H.is_working)
 			return FALSE
-		if(target_memory[the_target] <= 100)
+		if(target_memory[AddIdentifier(H)] <= 100)
 			return FALSE
 	if(H.has_status_effect(MEMORY_DEBUFF))
 		//You have inflicted 100 damage to us. Get jabbed.
-		if(target_memory[the_target] <= 100)
+		if(target_memory[AddIdentifier(H)] <= 100)
 			return FALSE
 
 /mob/living/simple_animal/hostile/better_memories_minion/AttackingTarget(atom/attacked_target)
@@ -296,10 +296,12 @@
 			if(!P.firer)
 				if(target_memory["nobuddy"] > 100)
 					patrol_reset()
-			//If our damage value for that person exceeds this number then we consider targeting them.
-			if(target_memory[P.firer] > 100)
-				FindTarget(list(P.firer), 1)
-		return second_on_hit_state
+			if(isliving(P.firer))
+				var/mob/living/L = P.firer
+				//If our damage value for that person exceeds this number then we consider targeting them.
+				if(target_memory[AddIdentifier(L)] > 100)
+					FindTarget(list(L), 1)
+			return second_on_hit_state
 	return ..()
 
 /mob/living/simple_animal/hostile/better_memories_minion/attacked_by(obj/item/I, mob/living/L)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -21,6 +21,7 @@ GLOBAL_LIST_EMPTY(marked_players)
 	var/projectilesound
 	var/casingtype		//set ONLY it and NULLIFY projectiletype, if we have projectile IN CASING
 	var/move_to_delay = 3 //delay for the automated movement.
+	//Uses tags. If you respawn or change bodies who even are you?
 	var/list/friends = list()
 	var/list/emote_taunt = list()
 	var/taunt_chance = 0
@@ -145,8 +146,8 @@ GLOBAL_LIST_EMPTY(marked_players)
 	SIGNAL_HANDLER
 	if (check_visible(user, crate) && stat != DEAD && !target)
 		addtimer(CALLBACK(src, PROC_REF(Theif_Talk)), 0)
-		if (!(user in glob_faction))
-			glob_faction += user
+		if (!(user.tag in glob_faction))
+			glob_faction += user.tag
 
 /mob/living/simple_animal/hostile/proc/Talk()
 	say(starting_looting_line)
@@ -163,36 +164,41 @@ GLOBAL_LIST_EMPTY(marked_players)
 	. = ..()
 	if(mark_once_attacked)
 		if(P.firer && get_dist(src, P.firer) <= aggro_vision_range)
-			if(!ishostile(P.firer))
-				if (!(P.firer in glob_faction))
-					glob_faction += P.firer
+			if(iscarbon(P.firer))
+				var/mob/living/carbon/C = P.firer
+				if (!(C.tag in glob_faction))
+					glob_faction += C.tag
 					say(attacked_line)
 
 	// Track damage for nuke rats achievement
 	if(glob_faction == GLOB.nuke_rats_players && P.firer && isliving(P.firer))
 		var/mob/living/L = P.firer
-		if(L.client && !(L in GLOB.nuke_rats_killers))
-			GLOB.nuke_rats_killers += L
+		if(L.client && !(L.tag in GLOB.nuke_rats_killers))
+			GLOB.nuke_rats_killers += L.tag
 
 /mob/living/simple_animal/hostile/attackby(obj/item/O, mob/user, params)
 	. = ..()
 	if(mark_once_attacked)
 		if(ishuman(user))
 			if (O.force > 0)
-				if (!(user in glob_faction ))
-					glob_faction += user
+				if (!(user.tag in glob_faction ))
+					glob_faction += user.tag
 					say(attacked_line)
 		else
-			if (!(user in glob_faction ))
-				glob_faction += user
+			if (!(user.tag in glob_faction ))
+				glob_faction += user.tag
 				say(attacked_line)
 
 	// Track damage for nuke rats achievement
-	if(glob_faction == GLOB.nuke_rats_players && user && user.client && !(user in GLOB.nuke_rats_killers))
-		GLOB.nuke_rats_killers += user
+	if(glob_faction == GLOB.nuke_rats_players && user && user.client && !(user.tag in GLOB.nuke_rats_killers))
+		GLOB.nuke_rats_killers += user.tag
 
 /mob/living/simple_animal/hostile/Destroy()
+	target = null
 	targets_from = null
+	target_memory = null
+	friends = null
+	patrol_path = null
 	if(mark_once_attacked)
 		UnregisterSignal(SSdcs, COMSIG_CRATE_LOOTING_STARTED)
 		UnregisterSignal(SSdcs, COMSIG_CRATE_LOOTING_ENDED)
@@ -210,9 +216,9 @@ GLOBAL_LIST_EMPTY(marked_players)
 
 		if(all_dead && GLOB.nuke_rats_killers.len)
 			// Award achievement to all players who participated in killing nuke rats
-			for(var/mob/living/L in GLOB.nuke_rats_killers)
-				if(L.client)
-					L.client.give_award(/datum/award/achievement/lc13/city/nuke_rats_genocide, L)
+			for(var/mob/living/carbon/human/slayer in GLOB.player_list)
+				if(slayer.tag in GLOB.nuke_rats_killers && slayer.client)
+					slayer.client.give_award(/datum/award/achievement/lc13/city/nuke_rats_genocide, slayer)
 			// Clear the killers list after awarding
 			GLOB.nuke_rats_killers.Cut()
 
@@ -634,7 +640,7 @@ GLOBAL_LIST_EMPTY(marked_players)
 				return FALSE
 
 			if(mark_once_attacked)
-				if (the_target in glob_faction)
+				if (L.tag in glob_faction)
 					return TRUE
 
 			var/faction_check = faction_check_mob(L)
@@ -643,7 +649,7 @@ GLOBAL_LIST_EMPTY(marked_players)
 					return FALSE
 				if(L.stat > stat_attack)
 					return FALSE
-				if(L in friends)
+				if(AddIdentifier(L) in friends)
 					return FALSE
 			else
 				if((faction_check && !attack_same) || L.stat)
@@ -714,8 +720,11 @@ GLOBAL_LIST_EMPTY(marked_players)
 /mob/living/simple_animal/hostile/proc/RegisterAggroValue(atom/remembered_target, value, damage_type)
 	if(!remembered_target || !damage_type)
 		return FALSE
-	if(!isnum(target_memory[remembered_target]))
-		target_memory += remembered_target
+	var/trg_tag = AddIdentifier(remembered_target)
+	if(!trg_tag)
+		return FALSE
+	if(!isnum(target_memory[trg_tag]))
+		target_memory += trg_tag
 
 	//could potentially add aggro as a mob armor type to also apply aggro damage coeff
 	//also could potentially check for remembered_target's aggro modifiers here such as from armor or status effects
@@ -726,11 +735,11 @@ GLOBAL_LIST_EMPTY(marked_players)
 			value *= aggro_stat_modifier
 	else
 		value *= damage_coeff.getCoeff(damage_type)
-	target_memory[remembered_target] += value
+	target_memory[trg_tag] += value
 
-	if(!QDELETED(target) && remembered_target != target && target_memory[remembered_target] > target_memory[target] + target_switch_resistance && CanAttack(remembered_target))
+	if(!QDELETED(target) && remembered_target != target && target_memory[trg_tag] > target_memory[AddIdentifier(target)] + target_switch_resistance && CanAttack(remembered_target))
 		GiveTarget(remembered_target)
-		target_memory[remembered_target] += value
+		target_memory[trg_tag] += value
 	return TRUE
 
 /*-------------------\
@@ -745,8 +754,10 @@ GLOBAL_LIST_EMPTY(marked_players)
 |Damage dealt +0 to +25
 \-------------------*/
 /mob/living/simple_animal/hostile/proc/ValueTarget(atom/target_thing)
-	if(!target_thing)
-		return
+	var/target_tag = AddIdentifier(target_thing)
+	if(!target_thing || !target_tag)
+		return 0
+
 	//This is a safety net just in the case that no value is returned.
 	. = 0
 
@@ -770,8 +781,8 @@ GLOBAL_LIST_EMPTY(marked_players)
 		. -= 60
 
 	//up to 25 points for damage taken from target_thing
-	if(target_memory[target_thing])
-		var/fraction_hp_lost_to_thing = min(target_memory[target_thing] / maxHealth, 1)
+	if(target_memory[target_tag])
+		var/fraction_hp_lost_to_thing = min(target_memory[target_tag] / maxHealth, 1)
 		. += fraction_hp_lost_to_thing * 25
 
 /mob/living/simple_animal/hostile/proc/GiveTarget(atom/new_target)
@@ -781,7 +792,7 @@ GLOBAL_LIST_EMPTY(marked_players)
 			return
 		target_memory.Cut()
 		target = new_target
-		target_memory[target] = 0
+		target_memory[AddIdentifier(target)] = 0
 		GainPatience()
 		Aggro()
 		Goto(target, move_to_delay, minimum_distance)
@@ -1240,11 +1251,12 @@ GLOBAL_LIST_EMPTY(marked_players)
 	|UNCATAGORIZED PROCS|
 	\------------------*/
 
-/mob/living/simple_animal/hostile/tamed(whomst)
+/mob/living/simple_animal/hostile/tamed(mob/living/whomst)
 	. = ..()
-	if(isliving(whomst) && !locate(whomst) in friends)
+	var/tamed_tag = AddIdentifier(whomst)
+	if(isliving(whomst) && !(tamed_tag in friends))
 		var/mob/living/fren = whomst
-		friends += fren
+		LAZYOR(friends, tamed_tag)
 		faction = fren.faction.Copy()
 
 /mob/living/simple_animal/hostile/proc/summon_backup(distance, exact_faction_match)

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/steel/warbeast.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/steel/warbeast.dm
@@ -84,7 +84,7 @@
 	var/turf/thrownat = get_ranged_target_turf_direct(src, L, 4, rand(-10, 10))
 	L.throw_at(thrownat, 8, 2, src, TRUE, force = MOVE_FORCE_OVERPOWERING, gentle = TRUE)
 	shake_camera(L, 2, 1)
-	if(target_memory[L] < 100)
+	if(target_memory[AddIdentifier(L)] < 100)
 		LoseTarget()
 	swat_cooldown = world.time + swat_delay
 

--- a/code/modules/spells/ability_types/_ability.dm
+++ b/code/modules/spells/ability_types/_ability.dm
@@ -122,24 +122,6 @@
 	hit_identifiers += identifer
 	return FALSE
 
-/obj/effect/proc_holder/ability/proc/AddIdentifier(atom/whazzit)
-	if(isturf(whazzit))
-		var/turf/U = whazzit
-		return "[U.x],[U.y],[U.z]"
-	if(isliving(whazzit))
-		var/mob/living/dude = whazzit
-		return dude.tag
-	if(isvehicle(whazzit))
-		var/obj/vehicle/ride = whazzit
-		var/following_ident = "[ride.x],[ride.y],[ride.z]"
-		var/driver = ride.return_drivers()
-		if(isliving(driver))
-			var/mob/living/guy = driver
-			following_ident = "[guy.tag]"
-
-		//Only identify by the driver
-		return "[ride]:[following_ident]"
-
 //Unique interactions with simplemobs such as var alterations
 /obj/effect/proc_holder/ability/proc/AbnoInteraction(mob/living/user)
 	return


### PR DESCRIPTION
## About The Pull Request
Changes temporary mob memory to instead hold a refrence of a identifying tag of the creature rather than a refrence. This should prevent hard deletes.

Also turns AddIdentifier into a root proc.

## Why It's Good For The Game
Prevents hard deletes.

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [x] This PR compiles
* [x] This PR runs fine in a local test
* [x] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
code: AddIdentifier root proc
refactor: Hostile Target Memory Code.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
