### PR TITLE
Updates Ardor Blossom Moth to have new attacks

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/ardor_blossom_moth.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/ardor_blossom_moth.dm
@@ -148,9 +148,12 @@
 
 
 /mob/living/simple_animal/hostile/abnormality/ardor_moth/proc/SpitFire()
-	var/turf/T = get_ranged_target_turf_direct(src, target, 6)
-	var/list/burn_turfs = getline(src, T) - get_turf(src)
-	dragon_fire_line(src, burn_turfs)
+	for(var/i = 1 to 3)
+		var/turf/T = get_ranged_target_turf_direct(src, target, 6)
+		var/list/burn_turfs = getline(src, T) - get_turf(src)
+		dragon_fire_line(src, burn_turfs)
+		SLEEP_CHECK_DEATH(5)
+
 	prepping_fire = FALSE
 
 /mob/living/simple_animal/hostile/abnormality/ardor_moth/proc/BurnAll()

--- a/code/modules/mob/living/simple_animal/abnormality/he/ardor_blossom_moth.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/ardor_blossom_moth.dm
@@ -7,16 +7,18 @@
 	icon_state = "blossom_moth"
 	icon_living = "blossom_moth"
 	portrait = "blossom_moth"
-	maxHealth = 1200
-	health = 1200
+	maxHealth = 800
+	health = 800
 	blood_volume = 0
 	ranged = TRUE
 	attack_verb_continuous = "sears"
 	attack_verb_simple = "sear"
 	is_flying_animal = TRUE
+	ranged = TRUE
 	stat_attack = HARD_CRIT
 	melee_damage_lower = 11
 	melee_damage_upper = 12
+	attack_sound = 'sound/weapons/bite.ogg'
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.5, WHITE_DAMAGE = 1, BLACK_DAMAGE = 0.7, PALE_DAMAGE = 2, FIRE = 0.2)
 	speak_emote = list("flutters")
 	vision_range = 14
@@ -24,7 +26,7 @@
 
 	can_breach = TRUE
 	threat_level = HE_LEVEL
-	faction = list("neutral", "hostile")
+	faction = list("hostile")
 	start_qliphoth = 3
 	work_chances = list(
 		ABNORMALITY_WORK_INSTINCT = 45,
@@ -63,6 +65,7 @@
 
 	var/stoked
 	var/stoke_timer
+	var/prepping_fire
 	light_color = COLOR_ORANGE
 	light_range = 5
 	light_power = 7
@@ -81,6 +84,7 @@
 
 	switch(work_type)
 		if(ABNORMALITY_WORK_ATTACHMENT)
+			faction = list("neutral", "hostile")
 			stoked = TRUE
 			light_on = TRUE
 			update_light()
@@ -90,15 +94,23 @@
 			to_chat(user, span_notice("You stoke the flames, and it burns hotter."))
 
 /mob/living/simple_animal/hostile/abnormality/ardor_moth/proc/Stoke()
+	if (!IsContained())
+		return
+	faction = list("hostile")
 	stoked = FALSE
 	light_on = FALSE
 	update_light()
 
 /mob/living/simple_animal/hostile/abnormality/ardor_moth/Destroy(force)
 	deltimer(stoke_timer)
+	if(!prepping_fire)
+		prepping_fire = TRUE
+		Explosion()
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/ardor_moth/Move()
+	if(prepping_fire)
+		return
 	..()
 	for(var/turf/open/T in range(1, src))
 		if(locate(/obj/effect/turf_fire/ardor) in T)
@@ -109,6 +121,65 @@
 /mob/living/simple_animal/hostile/abnormality/ardor_moth/spawn_gibs()
 	return new /obj/effect/decal/cleanable/ash(drop_location(), src)
 
+/mob/living/simple_animal/hostile/abnormality/ardor_moth/CanAttack(atom/the_target)
+	..()
+	if(prepping_fire)
+		return FALSE
+
+/mob/living/simple_animal/hostile/abnormality/ardor_moth/OpenFire()
+	..()
+	if(prepping_fire)
+		return
+	if(prob(0.5))
+		prepping_fire = TRUE
+		Explosion()
+		return
+
+	if(prob(50))
+		switch (rand(1,2))
+			if(1)
+				prepping_fire = TRUE
+				manual_emote("rears back...")
+				addtimer(CALLBACK(src, PROC_REF(SpitFire)), 10, TIMER_STOPPABLE)
+			if(2)
+				prepping_fire = TRUE
+				manual_emote("emits heat...")
+				addtimer(CALLBACK(src, PROC_REF(BurnAll)), 10, TIMER_STOPPABLE)
+
+
+/mob/living/simple_animal/hostile/abnormality/ardor_moth/proc/SpitFire()
+	var/turf/T = get_ranged_target_turf_direct(src, target, 6)
+	var/list/burn_turfs = getline(src, T) - get_turf(src)
+	dragon_fire_line(src, burn_turfs)
+	prepping_fire = FALSE
+
+/mob/living/simple_animal/hostile/abnormality/ardor_moth/proc/BurnAll()
+	for(var/i = 1 to 4)
+		for(var/turf/T in range(i, src))
+			if(T in range(i - 1, src))
+				continue // skip tiles already hit
+			// hit only the new outer ring
+			new /obj/effect/turf_fire/ardor(T)
+		SLEEP_CHECK_DEATH(2)
+	prepping_fire = FALSE
+
+/mob/living/simple_animal/hostile/abnormality/ardor_moth/proc/Explosion()
+	manual_emote("glows insanely bright...")
+	playsound(get_turf(src), 'sound/abnormalities/scorchedgirl/ability.ogg', 60, 0, 4)
+	SLEEP_CHECK_DEATH(3 SECONDS)
+	// Ka-boom
+	playsound(get_turf(src), 'sound/abnormalities/scorchedgirl/explosion.ogg', 125, 0, 8)
+	for(var/i = 1 to 9)
+		for(var/turf/T in range(i, src))
+			if(T in range(i - 1, src))
+				continue // skip tiles already hit
+			// hit only the new outer ring
+			new /obj/effect/turf_fire/ardor(T)
+		SLEEP_CHECK_DEATH(2)
+	qdel(src)
+
+
+//The special fire type
 /obj/effect/turf_fire/ardor
 	burn_time = 30 SECONDS
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/ardor_blossom_moth.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/ardor_blossom_moth.dm
@@ -121,11 +121,6 @@
 /mob/living/simple_animal/hostile/abnormality/ardor_moth/spawn_gibs()
 	return new /obj/effect/decal/cleanable/ash(drop_location(), src)
 
-/mob/living/simple_animal/hostile/abnormality/ardor_moth/CanAttack(atom/the_target)
-	..()
-	if(prepping_fire)
-		return FALSE
-
 /mob/living/simple_animal/hostile/abnormality/ardor_moth/OpenFire()
 	..()
 	if(prepping_fire)

--- a/code/modules/paperwork/records/info/he.dm
+++ b/code/modules/paperwork/records/info/he.dm
@@ -516,7 +516,7 @@
 	abno_code = "T-02-182"
 	abno_info = list(
 		"When Attachment work was completed on T-02-182 the employee working started to stoke the moth's flames.",
-		"While stoked, work chance was increased, and the Qliphoth Counter increased.",
+		"While stoked, work chance was increased, and the Qliphoth Counter increased, and T-02-182 became less agressive.",
 		"Employees who worked on Ardor Blossom Moth without a proper fire had a small chance of lowering the Qliphoth counter by 2.",
 		)
 


### PR DESCRIPTION
## About The Pull Request
Gives Ardor moth 3 new attacks:
A suicidal explosion that coats an entire area with fire
A Fire Breath
A Fire AOE

Ardor Moth is passive if breaching when stoked, and hostile if not.
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is part of an ongoing update to Abnormalities.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [ ] This PR compiles
* [ ] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
balance: Ardor Blossom Moth gains a few new attacks.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
