### PR TITLE
Fixes Perversion waking up contained abnos

### DIFF
--- a/ModularLobotomy/ego_weapons/melee/abnormality/aleph.dm
+++ b/ModularLobotomy/ego_weapons/melee/abnormality/aleph.dm
@@ -2879,7 +2879,7 @@
 // Root any nearby enemies with Contempt in sight. We'll store their status effects in a list so we can delete them later.
 /obj/item/ego_weapon/perversion/proc/DrawAttackRootContempt(mob/living/carbon/human/user)
 	for(var/mob/living/L in viewers(cascading_gaze_radius, user))
-		if(!(L.has_status_effect(STATUS_EFFECT_CONTEMPT)))
+		if(!(L.has_status_effect(STATUS_EFFECT_CONTEMPT)) || L.status_flags & GODMODE)
 			continue
 		if(user.faction_check_mob(L))
 			continue
@@ -3006,7 +3006,7 @@
 	for(var/turf/T in cascading_gaze_affected_turfs)
 		var/sent_visual = FALSE
 		for(var/mob/living/L in T)
-			if((L in shared_hitlist) || (user.faction_check_mob(L)) || (L.stat >= DEAD))
+			if((L in shared_hitlist) || (user.faction_check_mob(L)) || (L.stat >= DEAD) || (L.status_flags & GODMODE))
 				continue
 
 			shared_hitlist |= L
@@ -3310,6 +3310,8 @@
 /* ------------------------ COMBAT ------------------------ */
 // Basic proc used to apply this weapon's version of Gaze. Will not apply Gaze if they already have Contempt.
 /obj/item/ego_weapon/perversion/proc/ApplyGaze(mob/living/target, stacks_to_apply)
+	if(!target || !isliving(target) || target.status_flags & GODMODE)
+		return
 	var/datum/status_effect/stacking/perversion_weapon_gaze/gazing = target.has_status_effect(STATUS_EFFECT_GAZE)
 	var/datum/status_effect/display/perversion_weapon_contempt/contempting = target.has_status_effect(STATUS_EFFECT_CONTEMPT)
 	if(contempting)
@@ -3585,7 +3587,8 @@
 				continue
 			if(L.stat >= DEAD)
 				continue
-
+			if(L.status_flags & GODMODE)
+				continue
 			shared_hitlist |= L
 
 			new /obj/effect/temp_visual/dir_setting/bloodsplatter(T3, pick(GLOB.alldirs))
@@ -3666,6 +3669,8 @@
 			if(user.faction_check_mob(L))
 				continue
 			if(L.stat >= DEAD)
+				continue
+			if(L.status_flags & GODMODE)
 				continue
 
 			shared_hitlist |= L


### PR DESCRIPTION
## About The Pull Request
What it says on the tin. (Was able to inflict Gaze/Contempt on contained abnos and root them with Cascading Gaze of Awe Underneath Contempt, which would wake them up after it ended)
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fix 😄 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
fix: Perversion no longer able to wake up Abnormalities in containment, or inflict its statuses on them
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
