### PR TITLE
Grunt work o more hard dels pt2 [STALE]

### DIFF
--- a/ModularLobotomy/rcorp/rcorp_abnos/easyteam/easycombat/woodsman.dm
+++ b/ModularLobotomy/rcorp/rcorp_abnos/easyteam/easycombat/woodsman.dm
@@ -143,8 +143,10 @@
 	initial_flurry_delay = flurry_delay
 	initial_flurry_pause = flurry_pause
 	initial_move_to_delay = move_to_delay
+	/*
 	var/obj/effect/proc_holder/spell/pointed/axe_throw/AS = new /obj/effect/proc_holder/spell/pointed/axe_throw(src)
 	AddSpell(AS)
+	*/
 
 /mob/living/simple_animal/hostile/rcorp_abno/easy/woodsman/Destroy()
 	if(soundloop)

--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -431,6 +431,13 @@
 		return current.GetPortrait()
 	return portrait
 
+//Return the current iteration of this Abnormality
+//Im sorry im building dependence on abno datums.
+/datum/abnormality/proc/GetCurrent()
+	if(current)
+		return current
+	return
+
 /// Swaps the cells with target abnormality datum
 /datum/abnormality/proc/SwapPlaceWith(datum/abnormality/target = null)
 	if(!istype(target))

--- a/code/datums/ai/sanity/_sanityloss_controller.dm
+++ b/code/datums/ai/sanity/_sanityloss_controller.dm
@@ -909,8 +909,10 @@
 			continue
 		if(!AC.datum_reference)
 			continue
-		if(!(AC.datum_reference.current.status_flags & GODMODE))
-			continue
+		var/mob/living/simple_animal/hostile/abnormality/abno = AC.datum_reference.GetCurrent()
+		if(abno)
+			if(!(abno.status_flags & GODMODE))
+				continue
 		if(blackboard[BB_INSANE_BLACKLISTITEMS][AC] > world.time)
 			continue
 		if((AC.datum_reference.qliphoth_meter_max > 0) && (AC.datum_reference.qliphoth_meter > 0))

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -298,7 +298,7 @@
 /datum/status_effect/pacify/on_creation(mob/living/new_owner, set_duration)
 	if(isnum(set_duration))
 		duration = set_duration
-	. = ..()
+	return ..()
 
 /datum/status_effect/pacify/on_apply()
 	ADD_TRAIT(owner, TRAIT_PACIFISM, "status_effect")

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -677,6 +677,10 @@ The variable's key needs to be non-numerical.*/
 	//Abnormalities dont explode on mass most of the time so they can keep gibs.
 	return new /obj/effect/gibspawner/generic(drop_location(), src, get_static_viruses())
 
+//Used for abnormality abilities in order to reset sprites or special states.
+/mob/living/simple_animal/hostile/abnormality/proc/SpecialReset()
+	return
+
 // Actions
 /datum/action/innate/abnormality_attack
 	name = "Abnormality Attack"

--- a/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
@@ -81,7 +81,7 @@
 	var/hired = FALSE
 	var/lie_chance = 30 // % chance to lie
 	var/datum/abnormality/buddy //the red buddy datum linked to this shepherd
-	var/mob/living/simple_animal/hostile/abnormality/red_buddy/awakened_buddy //the red buddy shepherd is currently fighting with
+	var/mob/living/simple_animal/hostile/abnormality/red_buddy/awakened_buddy
 	var/awakened = FALSE //if shepherd has seen red buddy or not
 	var/list/people_list = list() //list of people shepperd can mention
 	var/buddy_hit = FALSE
@@ -305,6 +305,7 @@
 	UnregisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH)
 	UnregisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED)
 	UnregisterSignal(SSdcs, COMSIG_GLOB_ABNORMALITY_SPAWN)
+	UnregisterBuddy()
 	LAZYCLEARLIST(people_list)
 	return ..()
 
@@ -322,7 +323,7 @@
 /mob/living/simple_animal/hostile/abnormality/blue_shepherd/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	var/mob/living/simple_animal/hostile/abnormality/red_buddy/buddy_abno = buddy?.current
 	if(buddy_abno?.suffering >= 40)
-		user.Apply_Gift(new gift_type) //you get a free gift if you somehow made the dog suffer that much
+		user.Apply_Gift(new gift_type) //you get a free gift if you somehow made the awakened_buddy suffer that much
 		datum_reference.qliphoth_change(-1)
 	if(work_type == ABNORMALITY_WORK_REPRESSION)
 		datum_reference.qliphoth_change(1)
@@ -370,6 +371,7 @@
 	if(slash_current == 0)
 		slash_current = slash_cooldown
 		slashing = TRUE
+
 		switch(rand(1,3))
 			if(1)
 				say(pick(combat_lines))
@@ -409,27 +411,13 @@
 
 /mob/living/simple_animal/hostile/abnormality/blue_shepherd/Life()
 	. = ..()
-	if(status_flags & GODMODE)
+	if(status_flags & GODMODE || awakened)
 		return
-	var/mob/living/buddy_abno = buddy?.current
+	var/mob/living/buddy_abno = buddy.GetCurrent()
 	if(!buddy_abno)
 		return
-
-	if(!awakened && can_see(src, buddy_abno, 10))
-		awakened_buddy = buddy_abno
-		awakened = TRUE //ho god ho fuck
-		slash_cooldown = 3
-		slash_damage = 50
-		melee_damage_lower = 30
-		melee_damage_upper = 40
-		ChangeMoveToDelayBy(-0.5)
-		maxHealth = maxHealth * 4 //5000 health, will get hurt by buddy's howl to make up for the high health
-		set_health(health * 4)
-		med_hud_set_health()
-		med_hud_set_status()
-		update_health_hud() //I have to do this shit manually because adjustHealth is just fucked when changing max HP
-	if(!awakened_buddy)
-		return
+	if(can_see(src, buddy_abno, 10))
+		RegisterBuddy(buddy_abno)
 
 /mob/living/simple_animal/hostile/abnormality/blue_shepherd/Move()
 	if(slashing)
@@ -452,9 +440,27 @@
 		return FALSE
 	return ..()
 
+/mob/living/simple_animal/hostile/abnormality/blue_shepherd/PatrolSelect()
+	. = ..()
+	if(awakened && awakened_buddy)
+		if(!awakened_buddy.target && pulling != awakened_buddy)
+			walk_to(awakened_buddy, src, 1, awakened_buddy.move_to_delay)
+
+/mob/living/simple_animal/hostile/abnormality/blue_shepherd/SelectPatrolLocation()
+	var/mob/living/simple_animal/hostile/abnormality/doggo
+	if(!awakened && buddy)
+		doggo = buddy.GetCurrent()
+		if(doggo)
+			var/turf/target_turf = get_turf(doggo)
+			if(istype(target_turf) && !(doggo.status_flags & GODMODE))
+				if(target_turf.z == z)
+					return target_turf
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/blue_shepherd/proc/slash()
-	if(buddy?.current?.status_flags & GODMODE)
-		buddy.qliphoth_change(-1) //buddy can hear it fight
+	if(!awakened)
+		if(buddy)
+			buddy.qliphoth_change(-1) //buddy can hear it fight
 	var/turf/orgin = get_turf(src)
 	var/list/all_turfs = RANGE_TURFS(range, orgin)
 	playsound(src, 'sound/weapons/slice.ogg', 75, FALSE, 4)
@@ -558,6 +564,7 @@
 		return FALSE
 	if(!ishuman(died))
 		return FALSE
+	people_list -= died
 	if(!died.ckey)
 		return FALSE
 	if(died.z != z)
@@ -651,3 +658,32 @@
 			A.Trigger()
 	if(!triggered)
 		slashing = FALSE
+
+/mob/living/simple_animal/hostile/abnormality/blue_shepherd/proc/RegisterBuddy(mob/living/simple_animal/hostile/abnormality/red_buddy/bud)
+	if(!bud || awakened)
+		return
+	RegisterSignal(bud, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING), PROC_REF(UnregisterBuddy))
+	awakened_buddy = bud
+	awakened = TRUE //ho god ho fuck
+	slash_cooldown = 3
+	slash_damage = 50
+	melee_damage_lower = 30
+	melee_damage_upper = 40
+	ChangeMoveToDelayBy(-0.5)
+	maxHealth = maxHealth * 4 //5000 health, will get hurt by buddy's howl to make up for the high health
+	set_health(health * 4)
+	med_hud_set_health()
+	med_hud_set_status()
+	update_health_hud() //I have to do this shit manually because adjustHealth is just fucked when changing max HP
+	awakened_buddy.Awaken(src)
+
+/mob/living/simple_animal/hostile/abnormality/blue_shepherd/proc/UnregisterBuddy()
+	if(!awakened_buddy)
+		return
+	UnregisterSignal(awakened_buddy, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING))
+	melee_damage_lower = 10
+	melee_damage_upper = 15
+	slash_damage = 20
+	ChangeMoveToDelayBy(-0.8) //we severely nerf shepherd's damage but make him way faster on buddy's death, it's last one tango.
+	say("A wolf. A wolf. Why won't you believe me? it's right there. IT WAS RIGHT THERE!")
+	awakened_buddy = null

--- a/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
@@ -247,8 +247,7 @@
 				return
 			portal_cooldown = world.time + portal_cooldown_time
 			var/mob/living/simple_animal/hostile/der_freis_portal/P = new /mob/living/simple_animal/hostile/der_freis_portal(T)
-			portals.Add(P)
-			P.connected_abno = src
+			RegisterMob(P)
 			return
 		return
 	if (current_portal_index > 0)
@@ -353,9 +352,8 @@
 		var/turf/W = pick(portal_spawns)
 		LAZYREMOVE(portal_spawns, W)
 		new_portal = new /mob/living/simple_animal/hostile/der_freis_portal(get_turf(W))
-		new_portal.connected_abno = src
+		RegisterMob(new_portal)
 		new_portal.bullet_damage = bullet_damage
-		LAZYADD(portals, new_portal)
 	addtimer(CALLBACK(src, PROC_REF(PortalAssault)), 5 SECONDS)
 
 /mob/living/simple_animal/hostile/abnormality/der_freischutz/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
@@ -433,7 +431,7 @@
 	var/firer = P.firer
 	if(firer == src || LAZYFIND(portals, firer))
 		return
-	. = ..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/der_freischutz/proc/ContainedFireBullet()
 	var/list/targets = list()
@@ -530,16 +528,35 @@
 	return
 
 /mob/living/simple_animal/hostile/abnormality/der_freischutz/death()
-	if(portal_assault_timer)
-		deltimer(portal_assault_timer)
-	for(var/mob/living/simple_animal/hostile/der_freis_portal/P in portals)
-		P.death(FALSE)
 	density = FALSE
 	animate(src, alpha = 0, time = 10 SECONDS)
 	QDEL_IN(src, 10 SECONDS)
-	..()
+	return ..()
 
+/mob/living/simple_animal/hostile/abnormality/der_freischutz/Destroy()
+	if(portal_assault_timer)
+		deltimer(portal_assault_timer)
+	QDEL_LIST(portals)
+	return ..()
 
+/mob/living/simple_animal/hostile/abnormality/der_freischutz/proc/RegisterMob(mob/living/L)
+	RegisterSignal(L, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMob))
+	var/mob/living/simple_animal/hostile/der_freis_portal/P = L
+	P.master_tag = tag
+	portals += P
+
+/mob/living/simple_animal/hostile/abnormality/der_freischutz/proc/UnregisterMob(mob/living/L)
+	UnregisterSignal(L, list(COMSIG_PARENT_QDELETING))
+	portals -= L
+
+/mob/living/simple_animal/hostile/abnormality/der_freischutz/proc/UnregisterAll()
+	for(var/mob/living/L in portals)
+		UnregisterMob(L)
+	portals.Cut()
+
+/*------\
+|Portals|
+\------*/
 /mob/living/simple_animal/hostile/der_freis_portal
 	name = "magic portal"
 	desc = "A strange blue portal... You feel like you are being watched though it."
@@ -567,8 +584,8 @@
 	var/bullet_max_range = 100
 	var/bullet_damage = 150
 	var/assault_timer = 0
-
-	var/mob/living/simple_animal/hostile/abnormality/der_freischutz/connected_abno
+	//Checks mob tag to see if its our master.
+	var/master_tag
 	var/datum/component/orbiter/self_orbiter
 
 /mob/living/simple_animal/hostile/der_freis_portal/Initialize()
@@ -576,20 +593,23 @@
 	animate(src, alpha = 255, time = 6)
 	playsound(get_turf(src), 'sound/abnormalities/freischutz/portal.ogg', 100, 0, 10)
 
-/mob/living/simple_animal/hostile/der_freis_portal/death()
+/mob/living/simple_animal/hostile/der_freis_portal/Destroy()
 	if(assault_timer)
 		deltimer(assault_timer)
-	connected_abno.RemovePortal(src)
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/der_freis_portal/Move()
 	return FALSE
 
 /mob/living/simple_animal/hostile/der_freis_portal/bullet_act(obj/projectile/P)
 	var/firer = P.firer
-	if(firer == connected_abno || istype(firer, /mob/living/simple_animal/hostile/der_freis_portal))
+	if(istype(firer, /mob/living/simple_animal/hostile/der_freis_portal))
 		return
-	. = ..()
+	if(isliving(firer))
+		var/mob/living/shoota = firer
+		if(shoota.tag == master_tag)
+			return
+	return ..()
 
 /mob/living/simple_animal/hostile/der_freis_portal/AttackingTarget(atom/attacked_target)
 	return OpenFire(attacked_target)

--- a/code/modules/mob/living/simple_animal/abnormality/he/doomsday_calendar.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/doomsday_calendar.dm
@@ -100,16 +100,15 @@
 	density = FALSE
 	playsound(src, 'sound/abnormalities/doomsdaycalendar/Doomsday_Dead.ogg', 100, 1)
 	icon = 'ModularLobotomy/_Lobotomyicons/abno_cores/he.dmi'
-	for(var/mob/living/simple_animal/hostile/doomsday_doll/D in spawned_dolls) //delete the dolls when suppressed
-		D.death()
-		QDEL_IN(D, rand(1,5) SECONDS)
-		spawned_dolls -= D
 	animate(src, alpha = 0, time = 10 SECONDS)
 	QDEL_IN(src, 10 SECONDS)
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/doomsday_calendar/Destroy()
 	UnregisterSignal(SSdcs, COMSIG_GLOB_WORK_STARTED)
+	for(var/mob/living/simple_animal/hostile/doomsday_doll/D in spawned_dolls) //delete the dolls when suppressed
+		D.death()
+	UnregisterAll()
 	return ..()
 
 //*** Work Mechanics ***//
@@ -312,7 +311,7 @@
 			to_chat(user, span_warning("[src] rejects your offering!"))
 			return
 		if(istype(M ,/mob/living/simple_animal/hostile/doomsday_doll))
-			spawned_dolls -= M
+			UnregisterMob(M)
 		to_chat(user, span_nicegreen("[src] is sated by your offering!"))
 		M.gib()
 		is_fed = TRUE
@@ -320,6 +319,19 @@
 		pulse_damage -= 1
 		playsound(get_turf(src),'sound/effects/limbus_death.ogg', 50, 1)
 		AddModifier(/datum/dc_change/sacrificed)
+
+/mob/living/simple_animal/hostile/abnormality/doomsday_calendar/proc/RegisterMob(mob/living/L)
+	RegisterSignal(L, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMob))
+	spawned_dolls += L
+
+/mob/living/simple_animal/hostile/abnormality/doomsday_calendar/proc/UnregisterMob(mob/living/L)
+	UnregisterSignal(L, list(COMSIG_PARENT_QDELETING))
+	spawned_dolls -= L
+
+/mob/living/simple_animal/hostile/abnormality/doomsday_calendar/proc/UnregisterAll()
+	for(var/mob/living/L in spawned_dolls)
+		UnregisterMob(L)
+	spawned_dolls.Cut()
 
 //***Simple Mobs***//
 //clay dolls
@@ -362,4 +374,4 @@
 		return
 	for(var/i = doll_count, i < doll_count_maximum, i++)//This counts up
 		var /mob/living/simple_animal/hostile/doomsday_doll/D= new(get_turf(src))
-		spawned_dolls += D
+		RegisterMob(D)

--- a/code/modules/mob/living/simple_animal/abnormality/he/funeral.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/funeral.dm
@@ -231,7 +231,7 @@
 /mob/living/simple_animal/hostile/abnormality/funeral/proc/KillAnimation(mob/living/carbon/human/killed)
 	killed.apply_status_effect(/datum/status_effect/butterfly_death_anim)
 
-/mob/living/simple_animal/hostile/abnormality/funeral/proc/SpecialReset()
+/mob/living/simple_animal/hostile/abnormality/funeral/SpecialReset()
 	ChangeBehavior(behav = FUNERAL_IDLE)
 
 /mob/living/simple_animal/hostile/abnormality/funeral/proc/ChangeBehavior(behav = FUNERAL_IDLE)

--- a/code/modules/mob/living/simple_animal/abnormality/he/pinocchio.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pinocchio.dm
@@ -74,6 +74,12 @@
 		),
 	)
 
+/mob/living/simple_animal/hostile/abnormality/pinocchio/Destroy()
+	if(realboy)
+		realboy = null
+		UnregisterSignal(realboy, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING))
+	return ..()
+
 //Spawn
 /mob/living/simple_animal/hostile/abnormality/pinocchio/PostSpawn()
 	..()
@@ -133,7 +139,7 @@
 	animate(src, alpha = 0,pixel_x = 0, pixel_z = 16, time = 4 SECONDS)
 	SLEEP_CHECK_DEATH(1 SECONDS)
 	realboy = new (get_turf(src)) //Technically the breach version is a separate entity, requires a lot of tinkering but works.
-	RegisterSignal(realboy, COMSIG_LIVING_DEATH, PROC_REF(PuppetDeath))
+	RegisterSignal(realboy, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING), PROC_REF(PuppetDeath))
 	realboy.name = "Pinocchio the Liar"
 	realboy.real_name = "Pinocchio the Liar"
 	realboy.adjust_all_attribute_levels(100)
@@ -172,7 +178,7 @@
 	return TRUE
 
 /mob/living/simple_animal/hostile/abnormality/pinocchio/proc/PuppetDeath(gibbed) //we die when the puppet mob dies
-	UnregisterSignal(realboy, COMSIG_LIVING_DEATH)
+	UnregisterSignal(realboy, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING))
 	if(!QDELETED(realboy))
 		realboy.dropItemToGround(realboy.get_inactive_held_item())
 		realboy.dropItemToGround(realboy.get_active_held_item())

--- a/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
@@ -67,11 +67,23 @@
 	pet_bonus_emote = "smiles!"
 	var/suffocation_range = 10
 	var/workingflag = FALSE
+	//flavor petting effect
 	var/pet_count = 0
-	var/mob/living/carbon/human/petter
+	var/petter
 
+	//Special made coral crown for the person we love
 	var/obj/item/clothing/head/unrequited_crown/crown
+	//KILL
 	var/mob/living/carbon/human/love_target
+/*
+* Writing this so i can better understand
+* Mermaid makes the crown, the crown has our
+* love as a var. The crown checks if mermaid
+* perishes and removes itself as the mermaids crown
+* Signals:
+* Mermaid <-- crown --> Wearer
+* Mermaid --> Love Target
+*/
 
 	attack_action_types = list(
 		/datum/action/innate/change_icon_merm,
@@ -118,10 +130,10 @@
 	if(!crown)
 		GiveGift(user)
 		return
-	if(crown?.loved == user)
-		if(crown.loved)
-			datum_reference.qliphoth_change(2)
-			crown.love_cooldown = (world.time + crown.love_cooldown_time) //Reset the qliphoth reduction timer
+	var/mob/living/carbon/loved = crown.returnLoved()
+	if(loved)
+		datum_reference.qliphoth_change(2)
+		crown.love_cooldown = (world.time + crown.love_cooldown_time) //Reset the qliphoth reduction timer
 		return
 
 /mob/living/simple_animal/hostile/abnormality/pisc_mermaid/AttemptWork(mob/living/carbon/human/user, work_type)
@@ -148,11 +160,11 @@
 	icon_state = icon_living
 	pixel_y = -16
 	base_pixel_y = -16
-	if(!isnull(crown?.loved))
-		ChangeResistances(list(RED_DAMAGE = 0.3, WHITE_DAMAGE = 0.3, BLACK_DAMAGE = 0.3, PALE_DAMAGE = 0.3)) //others can still help but it's going to take a lot of damage
-		love_target = crown.loved
+	if(crown)
+		if(crown.loved)
+			RegisterLovedTrg(crown.loved)
 		qdel(crown)
-		love_target.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/unrequited_slowdown)
+	if(love_target)
 		var/turf/orgin = get_turf(love_target)
 		var/list/all_turfs = RANGE_TURFS(1, orgin) //if the target is somehow surrounded by nothing but walls it might fuck up her teleport but you're still drowning
 		for(var/turf/T in all_turfs)
@@ -163,28 +175,32 @@
 			forceMove(T)
 			GiveTarget(love_target) //ANON YOU HAVEN'T REPLIED TO MY TEXTS IN THE PAST 15 MINUTES DON'T YOU LOVE ME ANYMORE?
 			playsound(get_turf(src), 'sound/abnormalities/piscinemermaid/waterjump.ogg', 50, 1)
-		to_chat(love_target, span_userdanger("You can't breath!"))
-	if(crown)
-		qdel(crown)
 
 /mob/living/simple_animal/hostile/abnormality/pisc_mermaid/death(gibbed)
 	if(love_target)
-		love_target.remove_movespeed_modifier(/datum/movespeed_modifier/unrequited_slowdown)
 		say("[love_target.name]... You promised we'd be...")
-		love_target = null
-	if(crown)
-		qdel(crown) //this shouldn't be possible for a crown to exist after her breach but we might as well
 	density = FALSE
 	animate(src, alpha = 0, time = 10 SECONDS)
 	QDEL_IN(src, 10 SECONDS)
-	..()
+	return ..()
+
+/mob/living/simple_animal/hostile/abnormality/pisc_mermaid/Destroy()
+	if(love_target)
+		love_target.remove_movespeed_modifier(/datum/movespeed_modifier/unrequited_slowdown)
+		UnregisterLovedTrg()
+	if(crown)
+		QDEL_NULL(crown) //this shouldn't be possible for a crown to exist after her breach but we might as well
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/pisc_mermaid/Life()
 	. = ..()
+	if(crown)
+		crown.PartOfMe(src)
 	if(status_flags & GODMODE)
 		return
 	if(!.)
 		return
+
 	if(!love_target)
 		for(var/mob/living/carbon/human/H in oview(src, suffocation_range))
 			if(IsCombatMap())
@@ -218,67 +234,75 @@
 
 /mob/living/simple_animal/hostile/abnormality/pisc_mermaid/bullet_act(obj/projectile/P)
 	. = ..()
-	if(!crown?.loved)
+	if(!love_target)
 		return
-	if(P.firer == crown.loved)
+	if(P.firer == love_target)
 		adjustHealth(P.damage * 1.25)
 
 //We adjust the crown wearer success mod according to the counter.
 /mob/living/simple_animal/hostile/abnormality/pisc_mermaid/OnQliphothChange(mob/living/carbon/human/user, amount)
-	..()
-	if(crown?.loved)
+	. = ..()
+	if(crown)
+		var/mob/living/carbon/human/lover = crown.returnLoved()
+		if(!lover)
+			return
 		var/crown_mod = crown.success_mod
-		crown.loved.physiology.work_success_mod /= crown_mod //We take the mod off temporarily so we don't accidentally add or take off too much.
+		lover.physiology.work_success_mod /= crown_mod //We take the mod off temporarily so we don't accidentally add or take off too much.
 		if(amount)
 			crown_mod += amount*0.05 // If it increases, amount should be positive, if it decreases it should be negative.
 		crown_mod = clamp(crown_mod, 1, 1.15)
 		crown.success_mod = crown_mod
-		crown.loved.physiology.work_success_mod *= crown_mod
+		lover.physiology.work_success_mod *= crown_mod
 
 //Gives a crown thing when you get good work on her. Anyone can wear the crown, even those that didn't work on her and there can only be one gift at a time.
 /mob/living/simple_animal/hostile/abnormality/pisc_mermaid/proc/GiveGift(mob/living/carbon/human/user)
 	FluffSpeak("Do you like it? You do right? I worked so hard on it...")
 	addtimer(CALLBACK(src, PROC_REF(FluffSpeak), "If you don't like it then can you find someone who does? Bring them to me please."), 3 SECONDS)
-	var/obj/item/clothing/head/unrequited_crown/UC = new(get_turf(src))
-	crown = UC
-	crown.throw_at(user, 4, 1, src, spin = FALSE, gentle = TRUE, quickstart = FALSE)
+	var/obj/item/clothing/head/unrequited_crown/UC = MakeCrown()
+	UC.throw_at(user, 4, 1, src, spin = FALSE, gentle = TRUE, quickstart = FALSE)
 	playsound(get_turf(src), 'sound/abnormalities/piscinemermaid/bigsplash.ogg', 50, 1)
-	UC.mermaid = src
+
+/mob/living/simple_animal/hostile/abnormality/pisc_mermaid/proc/MakeCrown()
+	var/obj/item/clothing/head/unrequited_crown/UC = new(get_turf(src))
+	UC.RegisterMermaid(src)
+	return UC
 
 //this is basically just teddy bear hugging but you're NOT buckled and the death is much much slower, you can technically survive it if a clerk is giving CPR... maybe
-/mob/living/simple_animal/hostile/abnormality/pisc_mermaid/proc/ExcessiveLove()
+/mob/living/simple_animal/hostile/abnormality/pisc_mermaid/proc/ExcessiveLove(mob/living/carbon/victem)
+	if(!victem)
+		return
 	if(!petter) // safety check
 		pet_count = 0
 		return
 	// here, we talk to them whilst they are dying, just a tiny bit
-	to_chat(petter, span_userdanger("Something is pulling you into the water!"))
+	to_chat(victem, span_userdanger("Something is pulling you into the water!"))
 	FluffSpeak("I'm really sorry, but it's fine, right? Isn't it wonderful to be loved?")
 	addtimer(CALLBACK(src, PROC_REF(FluffSpeak), "I am merely in love, I am merely wanting salvation."), 5 SECONDS)
 	addtimer(CALLBACK(src, PROC_REF(FluffSpeak), "You can breath underwater right?"), 30 SECONDS)
 	// here, we murder them whilst we are talking
-	petter.Stun(41 SECONDS)
-	petter.move_resist = MOVE_FORCE_VERY_STRONG
-	petter.pull_force = MOVE_FORCE_VERY_STRONG
+	victem.Stun(41 SECONDS)
+	victem.move_resist = MOVE_FORCE_VERY_STRONG
+	victem.pull_force = MOVE_FORCE_VERY_STRONG
 	for(var/times_strangled in 1 to 10)
-		if(petter.stat == DEAD)
+		if(victem.stat == DEAD)
 			break
-		petter.losebreath += (HUMAN_MEDIUM_OXYLOSS_RATE * times_strangled) // 440 oxydamage total.
+		victem.losebreath += (HUMAN_MEDIUM_OXYLOSS_RATE * times_strangled) // 440 oxydamage total.
 		times_strangled++
 		SLEEP_CHECK_DEATH(4 SECONDS)
-	petter.move_resist = MOVE_RESIST_DEFAULT
-	petter.pull_force = PULL_FORCE_DEFAULT
+	victem.move_resist = MOVE_RESIST_DEFAULT
+	victem.pull_force = PULL_FORCE_DEFAULT
 
 //This is a dating sim now fuck you
 /mob/living/simple_animal/hostile/abnormality/pisc_mermaid/funpet(mob/living/carbon/human/current_petter)
 	..()
 	if(!(status_flags & GODMODE))
 		return
-	if(current_petter != petter)
+	if(current_petter.tag != petter)
 		response_help_continuous = "pets"
 		response_help_simple = "pet"
 		pet_count = 0
 	pet_count++
-	petter = current_petter
+	petter = current_petter.tag
 	switch(pet_count)
 		if(5)
 			FluffSpeak("You won't leave right? You love me right?")
@@ -300,6 +324,27 @@
 	if(status_flags & GODMODE)
 		say(sentence)
 
+/mob/living/simple_animal/hostile/abnormality/pisc_mermaid/proc/Scorned(mob/living/carbon/human/H)
+	if(!love_target && H)
+		RegisterLovedTrg(H)
+	if(status_flags & GODMODE)
+		BreachEffect()
+
+/mob/living/simple_animal/hostile/abnormality/pisc_mermaid/proc/RegisterLovedTrg(mob/living/L)
+	if(!L || love_target)
+		return
+	RegisterSignal(L, list(COMSIG_PARENT_QDELETING, COMSIG_LIVING_DEATH), PROC_REF(UnregisterLovedTrg))
+	love_target = L
+	ChangeResistances(list(RED_DAMAGE = 0.3, WHITE_DAMAGE = 0.3, BLACK_DAMAGE = 0.3, PALE_DAMAGE = 0.3)) //others can still help but it's going to take a lot of damage
+	love_target.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/unrequited_slowdown)
+	to_chat(love_target, span_userdanger("You can't breath!"))
+
+/mob/living/simple_animal/hostile/abnormality/pisc_mermaid/proc/UnregisterLovedTrg()
+	if(!love_target)
+		return
+	UnregisterSignal(love_target, list(COMSIG_PARENT_QDELETING, COMSIG_LIVING_DEATH))
+	love_target = null
+
 //The crown gives 15% bonus work chance but you need to babysit mermaid constantly, you'll also get absolutely fucked by their breach if it happens at a bad time.
 //The work chance is also affected by mermaid's counter, so +10% chance at 2 counter, +5% at 1.
 //The crown destroys itself whenever it's taken off the headslot and automatically triggers mermaid's breach
@@ -309,6 +354,8 @@
 	icon_state = "unrequited_gift"
 	icon = 'icons/obj/clothing/ego_gear/head.dmi'
 	worn_icon = 'icons/mob/clothing/ego_gear/head.dmi'
+	//To prevent calling the qdel or breach multiple times.
+	var/breach_triggered = FALSE
 	var/success_mod = 1.15
 	var/love_cooldown
 	var/love_cooldown_time = 3.3 MINUTES //It takes around 10 minutes for mermaid to breach if left unchecked
@@ -318,32 +365,78 @@
 /obj/item/clothing/head/unrequited_crown/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
 	if(slot != ITEM_SLOT_HEAD)
-		if(loved)
-			STOP_PROCESSING(SSobj, src)
-			mermaid.datum_reference.qliphoth_change(-3)
-			mermaid.BreachEffect()
+		if(loved && mermaid && !breach_triggered)
+			mermaid.Scorned(loved)
+			breach_triggered = TRUE
 			qdel(src)
 		return
 	if(ishuman(user))
-		START_PROCESSING(SSobj, src)
 		mermaid.datum_reference.qliphoth_change(3)
 		user.physiology.work_success_mod *= success_mod
-		loved = user //Because, you know? You know? I'm doing it for you after all~
-		love_cooldown = world.time + love_cooldown_time
-
-/obj/item/clothing/head/unrequited_crown/process()
-	if((love_cooldown < world.time) && loved && mermaid.workingflag != TRUE)
-		var/obj/item/clothing/suit/armor/ego_gear/realization/forever/Z = loved.get_item_by_slot(ITEM_SLOT_OCLOTHING)
-		if(!istype(Z))
-			mermaid.datum_reference.qliphoth_change(-1)
-			new /obj/effect/temp_visual/heart(get_turf(loved))
-			to_chat(loved, span_warning("You feel as though you're forgetting someone..."))
+		RegisterWearer(user)
 		love_cooldown = world.time + love_cooldown_time
 
 /obj/item/clothing/head/unrequited_crown/Destroy()
 	if(loved)
 		loved.physiology.work_success_mod /= success_mod
+	UnregisterAll()
 	return ..()
+
+/obj/item/clothing/head/unrequited_crown/proc/RegisterMermaid(atom/A)
+	if(!A || mermaid)
+		return
+	RegisterSignal(A, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMermaid))
+	mermaid = A
+	mermaid.crown = src
+
+/obj/item/clothing/head/unrequited_crown/proc/UnregisterMermaid()
+	if(!mermaid)
+		return
+	UnregisterSignal(mermaid, list(COMSIG_PARENT_QDELETING))
+	mermaid.crown = null
+	mermaid = null
+	qdel(src)
+
+/obj/item/clothing/head/unrequited_crown/proc/RegisterWearer(atom/A)
+	if(loved || !A)
+		return
+	RegisterSignal(A, list(COMSIG_PARENT_QDELETING, COMSIG_LIVING_DEATH), PROC_REF(UnregisterWearer))
+	loved = A
+
+/obj/item/clothing/head/unrequited_crown/proc/UnregisterWearer()
+	if(!loved)
+		return
+	if(mermaid && !breach_triggered)
+		//If this occurs due to the wearer dying then breach normally
+		mermaid.datum_reference.qliphoth_change(-3)
+		if(mermaid)
+			mermaid.BreachEffect()
+		breach_triggered = TRUE
+	loved = null
+	qdel(src)
+
+/obj/item/clothing/head/unrequited_crown/proc/UnregisterAll()
+	if(loved)
+		UnregisterSignal(loved, list(COMSIG_PARENT_QDELETING, COMSIG_LIVING_DEATH))
+	if(mermaid)
+		UnregisterSignal(mermaid, list(COMSIG_PARENT_QDELETING))
+		mermaid.crown = null
+	loved = null
+	mermaid = null
+
+/obj/item/clothing/head/unrequited_crown/proc/returnLoved()
+	return loved
+
+//You need me as much as i need you
+/obj/item/clothing/head/unrequited_crown/proc/PartOfMe()
+	if((love_cooldown < world.time) && loved)
+		if(mermaid)
+			if(mermaid.workingflag == TRUE)
+				return
+			mermaid.datum_reference.qliphoth_change(-1)
+		new /obj/effect/temp_visual/heart(get_turf(src))
+		to_chat(loved, span_warning("You feel as though you're forgetting someone..."))
+		love_cooldown = world.time + love_cooldown_time
 
 //Mermaid bath water
 /obj/effect/mermaid_water

--- a/code/modules/mob/living/simple_animal/abnormality/he/puss_in_boots.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/puss_in_boots.dm
@@ -79,16 +79,21 @@
 	toggle_message = span_colossus("You will not perform a finisher anymore.")
 	button_icon_toggle_deactivated = "puss_toggle0"
 
+/mob/living/simple_animal/hostile/abnormality/puss_in_boots/Destroy()
+	UnregisterAll()
+	return ..()
+
 //Init stuff
 /mob/living/simple_animal/hostile/abnormality/puss_in_boots/Initialize()
 	. = ..()
 	if(IsCombatMap())
 		friendly = FALSE
 		return  // There are no friends in war.
+	//I dont understannd the purpose of this check. -IP
 	for(var/mob/living/carbon/human/potential_user in GLOB.player_list)
 		if(!potential_user.has_status_effect(STATUS_EFFECT_CHOSEN))
 			continue
-		blessed_human = potential_user
+		Blessing(potential_user)
 		friendly = TRUE
 		return
 
@@ -100,33 +105,32 @@
 		if(get_user_level(user) >= 2)
 			say("I cannot teach you anything, human.")
 			return
-		blessed_human = user
 		Blessing(user)
 		playsound(get_turf(user), 'sound/abnormalities/pussinboots/gatoblessing.ogg', 50, 0, 2)
 		friendly = TRUE
 		say("At last, someone worthy!")
 
 /mob/living/simple_animal/hostile/abnormality/puss_in_boots/proc/Blessing(mob/living/carbon/human/user)
-	var/datum/status_effect/chosen/status_holder = blessed_human.has_status_effect(/datum/status_effect/chosen)
-	if(status_holder)
-		return
+	blessed_human = user
 	user.apply_status_effect(STATUS_EFFECT_CHOSEN)
-	RegisterSignal(user, COMSIG_LIVING_DEATH, PROC_REF(BlessedDeath))
-	RegisterSignal(user, COMSIG_HUMAN_INSANE, PROC_REF(BlessedDeath))
+	RegisterSignal(user, list(COMSIG_LIVING_DEATH,COMSIG_HUMAN_INSANE), PROC_REF(BlessedDeath))
 	RegisterSignal(user, COMSIG_WORK_STARTED, PROC_REF(OnWorkStart))
 	RegisterSignal(SSdcs, COMSIG_GLOB_ABNORMALITY_BREACH, PROC_REF(OnAbnoBreach))
 
 /mob/living/simple_animal/hostile/abnormality/puss_in_boots/proc/BlessedDeath(datum/source, gibbed)
 	SIGNAL_HANDLER
 	blessed_human.remove_status_effect(STATUS_EFFECT_CHOSEN)
-	UnregisterSignal(blessed_human, COMSIG_LIVING_DEATH)
-	UnregisterSignal(blessed_human, COMSIG_HUMAN_INSANE)
-	UnregisterSignal(blessed_human, COMSIG_WORK_STARTED)
+	UnregisterSignal(blessed_human, list(COMSIG_LIVING_DEATH,COMSIG_HUMAN_INSANE,COMSIG_WORK_STARTED))
 	friendly = FALSE
 	GoToFriend()
 	BreachEffect()
 	blessed_human = null
 	return TRUE
+
+/mob/living/simple_animal/hostile/abnormality/puss_in_boots/proc/UnregisterAll()
+	UnregisterSignal(SSdcs, COMSIG_GLOB_ABNORMALITY_BREACH)
+	UnregisterSignal(blessed_human, list(COMSIG_LIVING_DEATH,COMSIG_HUMAN_INSANE,COMSIG_WORK_STARTED))
+	blessed_human = null
 
 /mob/living/simple_animal/hostile/abnormality/puss_in_boots/proc/OnWorkStart(datum/source, datum/abnormality/abno_reference, mob/living/carbon/human/user, work_type)
 	SIGNAL_HANDLER
@@ -338,8 +342,7 @@
 	alert_type = null
 	var/attribute_bonus = 0
 	tick_interval = 600 //stats update every 60s
-	var/obj/item/ego_weapon/lance/chosen_arms = null
-
+	var/obj/item/ego_weapon/lance/famiglia/chosen_arms
 /datum/status_effect/chosen/on_apply()
 	if(!ishuman(owner))
 		return
@@ -351,7 +354,8 @@
 	user.physiology.white_mod *= 0.8
 	user.physiology.black_mod *= 0.8
 	user.physiology.pale_mod *= 0.8
-	chosen_arms = new /obj/item/ego_weapon/lance/famiglia(get_turf(user))
+	var/obj/item/ego_weapon/lance/famiglia/new_weapon = new(get_turf(user))
+	RegisterArms(new_weapon)
 	return ..()
 
 /datum/status_effect/chosen/on_remove()
@@ -365,7 +369,9 @@
 	user.physiology.pale_mod /= 0.8
 	for(var/attribute in user.attributes)
 		user.adjust_attribute_buff(attribute, -attribute_bonus)
-	QDEL_IN(chosen_arms, 30)
+	if(chosen_arms)
+		QDEL_IN(chosen_arms, 30)
+		UnregisterArms()
 	return ..()
 
 /datum/status_effect/chosen/tick()
@@ -405,5 +411,17 @@
 		user.adjust_attribute_buff(attribute, (new_bonus - attribute_bonus)) //should keep the bonus dynamically updated
 	attribute_bonus = new_bonus
 	return
+
+/datum/status_effect/chosen/proc/RegisterArms(atom/A)
+	if(!A)
+		return
+	RegisterSignal(A, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterArms))
+	chosen_arms = A
+
+/datum/status_effect/chosen/proc/UnregisterArms()
+	if(!chosen_arms)
+		return
+	UnregisterSignal(chosen_arms, list(COMSIG_PARENT_QDELETING))
+	chosen_arms = null
 
 #undef STATUS_EFFECT_CHOSEN

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
@@ -63,8 +63,6 @@
 
 	///The blue smocked shepherd linked to red buddy
 	var/datum/abnormality/master
-	//the living shepherd it is currently fighting with
-	var/mob/living/simple_animal/hostile/abnormality/blue_shepherd/awakened_master
 	///How "hurt" buddy is, which affects his work damage
 	var/suffering = 0
 	///the timer id linked to shepherd's lie
@@ -98,9 +96,14 @@
 	if(!master)
 		RegisterSignal(SSdcs, COMSIG_GLOB_ABNORMALITY_SPAWN, PROC_REF(OnAbnoSpawn)) //if shepherd isn't here yet, buddy will wait for him like a good dog
 
+/mob/living/simple_animal/hostile/abnormality/red_buddy/Destroy()
+	if(!awakened)
+		UnregisterSignal(SSdcs, COMSIG_GLOB_ABNORMALITY_SPAWN)
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/red_buddy/proc/OnAbnoSpawn(datum/source, datum/abnormality/abno)
 	SIGNAL_HANDLER
-	if(abno.name == "Blue Smocked Shepherd")
+	if(abno.name == "Blue Smocked Shepherd" && !awakened)
 		master = abno
 		UnregisterSignal(SSdcs, COMSIG_GLOB_ABNORMALITY_SPAWN)
 
@@ -163,46 +166,24 @@
 
 /mob/living/simple_animal/hostile/abnormality/red_buddy/Life()
 	. = ..()
-	if(status_flags & GODMODE)
+	if(status_flags & GODMODE || !.)
 		return
 	if(awoo_cooldown <= world.time && !awakened)
 		Awoo()
-	var/mob/living/master_abno = master?.current
-	if(!master_abno)
-		return
-	if(master_abno.status_flags & GODMODE) //no reason to look for shepherd if he's not out
+
+	if(!master || awakened)
 		return
 
-	if(can_see(src, master_abno, 10) && !awakened)
-		maxHealth = maxHealth * 3 //6600 HP, a LOT but gets hurt by shepherd's slash a metric ton to counter act it
-		set_health(health * 3)
-		awakened = TRUE
-		awakened_master = master_abno
-		var/turf/orgin = get_turf(awakened_master)
-		var/list/all_turfs = RANGE_TURFS(1, orgin)
-		var/turf/open/Y = pick(all_turfs - orgin)
-		forceMove(Y) //the lazy solution that forces buddy to get pulled by shepherd, ideally this should only happen once.
-		awakened_master.start_pulling(src)
-		awakened_master.awakened_buddy = src
-		med_hud_set_health()
-		med_hud_set_status()
-		update_health_hud()
-		awoo_cooldown_time = 15 SECONDS //awoo now only triggers when buddy takes 10% of their health instead of every X seconds but still has a min cooldown
-		awoo_cooldown = 0 //resets the awoo cooldown too
-		melee_damage_lower = 60
-		melee_damage_upper = 80
-		ChangeMoveToDelayBy(-1) //this doesn't matter as much as you'd think because he can't move before shepherd
-		vision_range = 3
-		aggro_vision_range = 3 //red buddy should only move for things it can actually reach, in this case somewhat within shepherd's reach
-		can_patrol = FALSE //just in case
 
 ///we're doing a bunch of checks for diagonal movement because it acts real weird with forced dragging
 /mob/living/simple_animal/hostile/abnormality/red_buddy/Move(atom/newloc)
-	if(!awakened_master || (moving_diagonally && !target))
-		return ..()
-
-	if(!awakened_master.Adjacent(newloc) && !awakened_master.moving_diagonally)
-		return FALSE
+	if(!awakened && master)
+		if((moving_diagonally && !target))
+			return ..()
+		var/mob/living/simple_animal/hostile/abnormality/blue_shepherd/awakened_master = master.GetCurrent()
+		if(awakened_master)
+			if(!awakened_master.Adjacent(newloc) && !awakened_master.moving_diagonally && !(awakened_master.status_flags & GODMODE))
+				return FALSE
 
 	if(mauling)
 		return FALSE
@@ -216,23 +197,27 @@
 ///basically a stronger fragment song that hurts red buddy, it's slower hitting than fragment however
 /mob/living/simple_animal/hostile/abnormality/red_buddy/proc/Awoo(abused = FALSE)
 	awoo_cooldown = world.time + awoo_cooldown_time
-	var/mob/living/simple_animal/hostile/abnormality/blue_shepherd/shepherd = master?.current
-	if(shepherd?.status_flags & GODMODE)
-		shepherd.hired = TRUE //it's more likely for them to run into each other this way
-		master.qliphoth_change(-1) //shepherd doesn't breach instantly but it's only a matter of time
+	if(master)
+		var/mob/living/simple_animal/hostile/abnormality/blue_shepherd/shepherd = master.GetCurrent()
+		if(shepherd?.status_flags & GODMODE)
+			shepherd.hired = TRUE //it's more likely for them to run into each other this way
+			master.qliphoth_change(-1) //shepherd doesn't breach instantly but it's only a matter of time
 	playsound(src, 'sound/abnormalities/redbuddy/redbuddy_howl.ogg', 100, FALSE, 8)
 	for(var/i = 1 to 4)
-		addtimer(CALLBACK(src, PROC_REF(AwooDamage), abused), 1 SECONDS * (i))
+		addtimer(CALLBACK(src, PROC_REF(AwooDamage), abused), 1 SECONDS * (i), TIMER_STOPPABLE)
 
 /mob/living/simple_animal/hostile/abnormality/red_buddy/proc/AwooDamage(abused = FALSE)
+	if(stat == DEAD)
+		return
 	var/heard_awoo = FALSE //red buddy is only hurt by his howl if someone hears it
 	for(var/mob/living/L in view(7, src))
-		if(faction_check_mob(L, FALSE) && L != awakened_master) //it can't hurt other pink midnight abnos but can still hurt his master
+		if(faction_check_mob(L, FALSE) && !istype(L, /mob/living/simple_animal/hostile/abnormality/blue_shepherd)) //it can't hurt other pink midnight abnos but can still hurt his master
 			continue
 		if(L.stat == DEAD)
 			continue
-		if(L == awakened_master)
-			awakened_master.adjustHealth(150) //800 damage in total, takes approximatively 8 howls to take shepherd down
+		if(istype(L, /mob/living/simple_animal/hostile/abnormality/blue_shepherd))
+			var/mob/living/simple_animal/hostile/abnormality/shep = L
+			shep.adjustHealth(150) //800 damage in total, takes approximatively 8 howls to take shepherd down
 		L.deal_damage(10, WHITE_DAMAGE, src, attack_type = (ATTACK_TYPE_SPECIAL))
 		heard_awoo = TRUE
 	if(health >= 75 && heard_awoo && !abused)
@@ -240,7 +225,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/red_buddy/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
 	. = ..()
-	if(!awakened_master)
+	if(!awakened)
 		return
 	accumulated_damage += amount
 
@@ -259,19 +244,11 @@
 
 
 /mob/living/simple_animal/hostile/abnormality/red_buddy/death(gibbed)
-	if(awakened_master)
-		awakened_master.melee_damage_lower = 10
-		awakened_master.melee_damage_upper = 15
-		awakened_master.slash_damage = 20
-		awakened_master.ChangeMoveToDelayBy(-0.8) //we severely nerf shepherd's damage but make him way faster on buddy's death, it's last one tango.
-		awakened_master.say("A wolf. A wolf. Why won't you believe me? it's right there. IT WAS RIGHT THERE!")
-	awakened_master = null
 	density = FALSE
 	animate(src, alpha = 0, time = 10 SECONDS)
 	QDEL_IN(src, 10 SECONDS)
 	UnregisterSignal(SSdcs, COMSIG_GLOB_ABNORMALITY_SPAWN)
-	..()
-
+	return ..()
 
 //Red Buddy Attacks
 /mob/living/simple_animal/hostile/abnormality/red_buddy/AttackingTarget()
@@ -283,8 +260,7 @@
 	if(prob(30))
 		startMaul()
 		return
-	. = ..()
-
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/red_buddy/proc/startMaul()
 	if(maulready)
@@ -324,6 +300,33 @@
 	SLEEP_CHECK_DEATH(10)
 
 /mob/living/simple_animal/hostile/abnormality/red_buddy/bullet_act(obj/projectile/P)
-	..()
+	. = ..()
 	if(P.firer == target)
 		startMaul()
+
+/mob/living/simple_animal/hostile/abnormality/red_buddy/proc/Awaken(mob/living/simple_animal/hostile/abnormality/blue_shepherd/awakened_master)
+	if(awakened)
+		return FALSE
+
+	maxHealth = maxHealth * 3 //6600 HP, a LOT but gets hurt by shepherd's slash a metric ton to counter act it
+	set_health(health * 3)
+	awakened = TRUE
+	if(awakened_master)
+		var/turf/orgin = get_turf(awakened_master)
+		var/list/all_turfs = RANGE_TURFS(1, orgin) - orgin
+		if(LAZYLEN(all_turfs))
+			var/turf/open/Y = pick(all_turfs - orgin)
+			forceMove(Y) //the lazy solution that forces buddy to get pulled by shepherd, ideally this should only happen once.
+			awakened_master.start_pulling(src)
+	med_hud_set_health()
+	med_hud_set_status()
+	update_health_hud()
+	awoo_cooldown_time = 15 SECONDS //awoo now only triggers when buddy takes 10% of their health instead of every X seconds but still has a min cooldown
+	awoo_cooldown = 0 //resets the awoo cooldown too
+	melee_damage_lower = 60
+	melee_damage_upper = 80
+	ChangeMoveToDelayBy(-1) //this doesn't matter as much as you'd think because he can't move before shepherd
+	vision_range = 3
+	aggro_vision_range = 3 //red buddy should only move for things it can actually reach, in this case somewhat within shepherd's reach
+	can_patrol = FALSE //just in case
+	return TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_shoes.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_shoes.dm
@@ -50,7 +50,7 @@
 	)
 
 	var/mutable_appearance/breach_icon
-	var/mob/living/possessee
+	var/mob/living/carbon/human/possessee
 	var/list/death_lines = list(
 		"Give them back to me!",
 		"Don't take them away from me...",
@@ -84,24 +84,25 @@
 	if(possessee)
 		death_message = FALSE
 		del_on_death = TRUE
-	density = FALSE
-	for(var/obj/O in src)
-		O.forceMove(loc)
-	if(possessee)//hopefully this refers to the specific individual
-		var/mob/living/carbon/human/H = possessee
-		possessee.status_flags &= ~GODMODE
-		possessee.forceMove(loc)
-		possessee = null
-		H.adjustBruteLoss(500)//the host dies
-	for(var/mob/living/carbon/human/H in GLOB.mob_living_list)//stops possessing people, prevents runtimes. Panicked players are ghosted so use mob_living_list
-		UnPossess(H)
+
 	say(pick(death_lines))
 	alpha = 255
+	density = FALSE
 	QDEL_IN(src, 10 SECONDS)
-	QDEL_NULL(soundloop)
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/red_shoes/Destroy()
+	var/turf/dumpsite = get_turf(src)
+	for(var/obj/O in src)
+		O.forceMove(dumpsite)
+	if(possessee)//hopefully this refers to the specific individual
+		var/mob/living/carbon/human/H = possessee
+		possessee.status_flags &= ~GODMODE
+		possessee.forceMove(dumpsite)
+		UnregisterPossessed()
+		H.adjustBruteLoss(500)//the host dies
+	for(var/mob/living/carbon/human/H in GLOB.mob_living_list)//stops possessing people, prevents runtimes. Panicked players are ghosted so use mob_living_list
+		UnPossess(H)
 	if(soundloop)
 		QDEL_NULL(soundloop)
 	return ..()
@@ -172,7 +173,7 @@
 		return
 	if(possessee)
 		return
-	possessee = user
+	RegisterPossessed(user)
 	var/mob/living/carbon/human/H = user
 	if(ishuman(H) && (H.sanity_lost))
 		var/obj/item/clothing/suit/armor/ego_gear/EQ = H.get_item_by_slot(ITEM_SLOT_OCLOTHING)//copies all resistances from worn E.G.O
@@ -240,6 +241,19 @@
 	playsound(src, 'sound/abnormalities/redshoes/RedShoes_Kill.ogg', 100, 1)
 	l_foot?.dismember()
 	r_foot?.dismember()
+
+//Signals
+/mob/living/simple_animal/hostile/abnormality/red_shoes/proc/RegisterPossessed(atom/A)
+	if(!A || !ishuman(A))
+		return
+	RegisterSignal(A, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterPossessed))
+	possessee = A
+
+/mob/living/simple_animal/hostile/abnormality/red_shoes/proc/UnregisterPossessed()
+	if(!possessee)
+		return
+	UnregisterSignal(possessee, list(COMSIG_PARENT_QDELETING))
+	possessee = null
 
 //***Debuff Definition***/
 //Possession

--- a/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
@@ -113,8 +113,7 @@
 	to_chat(attacker, span_userdanger("[src] counter attacks!"))
 	if(attacker.has_status_effect(/datum/status_effect/stay_home) || !ishuman(attacker) || stat == DEAD)
 		return
-	attacker.apply_status_effect(/datum/status_effect/stay_home)
-	agent_friends += attacker
+	agent_friends += attacker.apply_status_effect(/datum/status_effect/stay_home)
 
 //She creates the road as she walks, the actual path is predetermined in advance, but the road has a bunch of effects.
 /mob/living/simple_animal/hostile/abnormality/road_home/proc/CreateRoad()
@@ -152,13 +151,13 @@
 		addtimer(CALLBACK(src, PROC_REF(FlipAttack)), 2 SECONDS)
 		return
 
-/mob/living/simple_animal/hostile/abnormality/road_home/Destroy(gibbed)
-	for(var/obj/effect/golden_road/GR in brick_list)
-		brick_list -= GR
-		qdel(GR)
-	qdel(house)
-	for(var/mob/living/carbon/human/H in agent_friends)
-		H.remove_status_effect(/datum/status_effect/stay_home)
+/mob/living/simple_animal/hostile/abnormality/road_home/Destroy()
+	move_timer_id = null
+	house_path = null
+	QDEL_LIST(brick_list)
+	if(house)
+		QDEL_NULL(house)
+	QDEL_LIST(agent_friends)
 	agent_friends = null
 	return ..()
 
@@ -171,8 +170,7 @@
 	for(var/mob/living/L in view(15, src))
 		if(!ishuman(L) || L.stat == DEAD || L.has_status_effect(/datum/status_effect/stay_home))
 			continue
-		L.apply_status_effect(/datum/status_effect/stay_home)
-		agent_friends += L
+		agent_friends += L.apply_status_effect(/datum/status_effect/stay_home)
 
 /mob/living/simple_animal/hostile/abnormality/road_home/Move(atom/newloc)
 	if(!voluntary_movement && !ckey)
@@ -269,7 +267,7 @@
 		house.forceMove(house_turf)
 	house.pixel_z = 128
 	house.alpha = 0
-	house.road_home_mob = src
+	house.RegisterMaster(src)
 
 	addtimer(CALLBACK(house, TYPE_PROC_REF(/obj/road_house, FallDown)), 3 SECONDS)
 	road_finished = FALSE
@@ -285,15 +283,8 @@
 
 //Bring everyone on the golden tiles back to road home. turn them insane if they aren't already. Also destroys all gold tiles if there are any.
 /mob/living/simple_animal/hostile/abnormality/road_home/proc/BringInsane()
-	for(var/mob/living/carbon/human/H in agent_friends)
-		H.adjustSanityLoss(1000)
-		if(H.sanity_lost)
-			QDEL_NULL(H.ai_controller)
-			H.forceMove(get_turf(src))
-			H.ai_controller = /datum/ai_controller/insane/road_home
-			H.InitializeAIController()
-			var/datum/ai_controller/insane/road_home/RHI = H.ai_controller
-			RHI.road_home_mob = src
+	for(var/datum/status_effect/stay_home/H in agent_friends)
+		H.WayBackHome(src)
 
 //The house that road home tries to go back to. It falls down like a purple noon and serves as a "goal" to the road home.
 /obj/road_house
@@ -311,11 +302,18 @@
 	var/fall_speed = 3 SECONDS
 	var/mob/living/simple_animal/hostile/abnormality/road_home/road_home_mob
 
+/obj/road_house/Destroy()
+	UnregisterMaster()
+	return ..()
+
 //Repurposed purple noon code, except it deals white damage in an AOE and red damage if you stand on the ONE TILE it's landing on.
 /obj/road_house/proc/FallDown()
 	animate(src, pixel_z = 0, alpha = 255, time = fall_speed)
 	playsound(src, 'sound/abnormalities/roadhome/Cartoon_Falling_Sound_Effect.ogg', 100, FALSE, 8, falloff_exponent = 1.25)
 	sleep(fall_speed)
+	if(!road_home_mob)
+		qdel(src)
+		return
 	if(fall_speed > 0.5 SECONDS) //it falls very slowly at first but it can get very fast if you let her reach home too many times.
 		fall_speed -= 0.5 SECONDS //home falls faster and faster
 
@@ -347,8 +345,20 @@
 				H.InitializeAIController()
 				var/datum/ai_controller/insane/road_home/RHI = H.ai_controller
 				RHI.road_home_mob = road_home_mob
-				L.apply_status_effect(/datum/status_effect/stay_home)
-				road_home_mob.agent_friends += H
+				road_home_mob.agent_friends += L.apply_status_effect(/datum/status_effect/stay_home)
+
+//Signals
+/obj/road_house/proc/RegisterMaster(atom/A)
+	if(!A || !ishuman(A))
+		return
+	RegisterSignal(A, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMaster))
+	road_home_mob = A
+
+/obj/road_house/proc/UnregisterMaster()
+	if(!road_home_mob)
+		return
+	UnregisterSignal(road_home_mob, list(COMSIG_PARENT_QDELETING))
+	road_home_mob = null
 
 //Not an actual floor, but an effect you put on top of it. The gold road is periodically being created by the road home.
 /obj/effect/golden_road
@@ -427,3 +437,17 @@
 /datum/status_effect/stay_home/on_remove()
 	UnregisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE)
 	return ..()
+
+/datum/status_effect/stay_home/proc/WayBackHome(mob/living/invoker)
+	var/mob/living/carbon/human/H = owner
+	if(!owner)
+		qdel(src)
+		return
+	H.adjustSanityLoss(1000)
+	if(H.sanity_lost)
+		QDEL_NULL(H.ai_controller)
+		H.forceMove(get_turf(invoker))
+		H.ai_controller = /datum/ai_controller/insane/road_home
+		H.InitializeAIController()
+		var/datum/ai_controller/insane/road_home/RHI = H.ai_controller
+		RHI.road_home_mob = invoker

--- a/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
@@ -71,8 +71,6 @@
 	var/wait_for_friend = FALSE
 	/// The abnormality scaredy cat follows on breach
 	var/mob/living/simple_animal/hostile/abnormality/friend
-	/// The abnormality cat will prioritize as a friend on breach
-	var/mob/living/simple_animal/hostile/abnormality/priority_friend
 	/// How much time needs to pass before scaredy cat check if his friend is in view
 	var/protect_cooldown_time = 5 SECONDS
 	var/protect_cooldown
@@ -102,19 +100,19 @@
 		datum_reference.qliphoth_change(-1)
 	return
 
-
 /mob/living/simple_animal/hostile/abnormality/scaredy_cat/BreachEffect(mob/living/carbon/human/user, breach_type)
 	protect_cooldown = world.time + protect_cooldown_time //to avoid him teleporting twice for no reason on breach
-	if(priority_friend) //if an oz abno escape they take absolute priority
-		ProtectFriend(priority_friend)
-		priority_friend = null
-		return ..()
 	var/list/breached_abno = list()
 	for(var/datum/abnormality/A in SSlobotomy_corp.all_abnormality_datums)
-		if(!A.current)
+		var/mob/living/simple_animal/hostile/abnormality/abno = A.GetCurrent()
+		if(!abno)
 			continue
-		if(!(A.current.status_flags & GODMODE) && A != datum_reference)
+		if(!(abno.status_flags & GODMODE) && abno != src)
 			breached_abno += A.current
+			//Just you and me.
+			if(LAZYFIND(prefered_abno_list, abno.type))
+				breached_abno = list(A)
+				break
 	if(LAZYLEN(breached_abno))
 		ProtectFriend(pick(breached_abno))
 	else
@@ -126,7 +124,11 @@
 	. = ..()
 	if(!friend || status_flags & GODMODE || stat == DEAD) //for some reason life() works on death ain't that something
 		return
-	if(QDELETED(friend) || friend.status_flags & GODMODE) //if the friend is deleted instead of dying first somehow (looking at you pbird)
+	if(friend)
+		if(friend.status_flags & GODMODE)
+			Courage(FALSE)
+			return
+	if(QDELETED(friend)) //if the friend is deleted instead of dying first somehow (looking at you pbird)
 		Courage(FALSE)
 		return
 	if(protect_cooldown < world.time)
@@ -135,10 +137,12 @@
 			GoToFriend()
 
 /mob/living/simple_animal/hostile/abnormality/scaredy_cat/proc/ProtectFriend(mob/living/simple_animal/hostile/abnormality/abno)
+	if(!abno)
+		return
 	wait_for_friend = FALSE
 	Courage(TRUE)
-	friend = abno //You are friend =D
-	faction = friend.faction
+	RegisterAlly(abno) //You are friend =D
+	faction = abno.faction
 	GoToFriend()
 
 /mob/living/simple_animal/hostile/abnormality/scaredy_cat/death()
@@ -150,11 +154,14 @@
 	else
 		animate(src, alpha = 0, time = 10 SECONDS)
 		QDEL_IN(src, 10 SECONDS)
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/scaredy_cat/Destroy()
 	UnregisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH)
 	UnregisterSignal(SSdcs, COMSIG_GLOB_ABNORMALITY_BREACH)
+	if(stunned_effect)
+		QDEL_NULL(stunned_effect)
+	UnregisterAlly()
 	return ..()
 
 //if he still has a friend, revives
@@ -206,7 +213,7 @@
 		icon_living = "cat_courage"
 		icon_dead = "dead_courage"
 	else
-		friend = null //just to make sure it's actually empty
+		UnregisterAlly() //just to make sure it's actually empty
 		if(stat != DEAD)
 			wait_for_friend = TRUE //kill him fast before he finds another friend
 		faction = list("neutral")
@@ -228,6 +235,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/scaredy_cat/proc/OnMobDeath(datum/source, mob/living/died, gibbed)
 	SIGNAL_HANDLER
+
 	if(status_flags & GODMODE)
 		if(istype(died, /mob/living/simple_animal/hostile/abnormality))
 			datum_reference.qliphoth_change(1) //counter increase if another abno dies
@@ -244,15 +252,28 @@
 		return
 	if(status_flags & GODMODE)
 		if(LAZYFIND(prefered_abno_list, abno.type))
-			priority_friend = abno
+			RegisterAlly(abno)
 			datum_reference.qliphoth_change(-3) //for all intents and purposes he instantly breach
 		else
 			datum_reference.qliphoth_change(-1)
 		return
+
 	if(LAZYFIND(prefered_abno_list, abno.type) && !LAZYFIND(prefered_abno_list, friend.type))
-		friend = abno //literally ditches his old friend if an oz abno gets out and he's not already friend with one
+		RegisterAlly(abno) //literally ditches his old friend if an oz abno gets out and he's not already friend with one
 	if(stat == DEAD || !wait_for_friend)
 		return
 	if(abno != src)
 		ProtectFriend(abno)
 		return
+
+/mob/living/simple_animal/hostile/abnormality/scaredy_cat/proc/RegisterAlly(mob/living/L)
+	if(friend)
+		UnregisterAlly()
+	RegisterSignal(L, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterAlly))
+	friend = L
+
+/mob/living/simple_animal/hostile/abnormality/scaredy_cat/proc/UnregisterAlly()
+	if(!friend)
+		return
+	UnregisterSignal(friend, list(COMSIG_PARENT_QDELETING))
+	friend = null

--- a/code/modules/mob/living/simple_animal/abnormality/he/singing_machine.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/singing_machine.dm
@@ -57,9 +57,15 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 	var/playStatus = 0
 	var/playRange = 20
 	var/noiseFactor = 2
-	var/datum/looping_sound/singing_grinding/grindNoise
-	var/datum/looping_sound/singing_music/musicNoise
-	var/list/musicalAddicts = list()
+	var/datum/looping_sound/singing_grinding/grind_noise
+	var/datum/looping_sound/singing_music/music_noise
+	var/list/music_addicts = list()
+
+/mob/living/simple_animal/hostile/abnormality/singing_machine/Destroy()
+	QDEL_NULL(grind_noise)
+	QDEL_NULL(music_noise)
+	UnregisterAll()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/singing_machine/Life()
 	if(playStatus > 0) // If playstatus isn't 0, deal some damage in range.
@@ -67,7 +73,7 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 			if(faction_check_mob(H))
 				continue
 			H.deal_damage(rand(playStatus * noiseFactor, playStatus * noiseFactor * 2), WHITE_DAMAGE, flags = (DAMAGE_FORCED), attack_type = (ATTACK_TYPE_SPECIAL))
-			if(H in musicalAddicts)
+			if(H in music_addicts)
 				H.deal_damage(rand(playStatus * noiseFactor, playStatus * noiseFactor * 2), WHITE_DAMAGE, flags = (DAMAGE_FORCED), attack_type = (ATTACK_TYPE_SPECIAL))
 				to_chat(H, span_warning("You can hear it again... it needs more..."))
 			else
@@ -106,7 +112,7 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 				if(faction_check_mob(H))
 					continue
 				H.adjustSanityLoss(rand(-1,-2))
-			for(var/mob/living/carbon/human/H in musicalAddicts)
+			for(var/mob/living/carbon/human/H in music_addicts)
 				H.adjustSanityLoss(rand(-1,-2))
 	return ..()
 
@@ -117,10 +123,8 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 		pe = 0
 	if(work_type == ABNORMALITY_WORK_INSTINCT && datum_reference.qliphoth_meter > 0) // At the end of an instinct work that wasn't trying to raise its counter...
 		to_chat(user, span_nicegreen("There's something about that sound..."))
-		musicalAddicts |= user
-		user.apply_status_effect(STATUS_EFFECT_MUSIC) // Time to addict them.
+		RegisterMob(user)
 		SEND_SOUND(user, 'sound/abnormalities/singingmachine/addiction.ogg')
-		addtimer(CALLBACK(src, PROC_REF(removeAddict), user), 5 MINUTES)
 	return
 
 /mob/living/simple_animal/hostile/abnormality/singing_machine/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
@@ -148,12 +152,13 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 		eatBody(user) // If it is, you die.
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/singing_machine/ZeroQliphoth(mob/living/carbon/human/user) // WARNING: Don't call this on its own. Several zero-qliphoth behaviors rely on its qliphoth actually being 0.
+/mob/living/simple_animal/hostile/abnormality/singing_machine/ZeroQliphoth(mob/living/carbon/human/user)
+	// WARNING: Don't call this on its own. Several zero-qliphoth behaviors rely on its qliphoth actually being 0.
 	icon_state = "singingmachine_open_[cleanliness]" // Machine opens and starts making horrible empty grinding noises.
 	icon_living = icon_state
 	update_icon()
 	playsound(src, 'sound/abnormalities/singingmachine/open.ogg', 200, 0, playRange)
-	grindNoise = new(list(src), TRUE)
+	grind_noise = new(list(src), TRUE)
 	playStatus = 1
 	return
 
@@ -161,15 +166,30 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 	if(breach_type == BREACH_MINING)
 		ZeroQliphoth()
 
-/mob/living/simple_animal/hostile/abnormality/singing_machine/proc/removeAddict(mob/living/carbon/human/addict)
-	if(addict)
-		musicalAddicts -= addict // Your five minutes are over, you're free.
+/mob/living/simple_animal/hostile/abnormality/singing_machine/proc/RegisterMob(mob/living/L)
+	if(!L)
+		return
+	RegisterSignal(L, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMob))
+	L.apply_status_effect(STATUS_EFFECT_MUSIC)
+	music_addicts += L
+
+/mob/living/simple_animal/hostile/abnormality/singing_machine/proc/UnregisterMob(mob/living/L)
+	if(!L)
+		return
+	UnregisterSignal(L, list(COMSIG_PARENT_QDELETING))
+	L.remove_status_effect(STATUS_EFFECT_MUSIC)
+	music_addicts -= L
+
+/mob/living/simple_animal/hostile/abnormality/singing_machine/proc/UnregisterAll()
+	for(var/mob/living/L in music_addicts)
+		UnregisterMob(L)
+	music_addicts.Cut()
 
 /mob/living/simple_animal/hostile/abnormality/singing_machine/proc/stopPlaying()
-	if(grindNoise)
-		QDEL_NULL(grindNoise)
-	if(musicNoise)
-		QDEL_NULL(musicNoise)
+	if(grind_noise)
+		QDEL_NULL(grind_noise)
+	if(music_noise)
+		QDEL_NULL(music_noise)
 	playStatus = 0 // This exists solely because I needed to call it via a callback.
 
 /mob/living/simple_animal/hostile/abnormality/singing_machine/proc/eatBody(mob/living/carbon/human/user)
@@ -180,11 +200,11 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 	icon_state = "singingmachine_closed_[cleanliness]"
 	icon_living = icon_state
 	update_icon()
-	driveInsane(musicalAddicts)
+	driveInsane(music_addicts)
 	playStatus = 2
 	datum_reference.qliphoth_change(2)
-	grindNoise = new(list(src), TRUE)
-	musicNoise = new(list(src), TRUE)
+	grind_noise = new(list(src), TRUE)
+	music_noise = new(list(src), TRUE)
 	addtimer(CALLBACK(src, PROC_REF(stopPlaying)), playLength) // This is the callback from earlier.
 
 /mob/living/simple_animal/hostile/abnormality/singing_machine/proc/driveInsane(list/addicts)
@@ -215,6 +235,7 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 	duration = 5 MINUTES // Just like WCCA
 	alert_type = /atom/movable/screen/alert/status_effect/singing_machine
 	display_name = "musical_addiction"
+	on_remove_on_mob_delete = TRUE
 	var/addictionTick = 10 SECONDS
 	var/addictionTimer = 0
 	var/addictionSanityMin = 2

--- a/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
@@ -2,6 +2,7 @@
 #define HEAVY_PULL_DISTANCE 2
 #define NORMAL_PULL_DELAY 10
 #define HEAVY_PULL_DELAY 15
+#define CHAINAXE_COOLDOWN 7 SECONDS
 
 /mob/living/simple_animal/hostile/abnormality/woodsman
 	name = "Warm-Hearted Woodsman"
@@ -92,8 +93,6 @@
 	var/chain_pull_count = 0
 	var/active_pull_timer
 
-
-
 	var/obj/effect/proc_holder/ability/aimed/chainaxe_throw/axe_throw
 
 	//PLAYABLES ATTACKS
@@ -113,11 +112,6 @@
 		Your flurry attack is a 3x2 AoE in front of you, which deals RED damage, which will repeat 7 times in a row before end with a extra strong final hit.<br>\
 		You are able to toggle your flurry attack on and off with your ability.")
 
-/mob/living/simple_animal/hostile/abnormality/woodsman/Initialize()
-	. = ..()
-	axe_throw = new()
-	src.AddSpell(axe_throw)
-
 /datum/action/innate/abnormality_attack/toggle/woodsman_flurry_toggle
 	name = "Toggle Deforestation"
 	desc = "Toggle your ability to perform a multi-hitting attack that hits a wide area in front of you."
@@ -132,21 +126,12 @@
 /mob/living/simple_animal/hostile/abnormality/woodsman/Initialize()
 	. = ..()
 	soundloop = new(list(src), FALSE)
-	if(IsCombatMap())
-		combat_map = TRUE
-		initial_melee_damage_lower = melee_damage_lower
-		initial_melee_damage_upper = melee_damage_upper
-		initial_flurry_delay = flurry_delay
-		initial_flurry_pause = flurry_pause
-		initial_move_to_delay = move_to_delay
-	var/obj/effect/proc_holder/spell/pointed/axe_throw/AS = new /obj/effect/proc_holder/spell/pointed/axe_throw(src)
-	AddSpell(AS)
+	axe_throw = new()
+	src.AddSpell(axe_throw)
 
 /mob/living/simple_animal/hostile/abnormality/woodsman/Destroy()
 	if(soundloop)
 		QDEL_NULL(soundloop)
-	if(chain_beam)
-		QDEL_NULL(chain_beam)
 	if(axe_throw)
 		QDEL_NULL(axe_throw)
 	return ..()
@@ -157,9 +142,13 @@
 /datum/status_effect/chained
 	id = "chained"
 	status_type = STATUS_EFFECT_UNIQUE
+	duration = CHAINAXE_COOLDOWN
 	alert_type = /atom/movable/screen/alert/status_effect/chained
+	on_remove_on_mob_delete = TRUE
 	var/mob/living/simple_animal/hostile/abnormality/woodsman/core_abno
 	var/view_range = 7
+	var/chain_pull_count = 0
+	var/active_pull_timer = null
 	// Chain beam
 	var/datum/beam/chain_beam
 
@@ -168,11 +157,14 @@
 	desc = "You've been caught by the woodsman's chain!"
 	icon = 'ModularLobotomy/_Lobotomyicons/status_sprites.dmi'
 	icon_state = "locked"
-	on_remove_on_mob_delete = TRUE
 
 /datum/status_effect/chained/on_creation(mob/living/new_owner, mob/living/puller)
+	owner = new_owner
 	if(puller)
 		RegisterMob(puller)
+		new_owner.say("[puller] registered")
+	if(!owner)
+		return
 	return ..()
 
 // Movement restriction for chained targets
@@ -184,6 +176,7 @@
 /datum/status_effect/chained/on_remove()
 	UnregisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE)
 	UnregisterMob()
+	ReleaseTarget()
 	return ..()
 
 /datum/status_effect/chained/proc/CheckMovement(mob/living/carbon/human/H, turf/NewLoc)
@@ -207,23 +200,29 @@
 	if(!isliving(trg) || !trg)
 		return
 
-	update_chain_visuals()
+	UpdateChainVisuals(TRUE)
 	PullLoop()
 
 /datum/status_effect/chained/proc/PullLoop()
 	var/mob/living/chained_target = owner
-	if(!chained_target || !can_see(core_abno, chained_target, 14))
-		release_target()
+
+	if(!core_abno)
+		ReleaseTarget(TRUE)
 		return
 
-	if(IsKnockdown(chained_target))
-		release_target()
+	UpdateChainVisuals()
+
+	if(!chained_target || !can_see(core_abno, chained_target, 14))
+		ReleaseTarget(TRUE)
+		return
+
+	if(core_abno.IsKnockdown(chained_target))
+		ReleaseTarget(TRUE)
+		return
 
 	var/current_dist = get_dist(get_turf(chained_target), get_turf(core_abno))
-	if (current_dist < 2)
-		if(client)
-			chained_target.Knockdown(3 SECONDS)
-		release_target()
+	if (current_dist < 2 || current_dist > 14)
+		ReleaseTarget(TRUE)
 		return
 
 	chain_pull_count++
@@ -236,19 +235,19 @@
 	if (chain_pull_count % 3 == 2)
 		delay = HEAVY_PULL_DELAY
 
-	pull_target(pull_distance)
-	update_chain_visuals()
+	PullTarget(pull_distance)
 
-	active_pull_timer = addtimer(CALLBACK(core_abno, PROC_REF(PullLoop)), delay, TIMER_STOPPABLE)
+	active_pull_timer = addtimer(CALLBACK(src, PROC_REF(PullLoop)), delay, TIMER_STOPPABLE)
 
 
-/datum/status_effect/chained/proc/pull_target(distance)
+/datum/status_effect/chained/proc/PullTarget(distance)
 	var/mob/living/chained_target = owner
 	if(!chained_target)
-		update_chain_visuals()
+		UpdateChainVisuals()
 		return
-	if (chained_target.stat == DEAD)
-		release_target()
+	if(chained_target.stat == DEAD)
+		ReleaseTarget(TRUE)
+		return
 
 	var/turf/T = get_turf(core_abno)
 	var/turf/target_turf = get_turf(chained_target)
@@ -262,26 +261,26 @@
 	chained_target.throw_at(T, distance, throw_speed, core_abno)
 	playsound(target_turf, 'sound/weapons/chainhit.ogg', 50, TRUE)
 
-/datum/status_effect/chained/proc/update_chain_visuals()
+/datum/status_effect/chained/proc/UpdateChainVisuals(full_remove = FALSE)
+	var/mob/living/chained_target = owner
 	if(chain_beam)
 		QDEL_NULL(chain_beam)
+
+	if(full_remove)
 		return
 
-	if(!chain_beam)
-		chain_beam = Beam(ReturnChained(), icon_state="chain")
+	if(core_abno)
+		chain_beam = chained_target.Beam(core_abno, icon_state="chain")
 	// Beam datum will handle updating the visuals automatically when either end moves
 
-/datum/status_effect/chained/proc/release_target()
+/datum/status_effect/chained/proc/ReleaseTarget(deleting = FALSE)
 	var/mob/living/chained_target = owner
-	if(!chained_target)
-		update_chain_visuals()
-		return
+	chained_target.say("oughhhh")
 
-	chained_target.remove_status_effect(/datum/status_effect/chained)
-	chained_target = null
-	chain_pull_count = 0
-	update_chain_visuals()
+	UpdateChainVisuals(TRUE)
 	deltimer(active_pull_timer)
+	if(deleting)
+		qdel(src)
 
 /datum/status_effect/chained/proc/RegisterMob(mob/living/L)
 	RegisterSignal(L, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMob))
@@ -406,7 +405,7 @@
 			if(1)
 				Woodsman_Flurry(target)
 			if(2)
-				BeginPull(target)
+				axe_throw.Perform(target, src)
 			if(3)
 				AxeThrow(target)
 			else
@@ -616,13 +615,15 @@
 	desc = "Throw a chained axe at the next thing you click."
 	action_icon_state = "helper_dash0"
 	base_icon_state = "helper_dash"
-	cooldown_time = 1
+	cooldown_time = (CHAINAXE_COOLDOWN) + 10
+	var/obj/projectile/shootems = /obj/projectile/chainedaxe
 
 /obj/effect/proc_holder/ability/aimed/chainaxe_throw/can_cast(mob/user = usr)
 	if(isabnormalitymob(user))
 		var/mob/living/simple_animal/hostile/abnormality/abno = usr
-		if(abno.IsContained())
-			return FALSE
+		if(abno)
+			if(abno.IsContained())
+				return FALSE
 	return ..()
 
 /obj/effect/proc_holder/ability/aimed/chainaxe_throw/AbnoInteraction(mob/living/user)
@@ -632,26 +633,29 @@
 	ToggleAct(abno,TRUE)
 	abno.SpecialReset()
 
-/obj/effect/proc_holder/ability/aimed/chainaxe_throw/Perform(target, mob/living/user, enraged = FALSE)
-	. = ..()
+/obj/effect/proc_holder/ability/aimed/chainaxe_throw/Perform(target, mob/living/user)
 	if(!user || !target)
 		AbnoInteraction(user)
 		return
 	ToggleAct(user,FALSE)
 
-	if(istype(user, /mob/living/simple_animal/hostile/abnormality/woodsman))
-		var/mob/living/simple_animal/hostile/abnormality/woodsman/W = user
-		W.playsound(get_turf(W), 'sound/abnormalities/woodsman/woodsman_prepare.ogg', 75, 0, 5)
-		W.icon_state = "woodsman_prepare"
+	Telegraph(user)
 
-	sleep(15)
 	AxeThrow(target, user)
 
 	AbnoInteraction(user)
 	ToggleAct(user,TRUE)
 
-/obj/effect/proc_holder/ability/aimed/chainaxe_throw/AxeThrow(trg, mob/living/user)
-	var/obj/projectile/normalaxe/P = new(get_turf(user))
+/obj/effect/proc_holder/ability/aimed/chainaxe_throw/proc/Telegraph(mob/living/user)
+	if(istype(user, /mob/living/simple_animal/hostile/abnormality/woodsman))
+		var/mob/living/simple_animal/hostile/abnormality/woodsman/W = user
+		playsound(get_turf(W), 'sound/abnormalities/woodsman/woodsman_prepare.ogg', 75, 0, 5)
+		W.icon_state = "woodsman_prepare"
+
+	sleep(15)
+
+/obj/effect/proc_holder/ability/aimed/chainaxe_throw/proc/AxeThrow(trg, mob/living/user)
+	var/obj/projectile/P = new shootems(get_turf(user))
 	P.firer = user
 	P.preparePixelProjectile(trg, user)
 	P.fire()
@@ -679,7 +683,7 @@
 
 /obj/projectile/chainedaxe/on_hit(atom/trg, blocked = FALSE)
 	. = ..()
-	if(istype(trg, /mob/living/carbon/human))
+	if(istype(trg, /mob/living/carbon/human) && firer)
 		var/mob/living/carbon/human/H = trg
 		var/mob/living/simple_animal/hostile/abnormality/woodsman/W = firer
 		if(istype(W) && get_dist(get_turf(trg), get_turf(firer)) < 12)

--- a/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
@@ -204,7 +204,7 @@
 /mob/living/simple_animal/hostile/abnormality/woodsman/proc/begin_chain_pull(mob/living/carbon/human/trg)
 	if(!isliving(trg) || !trg)
 		return
-	chained_target = trg
+	var/mob/living/chained_target = trg
 	chain_pull_count = 0
 	var/datum/status_effect/chained/C = chained_target.has_status_effect(/datum/status_effect/chained)
 	if(!C)

--- a/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
@@ -83,7 +83,7 @@
 	var/datum/looping_sound/woodsman/soundloop
 
 	// chain stuff
-	var/mob/living/carbon/human/chained_target = null
+	var/datum/weakref/chained_memory
 	var/chain_pull_count = 0
 	var/active_pull_timer
 	var/NORMAL_PULL_DISTANCE = 1
@@ -114,7 +114,7 @@
 /datum/action/spell_action/spell/axe_throw/IsAvailable()
 	if (istype(owner, /mob/living/simple_animal/hostile/abnormality/woodsman))
 		var/mob/living/simple_animal/hostile/abnormality/woodsman/W = owner
-		if (W.chained_target)
+		if (W.ReturnChained())
 			return FALSE
 	return ..()
 
@@ -138,7 +138,7 @@
 
 	if (istype(user, /mob/living/simple_animal/hostile/abnormality/woodsman))
 		var/mob/living/simple_animal/hostile/abnormality/woodsman/W = user
-		if (W.chained_target)
+		if (W.ReturnChained())
 			return FALSE
 
 	var/obj/projectile/chainedaxe/P = new(get_turf(user))
@@ -199,6 +199,8 @@
 /mob/living/simple_animal/hostile/abnormality/woodsman/Destroy()
 	if(soundloop)
 		QDEL_NULL(soundloop)
+	if(chain_beam)
+		QDEL_NULL(chain_beam)
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/woodsman/proc/begin_chain_pull(mob/living/carbon/human/trg)
@@ -206,9 +208,9 @@
 		return
 	var/mob/living/chained_target = trg
 	chain_pull_count = 0
-	var/datum/status_effect/chained/C = chained_target.has_status_effect(/datum/status_effect/chained)
+	var/datum/status_effect/chained/C = target.has_status_effect(/datum/status_effect/chained)
 	if(!C)
-		C = chained_target.apply_status_effect(/datum/status_effect/chained)
+		C = target.apply_status_effect(/datum/status_effect/chained)
 		C.W = src
 
 	update_chain_visuals()
@@ -216,6 +218,7 @@
 
 
 /mob/living/simple_animal/hostile/abnormality/woodsman/proc/pull_loop()
+	var/mob/living/chained_target = ReturnChained()
 	if(!chained_target || !can_see(src, chained_target, 14))
 		release_target()
 		return
@@ -247,6 +250,7 @@
 
 
 /mob/living/simple_animal/hostile/abnormality/woodsman/proc/pull_target(distance)
+	var/mob/living/chained_target = ReturnChained()
 	if(!chained_target)
 		update_chain_visuals()
 		return
@@ -266,16 +270,20 @@
 	playsound(target_turf, 'sound/weapons/chainhit.ogg', 50, TRUE)
 
 /mob/living/simple_animal/hostile/abnormality/woodsman/proc/update_chain_visuals()
-	if(!chained_target)
+	if(!ReturnChained())
 		if(chain_beam)
 			QDEL_NULL(chain_beam)
 		return
 
 	if(!chain_beam)
-		chain_beam = Beam(chained_target, icon_state="chain")
+		chain_beam = Beam(ReturnChained(), icon_state="chain")
 	// Beam datum will handle updating the visuals automatically when either end moves
 
+/mob/living/simple_animal/hostile/abnormality/woodsman/proc/ReturnChained()
+	return chained_memory?.resolve()
+
 /mob/living/simple_animal/hostile/abnormality/woodsman/proc/release_target()
+	var/mob/living/chained_target = ReturnChained()
 	if(!chained_target)
 		update_chain_visuals()
 		return

--- a/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
@@ -1,3 +1,8 @@
+#define NORMAL_PULL_DISTANCE 1
+#define HEAVY_PULL_DISTANCE 2
+#define NORMAL_PULL_DELAY 10
+#define HEAVY_PULL_DELAY 15
+
 /mob/living/simple_animal/hostile/abnormality/woodsman
 	name = "Warm-Hearted Woodsman"
 	desc = "A mossy old robot that reeks of iron..."
@@ -86,13 +91,10 @@
 	var/datum/weakref/chained_memory
 	var/chain_pull_count = 0
 	var/active_pull_timer
-	var/NORMAL_PULL_DISTANCE = 1
-	var/HEAVY_PULL_DISTANCE = 2
-	var/NORMAL_PULL_DELAY = 10 // 1 second in deciseconds
-	var/HEAVY_PULL_DELAY = 15 // 1.5 seconds in deciseconds
 
-	// Chain beam
-	var/datum/beam/chain_beam
+
+
+	var/obj/effect/proc_holder/ability/aimed/chainaxe_throw/axe_throw
 
 	//PLAYABLES ATTACKS
 	attack_action_types = list(/datum/action/innate/abnormality_attack/toggle/woodsman_flurry_toggle)
@@ -111,66 +113,10 @@
 		Your flurry attack is a 3x2 AoE in front of you, which deals RED damage, which will repeat 7 times in a row before end with a extra strong final hit.<br>\
 		You are able to toggle your flurry attack on and off with your ability.")
 
-/datum/action/spell_action/spell/axe_throw/IsAvailable()
-	if (istype(owner, /mob/living/simple_animal/hostile/abnormality/woodsman))
-		var/mob/living/simple_animal/hostile/abnormality/woodsman/W = owner
-		if (W.ReturnChained())
-			return FALSE
-	return ..()
-
-/obj/effect/proc_holder/spell/pointed/axe_throw
-	name = "Chain Axe throw"
-	desc = "Throw your axe, and any human hit by hit will be chained to you making them unable to run away."
-	has_action = TRUE
-	action_icon = 'icons/mob/actions/actions_abnormality.dmi'
-	action_icon_state = "wood_axe"
-	clothes_req = FALSE
-	charge_max = 150
-	range = 10
-	selection_type = "range"
-	active_msg = "You prepare to throw your axe..."
-	deactive_msg = "You put away your axe..."
-	base_action = /datum/action/spell_action/spell/axe_throw
-
-
-/obj/effect/proc_holder/spell/pointed/axe_throw/cast(list/targets, mob/user)
-	var/target = targets[1]
-
-	if (istype(user, /mob/living/simple_animal/hostile/abnormality/woodsman))
-		var/mob/living/simple_animal/hostile/abnormality/woodsman/W = user
-		if (W.ReturnChained())
-			return FALSE
-
-	var/obj/projectile/chainedaxe/P = new(get_turf(user))
-	P.firer = user
-	P.preparePixelProjectile(target, user)
-	P.fire()
-
-/obj/projectile/chainedaxe
-	name = "chained axe"
-	icon_state = "wood_axe_animated"
-	damage_type = RED_DAMAGE
-	damage = 30
-	hitsound = 'sound/effects/splat.ogg'
-	var/chain
-
-/obj/projectile/chainedaxe/fire(setAngle)
-	if(firer)
-		chain = firer.Beam(src, icon_state = "chain")
-	return ..()
-
-/obj/projectile/chainedaxe/Destroy()
-	if(chain)
-		QDEL_NULL(chain)
-	return ..()
-
-/obj/projectile/chainedaxe/on_hit(atom/trg, blocked = FALSE)
+/mob/living/simple_animal/hostile/abnormality/woodsman/Initialize()
 	. = ..()
-	if(istype(trg, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = trg
-		var/mob/living/simple_animal/hostile/abnormality/woodsman/W = firer
-		if(istype(W) && get_dist(get_turf(trg), get_turf(firer)) < 12)
-			W.begin_chain_pull(H)
+	axe_throw = new()
+	src.AddSpell(axe_throw)
 
 /datum/action/innate/abnormality_attack/toggle/woodsman_flurry_toggle
 	name = "Toggle Deforestation"
@@ -201,32 +147,79 @@
 		QDEL_NULL(soundloop)
 	if(chain_beam)
 		QDEL_NULL(chain_beam)
+	if(axe_throw)
+		QDEL_NULL(axe_throw)
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/woodsman/proc/begin_chain_pull(mob/living/carbon/human/trg)
+/*-------------\
+|Chained Status|
+\-------------*/
+/datum/status_effect/chained
+	id = "chained"
+	status_type = STATUS_EFFECT_UNIQUE
+	alert_type = /atom/movable/screen/alert/status_effect/chained
+	var/mob/living/simple_animal/hostile/abnormality/woodsman/core_abno
+	var/view_range = 7
+	// Chain beam
+	var/datum/beam/chain_beam
+
+/atom/movable/screen/alert/status_effect/chained
+	name = "Chained"
+	desc = "You've been caught by the woodsman's chain!"
+	icon = 'ModularLobotomy/_Lobotomyicons/status_sprites.dmi'
+	icon_state = "locked"
+	on_remove_on_mob_delete = TRUE
+
+/datum/status_effect/chained/on_creation(mob/living/new_owner, mob/living/puller)
+	if(puller)
+		RegisterMob(puller)
+	return ..()
+
+// Movement restriction for chained targets
+/datum/status_effect/chained/on_apply()
+	. = ..()
+	RegisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(CheckMovement))
+	BeginPull(owner)
+
+/datum/status_effect/chained/on_remove()
+	UnregisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE)
+	UnregisterMob()
+	return ..()
+
+/datum/status_effect/chained/proc/CheckMovement(mob/living/carbon/human/H, turf/NewLoc)
+	SIGNAL_HANDLER
+
+	if(!istype(H))
+		return
+
+	if(!core_abno || !(H in view(view_range, core_abno)))
+		H.remove_status_effect(/datum/status_effect/chained)
+		return
+
+	var/current_dist = get_dist(get_turf(core_abno), get_turf(H))
+	var/new_dist = get_dist(get_turf(core_abno), NewLoc)
+
+	if(new_dist > current_dist)
+		to_chat(H, "<span class='warning'>The chain prevents you from moving further away!</span>")
+		return COMPONENT_MOVABLE_BLOCK_PRE_MOVE
+
+/datum/status_effect/chained/proc/BeginPull(mob/living/carbon/human/trg)
 	if(!isliving(trg) || !trg)
 		return
-	var/mob/living/chained_target = trg
-	chain_pull_count = 0
-	var/datum/status_effect/chained/C = target.has_status_effect(/datum/status_effect/chained)
-	if(!C)
-		C = target.apply_status_effect(/datum/status_effect/chained)
-		C.W = src
 
 	update_chain_visuals()
-	pull_loop()
+	PullLoop()
 
-
-/mob/living/simple_animal/hostile/abnormality/woodsman/proc/pull_loop()
-	var/mob/living/chained_target = ReturnChained()
-	if(!chained_target || !can_see(src, chained_target, 14))
+/datum/status_effect/chained/proc/PullLoop()
+	var/mob/living/chained_target = owner
+	if(!chained_target || !can_see(core_abno, chained_target, 14))
 		release_target()
 		return
 
 	if(IsKnockdown(chained_target))
 		release_target()
 
-	var/current_dist = get_dist(get_turf(chained_target), get_turf(src))
+	var/current_dist = get_dist(get_turf(chained_target), get_turf(core_abno))
 	if (current_dist < 2)
 		if(client)
 			chained_target.Knockdown(3 SECONDS)
@@ -246,18 +239,18 @@
 	pull_target(pull_distance)
 	update_chain_visuals()
 
-	active_pull_timer = addtimer(CALLBACK(src, PROC_REF(pull_loop)), delay, TIMER_STOPPABLE)
+	active_pull_timer = addtimer(CALLBACK(core_abno, PROC_REF(PullLoop)), delay, TIMER_STOPPABLE)
 
 
-/mob/living/simple_animal/hostile/abnormality/woodsman/proc/pull_target(distance)
-	var/mob/living/chained_target = ReturnChained()
+/datum/status_effect/chained/proc/pull_target(distance)
+	var/mob/living/chained_target = owner
 	if(!chained_target)
 		update_chain_visuals()
 		return
 	if (chained_target.stat == DEAD)
 		release_target()
 
-	var/turf/T = get_turf(src)
+	var/turf/T = get_turf(core_abno)
 	var/turf/target_turf = get_turf(chained_target)
 
 	// Calculate throw speed based on distance
@@ -266,24 +259,20 @@
 		throw_speed = 3
 
 	// Throw the target towards the woodsman
-	chained_target.throw_at(T, distance, throw_speed, src)
+	chained_target.throw_at(T, distance, throw_speed, core_abno)
 	playsound(target_turf, 'sound/weapons/chainhit.ogg', 50, TRUE)
 
-/mob/living/simple_animal/hostile/abnormality/woodsman/proc/update_chain_visuals()
-	if(!ReturnChained())
-		if(chain_beam)
-			QDEL_NULL(chain_beam)
+/datum/status_effect/chained/proc/update_chain_visuals()
+	if(chain_beam)
+		QDEL_NULL(chain_beam)
 		return
 
 	if(!chain_beam)
 		chain_beam = Beam(ReturnChained(), icon_state="chain")
 	// Beam datum will handle updating the visuals automatically when either end moves
 
-/mob/living/simple_animal/hostile/abnormality/woodsman/proc/ReturnChained()
-	return chained_memory?.resolve()
-
-/mob/living/simple_animal/hostile/abnormality/woodsman/proc/release_target()
-	var/mob/living/chained_target = ReturnChained()
+/datum/status_effect/chained/proc/release_target()
+	var/mob/living/chained_target = owner
 	if(!chained_target)
 		update_chain_visuals()
 		return
@@ -294,46 +283,18 @@
 	update_chain_visuals()
 	deltimer(active_pull_timer)
 
-// Status effect for chained targets
-/datum/status_effect/chained
-	id = "chained"
-	status_type = STATUS_EFFECT_UNIQUE
-	alert_type = /atom/movable/screen/alert/status_effect/chained
-	var/mob/living/simple_animal/hostile/abnormality/woodsman/W
-	var/view_range = 7
+/datum/status_effect/chained/proc/RegisterMob(mob/living/L)
+	RegisterSignal(L, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMob))
+	core_abno = L
 
-/atom/movable/screen/alert/status_effect/chained
-	name = "Chained"
-	desc = "You've been caught by the woodsman's chain!"
-	icon = 'ModularLobotomy/_Lobotomyicons/status_sprites.dmi'
-	icon_state = "locked"
+/datum/status_effect/chained/proc/UnregisterMob()
+	if(core_abno)
+		UnregisterSignal(core_abno, list(COMSIG_PARENT_QDELETING))
+	core_abno = null
 
-// Movement restriction for chained targets
-/datum/status_effect/chained/on_apply()
-	. = ..()
-	RegisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(check_movement))
-
-/datum/status_effect/chained/on_remove()
-	UnregisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE)
-	. = ..()
-
-/datum/status_effect/chained/proc/check_movement(mob/living/carbon/human/H, turf/NewLoc)
-	SIGNAL_HANDLER
-
-	if(!istype(H))
-		return
-
-	if(!W || !(H in view(view_range, W)))
-		H.remove_status_effect(/datum/status_effect/chained)
-		return
-
-	var/current_dist = get_dist(get_turf(W), get_turf(H))
-	var/new_dist = get_dist(get_turf(W), NewLoc)
-
-	if(new_dist > current_dist)
-		to_chat(H, "<span class='warning'>The chain prevents you from moving further away!</span>")
-		return COMPONENT_MOVABLE_BLOCK_PRE_MOVE
-
+/*---------\
+|Abno Procs|
+\---------*/
 
 /mob/living/simple_animal/hostile/abnormality/woodsman/Life()
 	. = ..()
@@ -445,7 +406,7 @@
 			if(1)
 				Woodsman_Flurry(target)
 			if(2)
-				begin_chain_pull(target)
+				BeginPull(target)
 			if(3)
 				AxeThrow(target)
 			else
@@ -577,6 +538,9 @@
 	hitsound = 'sound/effects/splat.ogg'
 	color = COLOR_RED
 
+/*----------\
+|Containment|
+\----------*/
 
 /mob/living/simple_animal/hostile/abnormality/woodsman/WorkChance(mob/living/carbon/human/user, chance, work_type)
 	var/newchance = chance
@@ -640,3 +604,88 @@
 	if (!isnull(user))
 		GiveTarget(user)
 
+/mob/living/simple_animal/hostile/abnormality/woodsman/SpecialReset()
+	. = ..()
+	icon_state = icon_living
+
+/*--------\
+|Abilities|
+\--------*/
+/obj/effect/proc_holder/ability/aimed/chainaxe_throw
+	name = "Axe Throw"
+	desc = "Throw a chained axe at the next thing you click."
+	action_icon_state = "helper_dash0"
+	base_icon_state = "helper_dash"
+	cooldown_time = 1
+
+/obj/effect/proc_holder/ability/aimed/chainaxe_throw/can_cast(mob/user = usr)
+	if(isabnormalitymob(user))
+		var/mob/living/simple_animal/hostile/abnormality/abno = usr
+		if(abno.IsContained())
+			return FALSE
+	return ..()
+
+/obj/effect/proc_holder/ability/aimed/chainaxe_throw/AbnoInteraction(mob/living/user)
+	if(!istype(user, /mob/living/simple_animal/hostile/abnormality))
+		return
+	var/mob/living/simple_animal/hostile/abnormality/abno = user
+	ToggleAct(abno,TRUE)
+	abno.SpecialReset()
+
+/obj/effect/proc_holder/ability/aimed/chainaxe_throw/Perform(target, mob/living/user, enraged = FALSE)
+	. = ..()
+	if(!user || !target)
+		AbnoInteraction(user)
+		return
+	ToggleAct(user,FALSE)
+
+	if(istype(user, /mob/living/simple_animal/hostile/abnormality/woodsman))
+		var/mob/living/simple_animal/hostile/abnormality/woodsman/W = user
+		W.playsound(get_turf(W), 'sound/abnormalities/woodsman/woodsman_prepare.ogg', 75, 0, 5)
+		W.icon_state = "woodsman_prepare"
+
+	sleep(15)
+	AxeThrow(target, user)
+
+	AbnoInteraction(user)
+	ToggleAct(user,TRUE)
+
+/obj/effect/proc_holder/ability/aimed/chainaxe_throw/AxeThrow(trg, mob/living/user)
+	var/obj/projectile/normalaxe/P = new(get_turf(user))
+	P.firer = user
+	P.preparePixelProjectile(trg, user)
+	P.fire()
+
+/*----------\
+|Projectiles|
+\----------*/
+/obj/projectile/chainedaxe
+	name = "chained axe"
+	icon_state = "wood_axe_animated"
+	damage_type = RED_DAMAGE
+	damage = 30
+	hitsound = 'sound/effects/splat.ogg'
+	var/chain
+
+/obj/projectile/chainedaxe/fire(setAngle)
+	if(firer)
+		chain = firer.Beam(src, icon_state = "chain")
+	return ..()
+
+/obj/projectile/chainedaxe/Destroy()
+	if(chain)
+		QDEL_NULL(chain)
+	return ..()
+
+/obj/projectile/chainedaxe/on_hit(atom/trg, blocked = FALSE)
+	. = ..()
+	if(istype(trg, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = trg
+		var/mob/living/simple_animal/hostile/abnormality/woodsman/W = firer
+		if(istype(W) && get_dist(get_turf(trg), get_turf(firer)) < 12)
+			H.apply_status_effect(/datum/status_effect/chained,W)
+
+#undef NORMAL_PULL_DISTANCE
+#undef HEAVY_PULL_DISTANCE
+#undef NORMAL_PULL_DELAY
+#undef HEAVY_PULL_DELAY

--- a/code/modules/mob/living/simple_animal/abnormality/teth/faelantern.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/faelantern.dm
@@ -67,7 +67,11 @@
 	var/lure_damage = 20
 	var/stab_cooldown
 	var/stab_cooldown_time = 30
-	var/lured_list = list()
+	var/list/lured_list = list()
+
+/mob/living/simple_animal/hostile/abnormality/faelantern/Destroy()
+	UnregisterAll()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/faelantern/AttackingTarget(atom/attacked_target)
 	if(!target)
@@ -199,7 +203,7 @@
 		if(get_attribute_level(victim, TEMPERANCE_ATTRIBUTE) >= 40)
 			continue
 		victim.apply_status_effect(STATUS_EFFECT_FAIRYLURE)
-		lured_list += victim
+		RegisterMob(victim)
 		victim.ai_controller = /datum/ai_controller/insane/faelantern
 		victim.InitializeAIController()
 		victim.add_overlay(mutable_appearance('ModularLobotomy/_Lobotomyicons/tegu_effects.dmi', "fairy_lure", -HALO_LAYER))
@@ -220,12 +224,25 @@
 
 /mob/living/simple_animal/hostile/abnormality/faelantern/proc/EndEnchant(mob/living/carbon/human/victim, stunned = FALSE)//cannibalized apocalypse bird handling
 	if(victim in lured_list)
-		lured_list -= victim
+		UnregisterMob(victim)
 		victim.cut_overlay(mutable_appearance('ModularLobotomy/_Lobotomyicons/tegu_effects.dmi', "fairy_lure", -HALO_LAYER))
 		if(istype(victim.ai_controller,/datum/ai_controller/insane/faelantern))
 			if(!stunned)
 				to_chat(victim, span_boldwarning("You snap out of your trance!"))
 			qdel(victim.ai_controller)
+
+/mob/living/simple_animal/hostile/abnormality/faelantern/proc/RegisterMob(mob/living/L)
+	RegisterSignal(L, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMob))
+	lured_list += L
+
+/mob/living/simple_animal/hostile/abnormality/faelantern/proc/UnregisterMob(mob/living/L)
+	UnregisterSignal(L, list(COMSIG_PARENT_QDELETING))
+	lured_list -= L
+
+/mob/living/simple_animal/hostile/abnormality/faelantern/proc/UnregisterAll()
+	for(var/mob/living/L in lured_list)
+		UnregisterMob(L)
+	lured_list.Cut()
 
 	//Effects
 /obj/effect/temp_visual/faespike

--- a/code/modules/mob/living/simple_animal/abnormality/teth/hurting_teddy.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/hurting_teddy.dm
@@ -53,18 +53,24 @@
 
 	abnormality_origin = ABNORMALITY_ORIGIN_LIMBUS
 
+	//tag
 	var/bearfriended //the one who can work on it safely
-	var/mob/living/carbon/human/hug_victim = null
+	//entity
+	var/datum/weakref/hug_memory
 	var/release_threshold = 100 //Total raw damage needed to break a player out of a grab (from any source)
 	var/release_damage = 0
 	var/hug_progress = 0
 	var/hug_damage = 8
 	var/crush_damage = 3
 
+/mob/living/simple_animal/hostile/abnormality/hurting_teddy/Destroy()
+	ReleaseHug()
+	return ..()
+
 //Work Mechanics
 
 /mob/living/simple_animal/hostile/abnormality/hurting_teddy/AttemptWork(mob/living/carbon/human/user, work_type)
-	if (user == bearfriended) //small reward to the bearfriend. it's a TETH, after all.
+	if (user.tag == bearfriended) //small reward to the bearfriend. it's a TETH, after all.
 		to_chat(user, span_nicegreen("Hurting Teddy Bear offers you an embrace!"))
 		user.adjustBruteLoss(-15)
 		user.adjustSanityLoss(-15)
@@ -73,14 +79,14 @@
 /mob/living/simple_animal/hostile/abnormality/hurting_teddy/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
 	. = ..()
 	if (bearfriended == null)
-		bearfriended = user
+		bearfriended = user.tag
 		to_chat(user, span_nicegreen("Hurting Teddy Bear becomes your friend!"))
 
-	if (user != bearfriended) //get punished.
+	if (user.tag != bearfriended) //get punished.
 		to_chat(user, span_warning("You feel something sharp being jabbed into you!"))
 		user.apply_status_effect(STATUS_EFFECT_NAILS)
 
-	if(work_type == ABNORMALITY_WORK_REPRESSION && user == bearfriended) //you can use this to swap the bearfriend if you're fine losing the counter on a bad or a neutral
+	if(work_type == ABNORMALITY_WORK_REPRESSION && user.tag == bearfriended) //you can use this to swap the bearfriend if you're fine losing the counter on a bad or a neutral
 		bearfriended = null
 		to_chat(user, span_warning("Hurting Teddy Bear isn't your friend anymore! You feel bad for betraying it..."))
 		user.apply_status_effect(STATUS_EFFECT_HEX)
@@ -99,7 +105,7 @@
 /mob/living/simple_animal/hostile/abnormality/hurting_teddy/WorkChance(mob/living/carbon/human/user, chance, work_type)
 	if (bearfriended == null)  //the first work should always have the high work rates. once a friend is made, anyone else who works on it suffers
 		return chance
-	if (user == bearfriended)
+	if (user.tag == bearfriended)
 		return chance + 10 //YAY!!! FRIEND!!! Might be unnecessary?
 	else
 		return chance - 20 //FUCK OFF YOU'RE NOT A FRIEND!!!
@@ -138,12 +144,14 @@
 /mob/living/simple_animal/hostile/abnormality/hurting_teddy/proc/HugAttack(mob/living/carbon/human/victim)
 	if(!istype(victim))
 		return
-	hug_victim = victim
+	hug_memory = WEAKREF(victim)
 	Strangle()
 	can_act = FALSE
 
 /mob/living/simple_animal/hostile/abnormality/hurting_teddy/proc/Strangle()
 	set waitfor = FALSE
+
+	var/mob/living/carbon/human/hug_victim = hug_memory?.resolve()
 	release_damage = 0
 	hug_victim.Immobilize(10)
 	if(hug_victim.sanity_lost)
@@ -154,6 +162,7 @@
 	StrangleHit(1)
 
 /mob/living/simple_animal/hostile/abnormality/hurting_teddy/proc/StrangleHit(count)
+	var/mob/living/carbon/human/hug_victim = hug_memory?.resolve()
 	if(!hug_victim)
 		ReleaseHug()
 		return
@@ -184,15 +193,15 @@
 	StrangleHit(count)
 
 /mob/living/simple_animal/hostile/abnormality/hurting_teddy/proc/ReleaseHug()
-	if(hug_victim)
-		hug_victim = null
+	if(hug_memory?.resolve())
+		hug_memory = null
 		can_act = TRUE
 
 /mob/living/simple_animal/hostile/abnormality/hurting_teddy/PostDamageReaction(damage_amount, damage_type, source, attack_type)
 	. = ..()
 	if(. <= 0)
 		return
-	if(hug_victim)
+	if(hug_memory?.resolve())
 		release_damage = clamp (release_damage + ., 0, release_threshold)
 	if(release_damage >= release_threshold)
 		ReleaseHug()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/skin_prophet.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/skin_prophet.dm
@@ -57,6 +57,10 @@
 	var/list/breach_candles = list()
 	var/breaching = FALSE
 
+/mob/living/simple_animal/hostile/abnormality/skin_prophet/Destroy()
+	UnregisterAll()
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/skin_prophet/WorkChance(mob/living/carbon/human/user, chance)
 	//work damage starts at 7, + candles stuffed
 	work_damage_amount = initial(work_damage_amount) + candles
@@ -71,7 +75,7 @@
 /mob/living/simple_animal/hostile/abnormality/skin_prophet/WorktickFailure(mob/living/carbon/human/user)
 	if(prob(30))
 		say(pick(speak_list))
-	..()
+	return ..()
 
 //If you success on temperance or repression, clear all your temperance/justice buffs and then add to your max stats.
 //You're on the hook for any changes in your attribute
@@ -144,10 +148,11 @@
 		var/obj/structure/prophet_candle/C = new()
 		C.forceMove(pick(GLOB.xeno_spawn))
 		C.transform = matrix(3, MATRIX_SCALE)
-		C.prophet_reference = src
+		RegisterSignal(C, list(COMSIG_PARENT_QDELETING), PROC_REF(CandleDestroyed))
 		breach_candles += C
 
 /mob/living/simple_animal/hostile/abnormality/skin_prophet/proc/CandleDestroyed(obj/structure/prophet_candle/C)
+	UnregisterSignal(C, list(COMSIG_PARENT_QDELETING))
 	breach_candles -= C
 	if(!LAZYLEN(breach_candles) && breaching)
 		// All candles destroyed, kill the prophet
@@ -157,6 +162,14 @@
 			qdel(F)
 		breaching = FALSE
 		death()
+
+/mob/living/simple_animal/hostile/abnormality/skin_prophet/proc/UnregisterAll()
+	for(var/obj/structure/S in breach_candles)
+		if(!S)
+			return
+		UnregisterSignal(S, list(COMSIG_PARENT_QDELETING))
+		breach_candles -= S
+		qdel(S)
 
 // Prophet's special fire effect
 /obj/effect/prophet_fire
@@ -204,7 +217,6 @@
 	anchored = TRUE
 	max_integrity = 50
 	integrity_failure = 0
-	var/mob/living/simple_animal/hostile/abnormality/skin_prophet/prophet_reference
 
 /obj/structure/prophet_candle/Initialize()
 	. = ..()
@@ -225,7 +237,4 @@
 
 /obj/structure/prophet_candle/Destroy()
 	remove_filter("prophet_glow")
-	if(prophet_reference)
-		prophet_reference.CandleDestroyed(src)
 	return ..()
-

--- a/code/modules/mob/living/simple_animal/abnormality/waw/babayaga.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/babayaga.dm
@@ -51,6 +51,10 @@
 	var/jump_cooldown_time = 35 SECONDS
 	var/list/spawned_mobs = list()
 
+/mob/living/simple_animal/hostile/abnormality/babayaga/Destroy()
+	UnregisterAll()
+	return ..()
+
 //Work Procs
 // any work performed with level <4 Fort and Temperance lowers qliphoth
 /mob/living/simple_animal/hostile/abnormality/babayaga/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
@@ -100,7 +104,7 @@
 /mob/living/simple_animal/hostile/abnormality/babayaga/death(gibbed)
 	for(var/mob/living/A in spawned_mobs)
 		A.death()
-	..()
+	return ..()
 
 //Attack procs
 /mob/living/simple_animal/hostile/abnormality/babayaga/proc/TryJump(atom/target)
@@ -178,8 +182,21 @@
 		new /obj/effect/temp_visual/dir_setting/cult/phase
 		if(prob(30))
 			var/mob/living/simple_animal/hostile/yagaslave/Y = new(T)
-			spawned_mobs+=Y
+			RegisterMob(Y)
 	return
+
+/mob/living/simple_animal/hostile/abnormality/babayaga/proc/RegisterMob(mob/living/L)
+	RegisterSignal(L, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMob))
+	spawned_mobs += L
+
+/mob/living/simple_animal/hostile/abnormality/babayaga/proc/UnregisterMob(mob/living/L)
+	UnregisterSignal(L, list(COMSIG_PARENT_QDELETING))
+	spawned_mobs -= L
+
+/mob/living/simple_animal/hostile/abnormality/babayaga/proc/UnregisterAll()
+	for(var/mob/living/L in spawned_mobs)
+		UnregisterMob(L)
+	spawned_mobs.Cut()
 
 // Misc Objects and effects
 /mob/living/simple_animal/hostile/yagaslave

--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm
@@ -373,7 +373,7 @@
 				var/mob/living/simple_animal/hostile/abnormality/red_hood/mercenary = L
 				if(mercenary.IsContained())
 					mercenary.BreachEffect()
-				mercenary.priority_target = src
+				mercenary.GivePriorityTarget(src)
 				mercenary.deal_damage(150, WHITE_DAMAGE, src, attack_type = (ATTACK_TYPE_SPECIAL)) //She takes triple damage from the wolf, becauser her resistances are high
 				mercenary.RageUpdate(2)
 			if(faction_check_mob(L, FALSE))

--- a/code/modules/mob/living/simple_animal/abnormality/waw/burrowing_heaven.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/burrowing_heaven.dm
@@ -37,6 +37,11 @@
 	var/seen
 	var/list/spawn_list = list()
 
+/mob/living/simple_animal/hostile/abnormality/burrowing_heaven/Destroy()
+	UnregisterAll()
+	QDEL_LIST(spawn_list)
+	return ..()
+
 //Sight Check
 /mob/living/simple_animal/hostile/abnormality/burrowing_heaven/Life()
 	. = ..()
@@ -51,11 +56,6 @@
 		seen = FALSE
 	else	//any amount of people that's not 1.
 		seen = TRUE
-
-/mob/living/simple_animal/hostile/abnormality/burrowing_heaven/death()
-	..()
-	for(var/mob/living/simple_animal/A in spawn_list)
-		qdel(A)
 
 //You can't traditionally move nor can you attack
 /mob/living/simple_animal/hostile/abnormality/burrowing_heaven/Move()
@@ -91,7 +91,6 @@
 	addtimer(CALLBACK(src, PROC_REF(TryTeleport)), 15 SECONDS)
 
 /mob/living/simple_animal/hostile/abnormality/burrowing_heaven/proc/TryTeleport()
-	spawn_list = list()
 	if(prob(10))	//The most rare one
 		Spawn_Babies()
 		return
@@ -163,7 +162,7 @@
 	playsound(src, 'sound/abnormalities/kog/GreedHit1.ogg',  75, 1)
 	for(var/turf/T in all_turfs)
 		for(var/mob/living/carbon/human/H in T.contents)
-			H.gib()
+			H.gib(FALSE,FALSE,TRUE)
 
 /obj/effect/temp_visual/burrowing_warning
 	duration = 20
@@ -177,8 +176,6 @@
 	plane = FLOOR_PLANE
 	base_icon_state = "shield-cult"
 
-
-
 //The Ruina Breach
 /mob/living/simple_animal/hostile/abnormality/burrowing_heaven/proc/Spawn_Babies()
 	addtimer(CALLBACK(src, PROC_REF(CheckAOE)), 40 SECONDS)	//40 seconds before the global AOE
@@ -188,20 +185,28 @@
 	var/turf/T = pick(GLOB.department_centers)
 	SLEEP_CHECK_DEATH(20)
 
-	forceMove(T)
+	forceMove(get_turf(T))
 	animate(src, alpha = 255, time = 5)
 	var/turf/orgin = get_turf(src)
+	//Reduce Reuse and Recycle
+	var/list/living_guys = spawn_list.Copy()
 	var/list/all_turfs = RANGE_TURFS(3, orgin)
 	for(var/i in 1 to 3)
 		var/turf/spawn_spot = pick(all_turfs)
+		if(length(living_guys))
+			var/mob/living/guy = pop(living_guys)
+			if(guy)
+				guy.forceMove(get_turf(spawn_spot))
+				continue
 		var/mob/living/simple_animal/hostile/burrowing_spawn/BS = new get_turf(spawn_spot)
-		spawn_list += BS
+		RegisterMob(BS)
 
 /mob/living/simple_animal/hostile/abnormality/burrowing_heaven/proc/CheckAOE()
 	var/aoe = 0
 	for(var/mob/living/simple_animal/A in spawn_list)
 		if(A && A.stat != DEAD)    //If any of them are alive, fuck them
 			aoe ++
+		UnregisterMob(A)
 		qdel(A)
 	if(aoe)
 		SpawnAOE(aoe)
@@ -216,6 +221,21 @@
 
 	addtimer(CALLBACK(src, PROC_REF(TryTeleport)), 5 SECONDS)
 
+/mob/living/simple_animal/hostile/abnormality/burrowing_heaven/proc/RegisterMob(mob/living/L)
+	RegisterSignal(L, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMob))
+	spawn_list += L
+
+/mob/living/simple_animal/hostile/abnormality/burrowing_heaven/proc/UnregisterMob(mob/living/L)
+	if(!L)
+		return
+	UnregisterSignal(L, list(COMSIG_PARENT_QDELETING))
+	spawn_list -= L
+
+/mob/living/simple_animal/hostile/abnormality/burrowing_heaven/proc/UnregisterAll()
+	if(length(spawn_list))
+		return
+	for(var/mob/living/L in spawn_list)
+		UnregisterMob(L)
 
 /* Burrowing Spawn */
 /mob/living/simple_animal/hostile/burrowing_spawn
@@ -232,10 +252,8 @@
 	stat_attack = HARD_CRIT
 	del_on_death = TRUE
 
-
 /mob/living/simple_animal/hostile/burrowing_spawn/Move()
 	return FALSE
 
 /mob/living/simple_animal/hostile/burrowing_spawn/AttackingTarget()
 	return FALSE
-

--- a/code/modules/mob/living/simple_animal/abnormality/waw/dreaming_current.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/dreaming_current.dm
@@ -53,7 +53,6 @@
 	)
 
 	var/list/movement_path = list()
-	var/list/been_hit = list()
 	var/charging = FALSE
 	var/dash_cooldown
 	var/dash_cooldown_time = 8 SECONDS
@@ -77,7 +76,9 @@
 	soundloop = new(list(src), TRUE)
 
 /mob/living/simple_animal/hostile/abnormality/dreaming_current/Destroy()
-	QDEL_NULL(soundloop)
+	if(soundloop)
+		QDEL_NULL(soundloop)
+	movement_path = null
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/dreaming_current/AttackingTarget(atom/attacked_target)
@@ -163,21 +164,21 @@
 	for(var/turf/T in movement_path) // Warning before charging
 		new /obj/effect/temp_visual/sparks/quantum(T)
 	SLEEP_CHECK_DEATH(18)
-	been_hit = list()
 	if(!secret_abnormality)
 		icon_state = "current_attack"
+	var/list/been_hit = list()
 	for(var/turf/T in movement_path)
 		if(QDELETED(T))
 			break
 		if(!Adjacent(T))
 			break
-		ChargeAt(T)
+		been_hit = ChargeAt(T, been_hit)
 		SLEEP_CHECK_DEATH(dash_speed)
 	charging = FALSE
 	icon_state = icon_living
 	dash_cooldown = world.time + dash_cooldown_time
 
-/mob/living/simple_animal/hostile/abnormality/dreaming_current/proc/ChargeAt(turf/T)
+/mob/living/simple_animal/hostile/abnormality/dreaming_current/proc/ChargeAt(turf/T, already_hit = list())
 	face_atom(T)
 	for(var/obj/structure/window/W in T.contents)
 		W.obj_destruction("teeth")
@@ -201,14 +202,15 @@
 			COLOR_PURPLE,
 		)
 		S.add_atom_colour(pick(potential_colors), FIXED_COLOUR_PRIORITY)
-		var/list/new_hits = HurtInTurf(TF, been_hit, dash_damage, RED_DAMAGE, check_faction = TRUE, hurt_mechs = TRUE, attack_type = (ATTACK_TYPE_MELEE | ATTACK_TYPE_SPECIAL)) - been_hit
-		been_hit += new_hits
+		var/list/new_hits = HurtInTurf(TF, already_hit, dash_damage, RED_DAMAGE, check_faction = TRUE, hurt_mechs = TRUE, attack_type = (ATTACK_TYPE_MELEE | ATTACK_TYPE_SPECIAL)) - already_hit
+		already_hit += new_hits
 		for(var/mob/living/L in new_hits)
 			visible_message(span_boldwarning("[src] bites [L]!"))
 			new /obj/effect/temp_visual/cleave(get_turf(L))
 			playsound(L, "sound/abnormalities/dreamingcurrent/bite.ogg", 50, TRUE)
 			if(L.health < 0)
-				L.gib()
+				L.gib(FALSE,FALSE,TRUE)
+	return already_hit
 
 /mob/living/simple_animal/hostile/abnormality/dreaming_current/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(user.sanity_lost)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
@@ -74,6 +74,15 @@
 	chosen_message = span_colossus("You will now damage all enemies around you.")
 	chosen_attack_num = 1
 
+
+/mob/living/simple_animal/hostile/abnormality/judgement_bird/Destroy()
+	//Kill all Burds
+	for(var/mob/living/V in birdlist)
+		birdlist -= V
+		V.death()
+	UnregisterAll()
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/judgement_bird/Move()
 	if(judging)
 		return FALSE
@@ -133,10 +142,9 @@
 					N.buckle_mob(L)
 					playsound(get_turf(L), 'sound/abnormalities/judgementbird/kill.ogg', 75, 0, 7)
 					playsound(get_turf(L), 'sound/abnormalities/judgementbird/hang.ogg', 100, 0, 7)
-					var/mob/living/simple_animal/hostile/runawaybird/V = new(get_turf(L))
-					birdlist+=V
-					V = new(get_turf(L))
-					birdlist+=V
+					for(var/cycle = 1 to 2)
+						var/mob/living/simple_animal/hostile/runawaybird/V = new(get_turf(L))
+						RegisterMob(V)
 
 	for(var/obj/vehicle/V in urange(judgement_range, src))
 		for(var/mob/living/occupant in V.occupants)
@@ -172,18 +180,12 @@
 		judgement_damage = 65
 		return
 
-	var/mob/living/simple_animal/hostile/runawaybird/V = new(get_turf(src))
-	birdlist+=V
-	V = new(get_turf(src))
-	birdlist+=V
-	V = new(get_turf(src))
-	birdlist+=V
+	for(var/cycle = 1 to 3)
+		var/mob/living/simple_animal/hostile/runawaybird/V = new(get_turf(src))
+		RegisterMob(V)
 
-//Kill all burds
 //Burd down
 /mob/living/simple_animal/hostile/abnormality/judgement_bird/death(gibbed)
-	for(var/mob/living/V in birdlist)
-		V.death()
 	animate(src, alpha = 0, time = 10 SECONDS)
 	QDEL_IN(src, 10 SECONDS)
 	..()
@@ -205,6 +207,20 @@
 		return
 	. = ..()
 
+/mob/living/simple_animal/hostile/abnormality/judgement_bird/proc/RegisterMob(mob/living/L)
+	RegisterSignal(L, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMob))
+	birdlist += L
+
+/mob/living/simple_animal/hostile/abnormality/judgement_bird/proc/UnregisterMob(mob/living/L)
+	if(!L)
+		return
+	UnregisterSignal(L, list(COMSIG_PARENT_QDELETING))
+	birdlist -= L
+
+/mob/living/simple_animal/hostile/abnormality/judgement_bird/proc/UnregisterAll()
+	for(var/mob/living/L in birdlist)
+		UnregisterMob(L)
+	birdlist.Cut()
 
 //Runaway birds - Mini Simple Smile, 2 spawned after Jbird kills a player, and 2 on spawn.
 /mob/living/simple_animal/hostile/runawaybird

--- a/code/modules/mob/living/simple_animal/abnormality/waw/my_form_empties.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/my_form_empties.dm
@@ -86,21 +86,20 @@
 
 /mob/living/simple_animal/hostile/abnormality/my_form_empties/Destroy()
 	QDEL_NULL(soundloop)
+	if(staff)
+		QDEL_NULL(staff)
+		return ..()
 	for(var/mob/living/L in current_minions)
 		QDEL_IN(L, rand(3) SECONDS)
-		current_minions -= L
-	if(!staff)
-		return ..()
-	qdel(staff)
+	UnregisterAll()
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/my_form_empties/death(gibbed)
 	RemoveKarma()
 	icon = 'ModularLobotomy/_Lobotomyicons/abno_cores/waw.dmi'
-	QDEL_NULL(soundloop)
 	animate(src, alpha = 0, time = 5 SECONDS)
 	QDEL_IN(src, 5 SECONDS)
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/my_form_empties/Move()
 	return FALSE
@@ -183,14 +182,7 @@
 	if(breach_type != BREACH_MINING)
 		forceMove(T)
 	for(var/i = 1, i <= minion_amount ,i++)
-		var/karma_vis = new /obj/effect/karma_halo
-		var/picked = pick(pick(possible_minion_list))
-		var/mob/living/minion = new picked(get_turf(src))
-		minion.name = "Lured " + "[minion.name]"
-		minion.maxHealth = 2000
-		minion.faction = faction
-		minion.vis_contents += karma_vis
-		current_minions += minion
+		SpawnThrall()
 	if(!staff)
 		T = get_ranged_target_turf(T, EAST, 1)
 		staff = new(T)
@@ -199,7 +191,6 @@
 	if(!(died in current_minions))
 		return
 	died.gib()
-	current_minions -= died
 
 /mob/living/simple_animal/hostile/abnormality/my_form_empties/AttemptWork(mob/living/carbon/human/user, work_type)
 	if(praying)
@@ -285,6 +276,31 @@
 		var/datum/status_effect/actor/S = L.has_status_effect(/datum/status_effect/stacking/karma)
 		if(S)
 			qdel(S)
+
+/mob/living/simple_animal/hostile/abnormality/my_form_empties/proc/SpawnThrall()
+	var/karma_vis = new /obj/effect/karma_halo
+	var/picked = pick(pick(possible_minion_list))
+	var/mob/living/minion = new picked(get_turf(src))
+	minion.name = "Lured " + "[minion.name]"
+	minion.maxHealth = 2000
+	minion.faction = faction
+	minion.vis_contents += karma_vis
+	RegisterMob(minion)
+
+/mob/living/simple_animal/hostile/abnormality/my_form_empties/proc/RegisterMob(mob/living/L)
+	RegisterSignal(L, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMob))
+	current_minions += L
+
+/mob/living/simple_animal/hostile/abnormality/my_form_empties/proc/UnregisterMob(mob/living/L)
+	if(!L)
+		return
+	UnregisterSignal(L, list(COMSIG_PARENT_QDELETING))
+	current_minions -= L
+
+/mob/living/simple_animal/hostile/abnormality/my_form_empties/proc/UnregisterAll()
+	for(var/mob/living/L in current_minions)
+		UnregisterMob(L)
+	current_minions.Cut()
 
 //***Buff Definitions***
 //For now, just a notification. If we ever want to do anything with it, it's here.

--- a/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
@@ -57,6 +57,7 @@
 	)
 
 	// Work Stuff
+	//uses tags
 	var/last_drawn = null
 	var/last_drawn_check = 0
 	var/failed = FALSE
@@ -153,6 +154,10 @@
 	. = ..()
 	AddComponent(/datum/component/bloodfeast, siphon = TRUE, range = 2, starting = 1000)
 
+/mob/living/simple_animal/hostile/abnormality/nosferatu/Destroy()
+	UnregisterAll()
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/nosferatu/PostSpawn()
 	. = ..()
 	if(!IsContained())
@@ -216,9 +221,9 @@
 		if(!failed)
 			to_chat(user, span_warning("[src] suddenly sucks your blood!"))
 	if(failed || datum_reference.qliphoth_meter < 3) // We sucked blood at least once, lets check the perp
-		if(last_drawn != user)
+		if(last_drawn != user.tag)
 			last_drawn_check = 0
-		last_drawn = user
+		last_drawn = user.tag
 		last_drawn_check += 1
 		if(last_drawn_check >= 3)
 			user.adjustBruteLoss(999)
@@ -401,17 +406,12 @@
 			return
 		target_atom = newturf
 	playsound(get_turf(target_atom), 'sound/abnormalities/nosferatu/batspawn.ogg', 50, 1)
-	//How many we have spawned
-	listclearnulls(spawned_bats)
-	for(var/mob/living/L in spawned_bats)
-		if(L.stat == DEAD)
-			spawned_bats -= L
 	if(length(spawned_bats) >= bat_spawn_limit)
 		return
 
 	//Actually spawning them
 	var/mob/living/simple_animal/hostile/nosferatu_mob/B = new(get_turf(target_atom))
-	spawned_bats+=B
+	RegisterMob(B)
 
 /mob/living/simple_animal/hostile/abnormality/nosferatu/proc/Banquet()//AOE attack
 	if(mist_form) // No attack abilities while in mist form
@@ -539,6 +539,21 @@
 		playsound(get_turf(src), 'sound/abnormalities/nosferatu/bloodcollect.ogg', 10, 1)
 	else
 		blood_transfer_target.LoseTarget()
+
+/mob/living/simple_animal/hostile/abnormality/nosferatu/proc/RegisterMob(mob/living/L)
+	RegisterSignal(L, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMob))
+	spawned_bats += L
+
+/mob/living/simple_animal/hostile/abnormality/nosferatu/proc/UnregisterMob(mob/living/L)
+	if(!L)
+		return
+	UnregisterSignal(L, list(COMSIG_PARENT_QDELETING))
+	spawned_bats -= L
+
+/mob/living/simple_animal/hostile/abnormality/nosferatu/proc/UnregisterAll()
+	for(var/mob/living/L in spawned_bats)
+		UnregisterMob(L)
+	spawned_bats.Cut()
 
 // Bat minion - A non-dense trash mob that automatically harvests blood on attacks and returns blood to nosferatu. Dangeorus.
 /mob/living/simple_animal/hostile/nosferatu_mob

--- a/code/modules/mob/living/simple_animal/abnormality/waw/parasite_tree.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/parasite_tree.dm
@@ -188,6 +188,12 @@
 	projectilesound = 'sound/machines/clockcult/steam_whoosh.ogg'
 	var/mob/living/simple_animal/hostile/abnormality/parasite_tree/connected_abno
 
+/mob/living/simple_animal/hostile/parasite_tree_sapling/Destroy()
+	if(connected_abno)
+		connected_abno.minions -= src
+	connected_abno = null
+	return ..()
+
 /mob/living/simple_animal/hostile/parasite_tree_sapling/Initialize()
 	. = ..()
 	icon_living = "sapling[pick(1,2)]"
@@ -202,7 +208,7 @@
 		connected_abno.endBreach()
 	for(var/atom/movable/AM in src)
 		AM.forceMove(get_turf(src))
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/parasite_tree_sapling/CanAttack(mob/living/carbon/human/the_target) //Your target has to be human and not have the tree curse.
 	if(isturf(the_target) || !the_target || the_target.type == /atom/movable/lighting_object) // bail out on invalids
@@ -322,6 +328,7 @@
 	connected_abno.blessed -= src
 	if(status_holder.stat == DEAD)
 		connected_abno.datum_reference.qliphoth_change(1)
+	connected_abno = null
 	return ..()
 
 /datum/status_effect/display/parasite_tree_blessing/proc/facadeFalls()
@@ -373,6 +380,7 @@
 		nested_items(new_mob, status_holder.get_item_by_slot(ITEM_SLOT_BACK))
 		nested_items(new_mob, status_holder.get_item_by_slot(ITEM_SLOT_OCLOTHING))
 		QDEL_IN(owner, 5) //rabbit sanity implant explodes at 5
+	connected_abno = null
 	return ..()
 
 /datum/status_effect/display/parasite_tree_curse/TweakDisplayIcon()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/pygmalion.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/pygmalion.dm
@@ -69,6 +69,10 @@
 	if(unfocused_talent_cooldown <= world.time)
 		UnfocusedTalent()
 
+/mob/living/simple_animal/hostile/abnormality/pygmalion/Destroy()
+	SculptorDeathOrInsane()
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/pygmalion/CanAllowThrough(atom/movable/mover, turf/target)
 	if(sculptor && ishuman(mover))
 		return TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/red_riding_mercenary.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/red_riding_mercenary.dm
@@ -95,7 +95,8 @@ It has now been over four months. Now we get her for real. -Coxswain
 
 	var/red_rage = 0 // Goes up to 3; 1 for "weak rage" (against buddy and blue), 2 for "strong rage" (against wolf), 3 for "aimless rage" (denied wolf kill)
 	var/target_priority = 0 // Goes up to 4; 1 for Blue Smocked Shepherd, 2 for the requested target, 3 for Buddy, 4 for Wolf.
-	var/mob/living/priority_target // Stores current request target.
+	var/mob/living/priority_trg // Stores current request target.
+	var/priority_tag
 	var/fuzzy_tracking_cooldown = 10 SECONDS // How often red re-checks the closest landmark to the target.
 	var/list/tiered_request_costs = alist(
 		ZAYIN_LEVEL = 100,
@@ -180,7 +181,7 @@ It has now been over four months. Now we get her for real. -Coxswain
 	to_chat(A, chosen_message)
 
 /mob/living/simple_animal/hostile/abnormality/red_hood/proc/PlayerTargetFind()
-	HunterTracking(priority_target) // basically a redirect, ability code is weird
+	HunterTracking(priority_trg) // basically a redirect, ability code is weird
 
 /datum/action/innate/abnormality_attack/catch_breath // AI-controlled Red technically doesn't use this one EITHER.
 	name = "Evade"
@@ -229,7 +230,7 @@ It has now been over four months. Now we get her for real. -Coxswain
 
 /mob/living/simple_animal/hostile/abnormality/red_hood/PostDamageReaction(damage_amount, damage_type, source, attack_type)
 	. = ..()
-	if(health > (maxHealth * 0.8) || !priority_target)
+	if(health > (maxHealth * 0.8) || !priority_tag)
 		return
 	if(red_rage < 1 && target_priority > 2)
 		RageUpdate(1)
@@ -386,7 +387,7 @@ It has now been over four months. Now we get her for real. -Coxswain
 			say("Changed your mind? Tch. Call me when you need me.")
 		return FALSE
 
-	priority_target = hunted
+	GivePriorityTarget(hunted)
 	out_on_request = TRUE
 	fear_level = TETH_LEVEL
 	var/current_cost = default_request_cost //We start out at 100 and then start adding additional fees
@@ -407,9 +408,9 @@ It has now been over four months. Now we get her for real. -Coxswain
 	SSlobotomy_corp.available_box -= current_cost //Subtract the total from station PE
 
 	if(client)
-		to_chat(src, span_notice("You've been contracted to hunt [priority_target.name]."))
+		to_chat(src, span_notice("You've been contracted to hunt [hunted]."))
 	else
-		if(istype(priority_target, /mob/living/simple_animal/hostile/abnormality/big_wolf))
+		if(istype(hunted, /mob/living/simple_animal/hostile/abnormality/big_wolf))
 			manual_emote("'s grip on her weapon tightens.")
 			SLEEP_CHECK_DEATH(10)
 			say("Is he really here? You don't know how long I have been waiting for this.")
@@ -424,7 +425,7 @@ It has now been over four months. Now we get her for real. -Coxswain
 			BreachEffect()
 			RageUpdate(2) //She enrages instantly to go wolf hunting
 			return
-		if(istype(priority_target, /mob/living/simple_animal/hostile/abnormality/red_buddy))
+		if(istype(hunted, /mob/living/simple_animal/hostile/abnormality/red_buddy))
 			manual_emote("'s eye widens slightly.")
 			SLEEP_CHECK_DEATH(10)
 			say("Hm. A wolf? Not MY wolf, but a wolf nonetheless...")
@@ -434,7 +435,7 @@ It has now been over four months. Now we get her for real. -Coxswain
 			target_priority = 3
 			BreachEffect()
 			return
-		if(istype(priority_target, /mob/living/simple_animal/hostile/abnormality/blue_shepherd))
+		if(istype(hunted, /mob/living/simple_animal/hostile/abnormality/blue_shepherd))
 			manual_emote("'s eye narrows.")
 			SLEEP_CHECK_DEATH(10)
 			say("That idiot? You're sure?")
@@ -510,16 +511,17 @@ It has now been over four months. Now we get her for real. -Coxswain
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/red_hood/ValueTarget(atom/target_thing) //Naturally value priority targets over others
-	..()
-	if(target_thing == priority_target)
-		. += 60
+	. = ..()
+	if(isliving(target_thing))
+		var/mob/living/L = target_thing
+		if(L.tag == priority_tag)
+			. += 60
 
 /mob/living/simple_animal/hostile/abnormality/red_hood/proc/UpdatePriority(target_id = 0, mob/living/new_priority)
 	if(target_id > target_priority)
 		if(client)
 			to_chat(src, span_notice("You've found a higher priority target! Go after [new_priority]!"))
-		priority_target = new_priority
-		target_priority = target_id
+		GivePriorityTarget(new_priority)
 	return
 
 /mob/living/simple_animal/hostile/abnormality/red_hood/Move()
@@ -566,21 +568,22 @@ It has now been over four months. Now we get her for real. -Coxswain
 		return FALSE
 	if(!out_on_request && target_priority != 4) //Didn't get hired and not fighting the wolf
 		return
-	if(!priority_target) //For some reason we never got one
+	if(!priority_tag) //For some reason we never got one
 		ContractComplete()
 		return
-	if(QDELETED(priority_target) || priority_target.stat == DEAD || priority_target.z != z) //Target is dead or vanished or off-z
+	if(QDELETED(priority_trg) || priority_trg.stat == DEAD || priority_trg.z != z) //Target is dead or vanished or off-z
 		ContractComplete()
 		return
 
 /mob/living/simple_animal/hostile/abnormality/red_hood/SelectPatrolLocation() //Path right to our target
-	if(out_on_request || priority_target)
-		if(!priority_target) //For some reason we never got one
+	if(out_on_request || priority_tag)
+		if(!priority_tag || !priority_trg) //For some reason we never got one
 			return ..()
-		return get_turf(priority_target)
+		return get_turf(priority_trg)
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/red_hood/proc/ContractComplete()
+	GivePriorityTarget()
 	if(leaving)
 		return
 	leaving = TRUE
@@ -609,6 +612,23 @@ It has now been over four months. Now we get her for real. -Coxswain
 	AIStatus = AI_OFF
 	animate(src, alpha = 0, time = 10)
 	QDEL_IN(src,10)
+
+/mob/living/simple_animal/hostile/abnormality/red_hood/proc/GivePriorityTarget(mob/living/p_target)
+	if(!p_target)
+		UnregisterTrg()
+		return
+	if(priority_trg)
+		UnregisterTrg()
+	RegisterSignal(p_target, list(COMSIG_PARENT_QDELETING, COMSIG_LIVING_DEATH), PROC_REF(UnregisterTrg))
+	priority_tag = p_target.tag
+	priority_trg = p_target
+
+/mob/living/simple_animal/hostile/abnormality/red_hood/proc/UnregisterTrg()
+	if(!priority_trg)
+		return
+	UnregisterSignal(priority_trg, list(COMSIG_PARENT_QDELETING, COMSIG_LIVING_DEATH))
+	priority_tag = null
+	priority_trg = null
 
 /*--------\
 |Abilities|

--- a/code/modules/mob/living/simple_animal/abnormality/waw/red_riding_mercenary.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/red_riding_mercenary.dm
@@ -324,7 +324,7 @@ It has now been over four months. Now we get her for real. -Coxswain
 	say(pick(weapon_throw_lines))
 	blade_throw.Perform(target, src, red_rage)
 
-/mob/living/simple_animal/hostile/abnormality/red_hood/proc/SpecialReset()
+/mob/living/simple_animal/hostile/abnormality/red_hood/SpecialReset()
 	special_attacking = FALSE
 	icon = initial(icon)
 	icon_state = initial(icon_state)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/rose_sign.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/rose_sign.dm
@@ -53,8 +53,10 @@
 			Blossoms of flowers sprawled on the ground substitute its screams."),
 	)
 
+	//Is removed by work rose structures.
 	var/list/work_roses = list()
 	var/list/work_damages = list()
+	//Actual entities
 	var/list/summoned_roses = list()
 	var/rose_type = /mob/living/simple_animal/hostile/rose_summoned
 	var/rose_max = 4
@@ -62,6 +64,13 @@
 	var/rose_cooldown_time = 160 SECONDS
 	var/vine_cooldown
 	var/vine_cooldown_time = 45 SECONDS
+
+
+/mob/living/simple_animal/hostile/abnormality/rose_sign/Destroy()
+	for(var/mob/living/R in summoned_roses)
+		summoned_roses -= R
+		R.death()
+	return ..()
 
 //*** Basic Simple mob procs***//
 /mob/living/simple_animal/hostile/abnormality/rose_sign/Move()
@@ -83,13 +92,11 @@
 		return
 
 /mob/living/simple_animal/hostile/abnormality/rose_sign/death()
-	for(var/mob/living/R in summoned_roses)
-		R.death()
 	icon = 'ModularLobotomy/_Lobotomyicons/abno_cores/waw.dmi'
 	density = FALSE
 	animate(src, alpha = 0, time = 10 SECONDS)
 	QDEL_IN(src, 10 SECONDS)
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/rose_sign/WorkChance(mob/living/carbon/human/user, chance, work_type)//set the new work chances
 	. = chance // Set default return to chance
@@ -229,7 +236,7 @@
 		delay += 5
 
 /mob/living/simple_animal/hostile/abnormality/rose_sign/proc/RoseSounds(delay)
-	sleep(delay)
+	SLEEP_CHECK_DEATH(delay)
 	sound_to_playing_players_on_level("sound/abnormalities/rosesign/rose_summon.ogg", 100, zlevel = z)
 
 /mob/living/simple_animal/hostile/abnormality/rose_sign/proc/SpawnBreachRose(mob/living/carbon/human/target, turf/T)
@@ -239,9 +246,7 @@
 		T = get_ranged_target_turf(T, pick(GLOB.alldirs), 1)//This will move the target's turf to an adjacent one, preventing stacking and visual clutter to some degree.
 	var/list/flower_damtype = list()
 	var/damtype
-	var/mob/living/simple_animal/hostile/rose_summoned/R
-	R = new rose_type(T)//Spawns the rose
-	summoned_roses += R
+	var/mob/living/simple_animal/hostile/rose_summoned/R = new rose_type(T)//Spawns the rose
 	for(var/obj/item/W in target.held_items + target.get_equipped_items())//Searches the human for any E.G.O and adds them to a list.
 		if(is_ego_melee_weapon(W)) //FIXME!!!! The above line doesn't actually check suit storage slots, could be more efficient too
 			flower_damtype += W.damtype
@@ -253,12 +258,10 @@
 	else
 		damtype = pick(RED_DAMAGE, WHITE_DAMAGE, BLACK_DAMAGE, PALE_DAMAGE)
 	R.PickColor(damtype)
-	R.master = src
-	R.status_target = target
+	R.RegisterMstrNTrg(src, target)
 	target.apply_status_effect(STATUS_EFFECT_THORNS)
 	var/datum/status_effect/stacking/crownthorns/C = target.has_status_effect(/datum/status_effect/stacking/crownthorns)
-	C.status_applicant = R
-	C.master = src
+	C.RegisterSignals(src,R)
 	to_chat(target, span_userdanger("You feel a terrifying pain coming from [get_area(T)]."))
 
 /mob/living/simple_animal/hostile/abnormality/rose_sign/OpenFire()
@@ -305,19 +308,9 @@
 	pull_force = INFINITY
 	generic_canpass = FALSE
 	movement_type = PHASING | FLYING
+	layer = POINT_LAYER//Sprite should always be visible
 	var/boom_damage = 45
 	var/grabbed
-	layer = POINT_LAYER//Sprite should always be visible
-
-/obj/effect/temp_visual/rose_vine
-	name = "garden of infinity"
-	icon = 'ModularLobotomy/_Lobotomyicons/96x96.dmi'
-	icon_state = "rose_vines"
-	pixel_x = -32
-	base_pixel_x = -32
-	duration = 6 SECONDS
-	randomdir = 0
-	pixel_y = 0
 
 /obj/effect/rose_target/Initialize()
 	. = ..()
@@ -338,6 +331,16 @@
 		sleep(10 SECONDS)
 	qdel(src)
 
+/obj/effect/temp_visual/rose_vine
+	name = "garden of infinity"
+	icon = 'ModularLobotomy/_Lobotomyicons/96x96.dmi'
+	icon_state = "rose_vines"
+	pixel_x = -32
+	base_pixel_x = -32
+	duration = 6 SECONDS
+	randomdir = 0
+	pixel_y = 0
+
 /obj/effect/roseRoot
 	name = "root"
 	desc = "A target warning you of incoming pain"
@@ -348,8 +351,8 @@
 	generic_canpass = FALSE
 	movement_type = PHASING | FLYING
 	damtype = BLACK_DAMAGE
-	var/root_damage = 30 //Black Damage
 	layer = POINT_LAYER//should always be visible.
+	var/root_damage = 30 //Black Damage
 
 /obj/effect/roseRoot/Initialize()
 	. = ..()
@@ -395,9 +398,15 @@
 	damage_coeff = list(RED_DAMAGE = 0.5, WHITE_DAMAGE = 0.5, BLACK_DAMAGE = 0.5, PALE_DAMAGE = 0.5)
 	del_on_death = TRUE
 	var/flower_damage_type
-	var/mob/living/simple_animal/hostile/abnormality/rose_sign/master
-	var/mob/living/status_target
 	var/killed = TRUE
+	var/mob/living/simple_animal/hostile/abnormality/rose_sign/master
+	var/mob/living/carbon/status_target
+
+/mob/living/simple_animal/hostile/rose_summoned/Move()
+	return FALSE
+
+/mob/living/simple_animal/hostile/rose_summoned/CanAttack(atom/the_target)
+	return FALSE
 
 /mob/living/simple_animal/hostile/rose_summoned/proc/PickColor(picked_color)
 	icon_state = "rose_" + picked_color
@@ -414,21 +423,37 @@
 			name = "rose of death"
 	ChangeResistance(picked_color, 2, update = TRUE)
 
-/mob/living/simple_animal/hostile/rose_summoned/Move()
-	return FALSE
-
-/mob/living/simple_animal/hostile/rose_summoned/CanAttack(atom/the_target)
-	return FALSE
-
 /mob/living/simple_animal/hostile/rose_summoned/Destroy()
-	if(!killed || !status_target)
-		return ..()
-	if(flower_damage_type && master)
-		master.summoned_roses -= src
-		master.ChangeResistance(flower_damage_type, (master.damage_coeff.getCoeff(flower_damage_type) + 0.3), update = TRUE)
-	if(status_target.has_status_effect(/datum/status_effect/stacking/crownthorns))
-		status_target.remove_status_effect(STATUS_EFFECT_THORNS)
+	if(killed && status_target)
+		if(flower_damage_type && master)
+			master.ChangeResistance(flower_damage_type, (master.damage_coeff.getCoeff(flower_damage_type) + 0.3), update = TRUE)
+		if(status_target.has_status_effect(/datum/status_effect/stacking/crownthorns))
+			status_target.remove_status_effect(STATUS_EFFECT_THORNS)
+	UnregisterMaster()
+	UnregisterStatus()
 	return ..()
+
+/mob/living/simple_animal/hostile/rose_summoned/proc/RegisterMstrNTrg(mob/living/simple_animal/hostile/abnormality/rose_sign/R, mob/living/L)
+	if(!R || !L)
+		return
+	master = R
+	master.summoned_roses += src
+	RegisterSignal(R, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMaster))
+	status_target = L
+	RegisterSignal(L, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterStatus))
+
+/mob/living/simple_animal/hostile/rose_summoned/proc/UnregisterMaster()
+	if(!master)
+		return
+	master.summoned_roses -= src
+	UnregisterSignal(master, list(COMSIG_PARENT_QDELETING))
+	master = null
+
+/mob/living/simple_animal/hostile/rose_summoned/proc/UnregisterStatus()
+	if(!status_target)
+		return
+	UnregisterSignal(status_target, list(COMSIG_PARENT_QDELETING))
+	status_target = null
 
 /mob/living/simple_animal/hostile/rose_summoned/combat//mining breach variant
 	maxHealth = 1000
@@ -580,6 +605,8 @@
 	var/mob/living/carbon/human/status_holder = owner
 	status_holder.adjust_attribute_bonus(FORTITUDE_ATTRIBUTE, attribute_penalty)
 	status_holder.adjustBruteLoss(-attribute_penalty)
+	UnregistermMaster()
+	UnregisterApplicant()
 	return ..()
 
 /datum/status_effect/stacking/crownthorns/proc/PointToFlower()
@@ -593,6 +620,24 @@
 		new /obj/effect/temp_visual/cult/sparks(T)
 		i++
 		sleep(1)
+
+/datum/status_effect/stacking/crownthorns/proc/RegisterSignals(mob/living/abno_master, mob/living/applicant)
+	RegisterSignal(abno_master, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregistermMaster))
+	RegisterSignal(applicant, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterApplicant))
+	master = abno_master
+	status_applicant = applicant
+
+/datum/status_effect/stacking/crownthorns/proc/UnregistermMaster()
+	if(!master)
+		return
+	UnregisterSignal(master, list(COMSIG_PARENT_QDELETING))
+	master = null
+
+/datum/status_effect/stacking/crownthorns/proc/UnregisterApplicant()
+	if(!status_applicant)
+		return
+	UnregisterSignal(status_applicant, list(COMSIG_PARENT_QDELETING))
+	status_applicant = null
 
 //On-kill visual effect
 /obj/structure/rose_crucifix

--- a/code/modules/mob/living/simple_animal/abnormality/waw/siltcurrent.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/siltcurrent.dm
@@ -105,10 +105,13 @@
 	toggle_message = span_colossus("You will now dive while you attack.")
 	button_icon_toggle_deactivated = "_WAW"
 
-/mob/living/simple_animal/hostile/abnormality/siltcurrent/Life()
-	. = ..()
-	if(!.) // Dead
-		return FALSE
+/mob/living/simple_animal/hostile/abnormality/siltcurrent/Destroy()
+	for(var/obj/effect/obsessing_water_effect/W in water)
+		QDEL_IN(W, rand(5) SECONDS)
+		water -= W
+	UnregisterAll()
+	water.Cut()
+	return ..()
 
 //Checks if it's stunned or doing the dive attack to prevent it from attacking or moving while in those 2 states since it would be silly.
 /mob/living/simple_animal/hostile/abnormality/siltcurrent/Move()
@@ -151,11 +154,77 @@
 	if(!IsContained())//Prevents you from just refilling your oxygen during work. Go heal dibshit.
 		Refill(user)
 
-
 /mob/living/simple_animal/hostile/abnormality/siltcurrent/bullet_act(obj/projectile/P)
 	. = ..()
 	if(!IsContained())
 		Refill(P.firer)
+
+/mob/living/simple_animal/hostile/abnormality/dreaming_current/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
+	if(get_attribute_level(user, FORTITUDE_ATTRIBUTE) < 60)
+		datum_reference.qliphoth_change(-1)
+	return
+
+/mob/living/simple_animal/hostile/abnormality/siltcurrent/Worktick(mob/living/carbon/human/user, bubble_type = ABNO_BALLOON_GENERIC | ABNO_BALLOON_SPECIFIC, work_type)
+	user.adjustOxyLoss(1.5, updating_health=TRUE, forced=TRUE)//haha drown.
+	return ..()
+
+/mob/living/simple_animal/hostile/abnormality/siltcurrent/FailureEffect(mob/living/carbon/human/user, work_type, pe)
+	datum_reference.qliphoth_change(-1)
+	if(user.oxyloss >= 50)//POWER GRINDER SPOTTED! MUST MAUL THE FUCK!
+		datum_reference.qliphoth_change(-1)
+		GiveTarget(user)
+		SiltDive(get_turf(user),TRUE)
+	return
+
+/mob/living/simple_animal/hostile/abnormality/siltcurrent/BreachEffect(mob/living/carbon/human/user)
+	. = ..()
+	icon_living = "current_breach"
+	//icon_state = icon_living
+	addtimer(CALLBACK(src, PROC_REF(OxygenLoss)), 5 SECONDS, TIMER_LOOP)
+	for(var/mob/living/L in GLOB.player_list)//Spawns Flotsams in the halls and notifies people that it's out.
+		if(L.z != z || L.stat >= HARD_CRIT)
+			continue
+		to_chat(L, span_userdanger("You feel water is entering the facility!"))
+	var/list/spawn_turfs = GLOB.xeno_spawn.Copy()
+	for(var/i = 1 to (tube_spawn_amount))
+		if(!LAZYLEN(spawn_turfs)) //if list empty, recopy xeno spawns
+			spawn_turfs = GLOB.xeno_spawn.Copy()
+		var/X = pick_n_take(spawn_turfs)
+		var/turf/T = get_turf(X)
+		var/list/deployment_area = list()
+		var/turf/deploy_spot = T //spot you are being deployed
+		if(LAZYLEN(deployment_area)) //if deployment zone is empty just spawn at xeno spawn
+			deploy_spot = pick_n_take(deployment_area)
+		var/obj/structure/flotsam/F = new get_turf(deploy_spot)
+		RegisterFloat(F)
+
+/mob/living/simple_animal/hostile/abnormality/siltcurrent/death()
+	icon = 'ModularLobotomy/_Lobotomyicons/abno_cores/waw.dmi'
+	pixel_x = -16
+	base_pixel_x = -16
+	density = FALSE
+	animate(src, alpha = 0, time = 10 SECONDS)
+	QDEL_IN(src, 10 SECONDS)
+	return ..()
+
+/mob/living/simple_animal/hostile/abnormality/siltcurrent/PostSpawn()
+	. = ..()
+	for(var/turf/open/T in range(1, src)) // fill its cell with water
+		T.TerraformTurf(/turf/open/water/deep/obsessing_water, flags = CHANGETURF_INHERIT_AIR)
+
+/mob/living/simple_animal/hostile/abnormality/siltcurrent/proc/Stunned()
+	set waitfor = FALSE
+	stunned = TRUE
+	ChangeResistances(list(RED_DAMAGE = 1.5, WHITE_DAMAGE = 1.5, BLACK_DAMAGE = 1.5, PALE_DAMAGE = 1.5))//You did it nows your chance to beat the shit out of it!
+	SLEEP_CHECK_DEATH(12 SECONDS)
+	stunned = FALSE
+	ChangeResistances(list(RED_DAMAGE = 0.5, WHITE_DAMAGE = 0.5, BLACK_DAMAGE = 0.5, PALE_DAMAGE = 0.5))
+
+/mob/living/simple_animal/hostile/abnormality/siltcurrent/proc/OxygenLoss()//While its alive all humans around it will lose oxygen.
+	for(var/mob/living/carbon/human/H in oview(src, 20))//Used to be global but this should prevent it from being asinine when other abormalities are out
+		playsound(H, "sound/effects/bubbles.ogg", 50, TRUE, 7)
+		new /obj/effect/temp_visual/mermaid_drowning(get_turf(H))
+		H.adjustOxyLoss(4, updating_health=TRUE, forced=TRUE)
 
 //Less effective than attacking the flotsam but its another option in higher pop maps where flotsams are more farther away from each other.
 /mob/living/simple_animal/hostile/abnormality/siltcurrent/proc/Refill(mob/living/attacker)
@@ -203,79 +272,24 @@
 		SLEEP_CHECK_DEATH(0.5 SECONDS)
 		diving = FALSE
 
-/mob/living/simple_animal/hostile/abnormality/siltcurrent/proc/Stunned()
-	set waitfor = FALSE
-	stunned = TRUE
-	ChangeResistances(list(RED_DAMAGE = 1.5, WHITE_DAMAGE = 1.5, BLACK_DAMAGE = 1.5, PALE_DAMAGE = 1.5))//You did it nows your chance to beat the shit out of it!
-	SLEEP_CHECK_DEATH(12 SECONDS)
-	stunned = FALSE
-	ChangeResistances(list(RED_DAMAGE = 0.5, WHITE_DAMAGE = 0.5, BLACK_DAMAGE = 0.5, PALE_DAMAGE = 0.5))
+/mob/living/simple_animal/hostile/abnormality/siltcurrent/proc/RegisterFloat(atom/A)
+	if(!A || !istype(A,/obj/structure/flotsam))
+		return
+	var/obj/structure/flotsam/F = A
+	RegisterSignal(F, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterFloat))
+	spawned_flotsams += F
 
-/mob/living/simple_animal/hostile/abnormality/dreaming_current/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
-	if(get_attribute_level(user, FORTITUDE_ATTRIBUTE) < 60)
-		datum_reference.qliphoth_change(-1)
-	return
+/mob/living/simple_animal/hostile/abnormality/siltcurrent/proc/UnregisterFloat(obj/structure/flotsam/A)
+	UnregisterSignal(A, list(COMSIG_PARENT_QDELETING))
+	spawned_flotsams -= A
 
-/mob/living/simple_animal/hostile/abnormality/siltcurrent/Worktick(mob/living/carbon/human/user, bubble_type = ABNO_BALLOON_GENERIC | ABNO_BALLOON_SPECIFIC, work_type)
-	user.adjustOxyLoss(1.5, updating_health=TRUE, forced=TRUE)//haha drown.
-	return ..()
-
-/mob/living/simple_animal/hostile/abnormality/siltcurrent/FailureEffect(mob/living/carbon/human/user, work_type, pe)
-	datum_reference.qliphoth_change(-1)
-	if(user.oxyloss >= 50)//POWER GRINDER SPOTTED! MUST MAUL THE FUCK!
-		datum_reference.qliphoth_change(-1)
-		GiveTarget(user)
-		SiltDive(get_turf(user),TRUE)
-	return
-
-/mob/living/simple_animal/hostile/abnormality/siltcurrent/BreachEffect(mob/living/carbon/human/user)
-	. = ..()
-	icon_living = "current_breach"
-	//icon_state = icon_living
-	addtimer(CALLBACK(src, PROC_REF(OxygenLoss)), 5 SECONDS, TIMER_LOOP)
-	for(var/mob/living/L in GLOB.player_list)//Spawns Flotsams in the halls and notifies people that it's out.
-		if(L.z != z || L.stat >= HARD_CRIT)
+/mob/living/simple_animal/hostile/abnormality/siltcurrent/proc/UnregisterAll()
+	for(var/obj/O in spawned_flotsams)
+		if(!O)
 			continue
-		to_chat(L, span_userdanger("You feel water is entering the facility!"))
-	var/list/spawn_turfs = GLOB.xeno_spawn.Copy()
-	for(var/i = 1 to (tube_spawn_amount))
-		if(!LAZYLEN(spawn_turfs)) //if list empty, recopy xeno spawns
-			spawn_turfs = GLOB.xeno_spawn.Copy()
-		var/X = pick_n_take(spawn_turfs)
-		var/turf/T = get_turf(X)
-		var/list/deployment_area = list()
-		var/turf/deploy_spot = T //spot you are being deployed
-		if(LAZYLEN(deployment_area)) //if deployment zone is empty just spawn at xeno spawn
-			deploy_spot = pick_n_take(deployment_area)
-		var/obj/structure/flotsam/F = new get_turf(deploy_spot)
-		spawned_flotsams += F
-		F.silt = src
-
-/mob/living/simple_animal/hostile/abnormality/siltcurrent/proc/OxygenLoss()//While its alive all humans around it will lose oxygen.
-	for(var/mob/living/carbon/human/H in oview(src, 20))//Used to be global but this should prevent it from being asinine when other abormalities are out
-		playsound(H, "sound/effects/bubbles.ogg", 50, TRUE, 7)
-		new /obj/effect/temp_visual/mermaid_drowning(get_turf(H))
-		H.adjustOxyLoss(4, updating_health=TRUE, forced=TRUE)
-
-/mob/living/simple_animal/hostile/abnormality/siltcurrent/death()
-	icon = 'ModularLobotomy/_Lobotomyicons/abno_cores/waw.dmi'
-	pixel_x = -16
-	base_pixel_x = -16
-	density = FALSE
-	animate(src, alpha = 0, time = 10 SECONDS)
-	QDEL_IN(src, 10 SECONDS)
-	for(var/obj/structure/flotsam/F in spawned_flotsams)
-		QDEL_IN(F, rand(5) SECONDS)
-		spawned_flotsams -= F
-	for(var/obj/effect/obsessing_water_effect/W in water)
-		QDEL_IN(W, rand(5) SECONDS)
-		water -= W
-	..()
-
-/mob/living/simple_animal/hostile/abnormality/siltcurrent/PostSpawn()
-	..()
-	for(var/turf/open/T in range(1, src)) // fill its cell with water
-		T.TerraformTurf(/turf/open/water/deep/obsessing_water, flags = CHANGETURF_INHERIT_AIR)
+		UnregisterFloat(O)
+		qdel(O)
+	spawned_flotsams.Cut()
 
 /obj/structure/flotsam
 	name = "Flotsam"
@@ -291,7 +305,13 @@
 	light_color = COLOR_TEAL
 	light_range = 4
 	light_power = 5
+	//Should be fine since floatsam is destroyed when silt is destroyed so they shouldnt hard del.
 	var/mob/living/simple_animal/hostile/abnormality/siltcurrent/silt
+
+/obj/structure/flotsam/Destroy()
+	if(silt)
+		silt = null
+	return ..()
 
 /obj/structure/flotsam/attackby(obj/item/W, mob/user, params)
 	. = ..()
@@ -314,6 +334,8 @@
 
 /obj/structure/flotsam/proc/Refill(mob/living/attacker)
 	attacker.adjustOxyLoss(-100, updating_health=TRUE, forced=TRUE)
+	if(!silt)
+		return
 	if(!silt.target && !(silt.diving || silt.stunned))
 		silt.dive_cooldown = 0
 		to_chat(attacker, span_userdanger("Something is approaching  you!"))

--- a/code/modules/mob/living/simple_animal/abnormality/waw/spiral.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/spiral.dm
@@ -200,6 +200,28 @@ I'm feeling [strong BLACK/PALE, weak RED/WHITE] or [strong RED/BLACK, weak WHITE
 	var/stagger_unstagger_time = 100
 	var/list/stagger_resistances = list(RED_DAMAGE = 1.5, WHITE_DAMAGE = 1.6, BLACK_DAMAGE = 1.5, PALE_DAMAGE = 2) // WHITE and PALE are slightly higher to keep them as more effective during stagger than just 6 gaze stacks
 
+/mob/living/simple_animal/hostile/abnormality/spiral/Destroy()
+	deltimer(teleport_timer)
+	// Add up the lists that hold all people affected by our status effects, cleanse everyone in those lists and empty them out.
+	var/list/affected_by_stuff = list()
+	affected_by_stuff |= awed_workers
+	affected_by_stuff |= gazed_fighters
+	affected_by_stuff |= contempted_fighters
+	for(var/mob/living/survivor in affected_by_stuff)
+		survivor.remove_status_effect(STATUS_EFFECT_AWE)
+		survivor.remove_status_effect(STATUS_EFFECT_GAZE)
+		survivor.remove_status_effect(STATUS_EFFECT_CONTEMPT)
+	awed_workers = list()
+	gazed_fighters = list()
+	contempted_fighters = list()
+	// Cleanup any Shun mobs that may be left over.
+	for(var/mob/living/simple_animal/spiral_shun/possible_shunners in shun_mobs)
+		shun_mobs -= possible_shunners
+		qdel(possible_shunners)
+
+	shun_mobs = list()
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/spiral/say(message, bubble_type, list/spans, sanitize, datum/language/language, ignore_spam, forced)
 	. = ..()
 	playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 40, TRUE)
@@ -287,26 +309,6 @@ I'm feeling [strong BLACK/PALE, weak RED/WHITE] or [strong RED/BLACK, weak WHITE
 
 // Cleanup on death.
 /mob/living/simple_animal/hostile/abnormality/spiral/death(gibbed)
-	deltimer(teleport_timer)
-	// Add up the lists that hold all people affected by our status effects, cleanse everyone in those lists and empty them out.
-	var/list/affected_by_stuff = list()
-	affected_by_stuff |= awed_workers
-	affected_by_stuff |= gazed_fighters
-	affected_by_stuff |= contempted_fighters
-	for(var/mob/living/survivor in affected_by_stuff)
-		survivor.remove_status_effect(STATUS_EFFECT_AWE)
-		survivor.remove_status_effect(STATUS_EFFECT_GAZE)
-		survivor.remove_status_effect(STATUS_EFFECT_CONTEMPT)
-	awed_workers = list()
-	gazed_fighters = list()
-	contempted_fighters = list()
-	// Cleanup any Shun mobs that may be left over.
-	for(var/mob/living/simple_animal/spiral_shun/possible_shunners in shun_mobs)
-		qdel(possible_shunners)
-		shun_mobs -= possible_shunners
-
-	shun_mobs = list()
-
 	playsound(loc, 'sound/effects/ordeals/crimson/dusk_dead.ogg', 50, 1)
 	for(var/i in 1 to 5)
 		var/atom/temp = new /obj/effect/temp_visual/dir_setting/bloodsplatter(loc, pick(GLOB.alldirs))
@@ -573,6 +575,13 @@ I'm feeling [strong BLACK/PALE, weak RED/WHITE] or [strong RED/BLACK, weak WHITE
 	var/mob/living/simple_animal/hostile/abnormality/spiral/caster
 	var/image/cool_animation
 
+/obj/effect/temp_visual/spiral_grip/Destroy()
+	affected_turfs = null
+	cool_animation = null
+	QDEL_LIST(telegraph_vfx)
+	UnregisterCaster()
+	return ..()
+
 /obj/effect/temp_visual/spiral_grip/Initialize(mapload, radius = 1, windup = 1.2 SECONDS, mob/living/simple_animal/hostile/abnormality/spiral/spiral_ref)
 	. = ..()
 	if(!istype(spiral_ref))
@@ -581,7 +590,7 @@ I'm feeling [strong BLACK/PALE, weak RED/WHITE] or [strong RED/BLACK, weak WHITE
 	transform *= 0.8
 	final_radius = radius
 	final_windup = windup
-	caster = spiral_ref
+	RegisterCaster(spiral_ref)
 	Telegraph()
 
 /// Warns players about the danger tiles, sets a timer to perform the attack based on windup.
@@ -604,9 +613,7 @@ I'm feeling [strong BLACK/PALE, weak RED/WHITE] or [strong RED/BLACK, weak WHITE
 /// Causes the damage and fades out the effect.
 /obj/effect/temp_visual/spiral_grip/proc/Resolve()
 	// Cleanup telegraphs
-	for(var/atom/effect in telegraph_vfx)
-		qdel(effect)
-	QDEL_NULL(telegraph_vfx)
+	QDEL_LIST(telegraph_vfx)
 
 	playsound(get_turf(src), 'sound/abnormalities/so_that_no_cry/attack.ogg', 75)
 
@@ -626,13 +633,24 @@ I'm feeling [strong BLACK/PALE, weak RED/WHITE] or [strong RED/BLACK, weak WHITE
 
 	// Cleanup
 	deltimer(timerid)
-	caster = null
 	affected_turfs = null
 	// Fade out
 	animate(cool_animation, time = fadeout_time * 0.5, alpha = 255)
 	animate(time = fadeout_time * 0.5, alpha = 0 )
 	QDEL_IN(src, fadeout_time + 1)
 	QDEL_IN(cool_animation, fadeout_time + 1)
+
+/obj/effect/temp_visual/spiral_grip/proc/RegisterCaster(mob/living/L)
+	if(!L)
+		return
+	RegisterSignal(L, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterCaster))
+	caster = L
+
+/obj/effect/temp_visual/spiral_grip/proc/UnregisterCaster()
+	if(!caster)
+		return
+	UnregisterSignal(caster, list(COMSIG_PARENT_QDELETING))
+	caster = null
 
 // Telegraph sparkles with a customizable duration
 /obj/effect/temp_visual/sparkles/spiral
@@ -811,6 +829,7 @@ I'm feeling [strong BLACK/PALE, weak RED/WHITE] or [strong RED/BLACK, weak WHITE
 		return
 	spiral_ref.gazed_fighters -= owner
 	spiral_ref = null
+	attached_visual_status = null
 
 /datum/status_effect/stacking/spiral_gaze/threshold_cross_effect()
 	owner.apply_status_effect(STATUS_EFFECT_CONTEMPT, spiral_ref, spiral_ref.shun_windup, spiral_ref.shun_hands_hp, spiral_ref.shun_hands_resistances, spiral_ref.shun_radius)
@@ -1006,6 +1025,9 @@ I'm feeling [strong BLACK/PALE, weak RED/WHITE] or [strong RED/BLACK, weak WHITE
 	unbuckle_all_mobs(force = TRUE)
 	QDEL_NULL(contempt_status)
 	victim = null
+	affected_turfs = null
+	telegraph_vfx = null
+	QDEL_NULL(cool_animation)
 	return ..()
 
 /mob/living/simple_animal/spiral_shun/death(gibbed)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
@@ -134,6 +134,10 @@
 	StartCooldown()
 	return TRUE
 
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/Destroy()
+	UnregisterAll()
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/wrath_servant/Initialize(mapload)
 	. = ..()
 	RegisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH, PROC_REF(OnMobDeath))
@@ -291,7 +295,7 @@
 					"\"Friend\" is not a word in the book of law...",
 					"I can be a friend that you deserve.",
 				))
-				friend_ship += user
+				RegisterMob(user)
 				AdjustInstability(8) // Was 5
 				return
 		if(ABNORMALITY_WORK_REPRESSION)
@@ -540,7 +544,7 @@
 	ADD_TRAIT(src, TRAIT_MOVE_FLYING, ROUNDSTART_TRAIT)
 	animate(src, alpha = 255, time = 5)
 	new /obj/effect/temp_visual/guardian/phase/out(get_turf(src))
-	friend_ship = list()
+	UnregisterAll()
 	breach_affected = list()
 	src.datum_reference.qliphoth_change(5)
 	density = TRUE
@@ -660,6 +664,19 @@
 	new /obj/effect/temp_visual/guardian/phase/out(teleport_target)
 	forceMove(teleport_target)
 
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/proc/RegisterMob(mob/living/L)
+	RegisterSignal(L, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMob))
+	friend_ship += L
+
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/proc/UnregisterMob(mob/living/L)
+	UnregisterSignal(L, list(COMSIG_PARENT_QDELETING))
+	friend_ship -= L
+
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/proc/UnregisterAll()
+	for(var/mob/living/L in friend_ship)
+		UnregisterMob(L)
+	friend_ship.Cut()
+
 //Rival's code
 /mob/living/simple_animal/hostile/azure_hermit
 	name = "Hermit of the Azure Forest"
@@ -769,7 +786,7 @@
 			var/mob/living/simple_animal/hostile/azure_stave/AS = new(TT)
 			staves += AS
 			AS = new(TT)
-			staves += AS
+			RegisterMob(AS)
 			return
 	return ..()
 
@@ -795,7 +812,7 @@
 	playsound(src, 'sound/abnormalities/wrath_servant/hermit_magic.ogg', 60, FALSE, 10)
 	for(var/i = 0 to min(rand(1, 3), valid_turfs.len))
 		var/mob/living/simple_animal/hostile/azure_stave/AS = new(pick(valid_turfs))
-		staves += AS
+		RegisterMob(AS)
 	COOLDOWN_START(src, conjure, conjure_cooldown)
 	return
 
@@ -828,6 +845,10 @@
 	adjustBruteLoss(-maxHealth, forced = TRUE)
 	density = TRUE
 
+/mob/living/simple_animal/hostile/azure_hermit/Destroy()
+	UnregisterAll()
+	return ..()
+
 /mob/living/simple_animal/hostile/azure_hermit/death()
 	INVOKE_ASYNC(src, PROC_REF(Downed))
 
@@ -840,12 +861,24 @@
 	icon_state = icon_dead
 	density = FALSE
 	status_flags |= GODMODE
-	for(var/mob/living/L in staves)
-		L.visible_message(span_notice("[L] crumbles before you!"))
-		qdel(L)
 	animate(src, alpha = 0, time = (15 SECONDS))
 	QDEL_IN(src, 15 SECONDS)
 	return
+
+/mob/living/simple_animal/hostile/azure_hermit/proc/RegisterMob(mob/living/L)
+	RegisterSignal(L, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMob))
+	staves += L
+
+/mob/living/simple_animal/hostile/azure_hermit/proc/UnregisterMob(mob/living/L)
+	UnregisterSignal(L, list(COMSIG_PARENT_QDELETING))
+	staves -= L
+
+/mob/living/simple_animal/hostile/azure_hermit/proc/UnregisterAll()
+	for(var/mob/living/L in staves)
+		UnregisterMob(L)
+		L.visible_message(span_notice("[L] crumbles before you!"))
+		qdel(L)
+	staves.Cut()
 
 /mob/living/simple_animal/hostile/azure_stave
 	name = "Hermit's Staff"
@@ -874,7 +907,7 @@
 
 	del_on_death = TRUE
 
-/obj/effect/decal/cleanable/wrath_acid/
+/obj/effect/decal/cleanable/wrath_acid
 	name = "Not-so Acidic Goo"
 	desc = "Ah, that kinda stings..."
 	icon = 'ModularLobotomy/_Lobotomyicons/tegu_effects.dmi'
@@ -928,7 +961,7 @@
 	var/mob/living/L = AM
 	L.apply_status_effect(STATUS_EFFECT_ACIDIC_GOO)
 
-/obj/effect/decal/cleanable/wrath_acid/bad/
+/obj/effect/decal/cleanable/wrath_acid/bad
 	name = "Acidic Goo"
 	desc = "It seems to burn whatever it touches, best to stay away!"
 

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
@@ -33,11 +33,6 @@
 	gift_type =  /datum/ego_gifts/wingbeat
 	gift_message = "Fairy Dust covers your hands..."
 
-	var/heal_duration = 120 SECONDS
-	var/heal_amount = 0.05
-	var/heal_cooldown = 2 SECONDS
-	var/heal_cooldown_base = 2 SECONDS
-	var/list/mob/living/carbon/human/protected_people = list()
 	var/summon_count = 0
 	var/summon_type = /mob/living/simple_animal/hostile/mini_fairy
 	var/summon_cooldown
@@ -67,27 +62,13 @@
 			You retreat from the cell and the fairies' hungry gazes. <br>You've always known the true meaning of The Fairies' Care."),
 	)
 
-/mob/living/simple_animal/hostile/abnormality/fairy_festival/proc/FairyHeal()
-	for(var/mob/living/carbon/human/P in protected_people)
-		if(heal_cooldown <= world.time)
-			P.adjustBruteLoss(-heal_amount*P.getMaxHealth())
-			P.adjustFireLoss(-heal_amount*P.getMaxHealth())
-	heal_cooldown = (world.time + heal_cooldown_base)
-	return
-
 /mob/living/simple_animal/hostile/abnormality/fairy_festival/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	. = ..()
 	if(user.stat != DEAD && istype(user))
-		if(user in protected_people)
+		if(user.has_status_effect(/datum/status_effect/fairy_care))
 			return
 		flick("fairy_blessing",src)
-		protected_people += user
-		RegisterSignal(user, COMSIG_WORK_STARTED, PROC_REF(FairyPause))
-		RegisterSignal(user, COMSIG_WORK_COMPLETED, PROC_REF(FairyRestart))
-		to_chat(user, span_nicegreen("You feel at peace under the fairies' care."))
-		playsound(get_turf(user), 'sound/abnormalities/fairyfestival/fairylaugh.ogg', 50, 0, 2)
-		user.add_overlay(mutable_appearance('ModularLobotomy/_Lobotomyicons/tegu_effects.dmi', "fairy_heal", -MUTATIONS_LAYER))
-		addtimer(CALLBACK(src, PROC_REF(FairyEnd), user), heal_duration)
+		user.apply_status_effect(/datum/status_effect/fairy_care)
 	return
 
 /mob/living/simple_animal/hostile/abnormality/fairy_festival/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
@@ -96,43 +77,10 @@
 
 /mob/living/simple_animal/hostile/abnormality/fairy_festival/Life()
 	. = ..()
-	if(protected_people.len)
-		FairyHeal()
 	if(summon_count >= summon_maximum)
 		return
 	if((summon_cooldown < world.time) && !(status_flags & GODMODE))
 		SummonGuys(summon_type)
-
-/mob/living/simple_animal/hostile/abnormality/fairy_festival/proc/FairyEnd(mob/living/carbon/human/user)
-	protected_people.Remove(user)
-	user.cut_overlay(mutable_appearance('ModularLobotomy/_Lobotomyicons/tegu_effects.dmi', "fairy_heal", -MUTATIONS_LAYER))
-	to_chat(user, span_notice("The fairies giggle before returning to their queen."))
-	UnregisterSignal(user, COMSIG_WORK_STARTED)
-	UnregisterSignal(user, COMSIG_WORK_COMPLETED)
-	return
-
-/mob/living/simple_animal/hostile/abnormality/fairy_festival/proc/FairyPause(datum/source, datum/abnormality/datum_sent, mob/living/carbon/human/user, work_type)
-	SIGNAL_HANDLER
-	to_chat(user, span_notice("The fairies suddenly go eerily quiet."))
-	protected_people.Remove(user)
-
-/mob/living/simple_animal/hostile/abnormality/fairy_festival/proc/FairyRestart(datum/source, datum/abnormality/datum_sent, mob/living/carbon/human/user, work_type)
-	SIGNAL_HANDLER
-	to_chat(user, span_nicegreen("The fairies start giggling and playing once more."))
-	protected_people |= user
-	playsound(get_turf(user), 'sound/abnormalities/fairyfestival/fairylaugh.ogg', 50, 0, 2)
-
-//not called by anything anymore, left here if somebody wants to readd it later for any reason.
-/mob/living/simple_animal/hostile/abnormality/fairy_festival/proc/FairyGib(datum/source, datum/abnormality/datum_sent, mob/living/carbon/human/user, work_type)
-	SIGNAL_HANDLER
-	if(((user in protected_people) && datum_sent != datum_reference) && !(GODMODE in user.status_flags))
-		to_chat(user, span_userdanger("With a beat of their wings, the fairies pounce on you and ravenously consume your body!"))
-		playsound(get_turf(user), 'sound/magic/demon_consume.ogg', 75, 0)
-		UnregisterSignal(user, COMSIG_WORK_STARTED)
-		UnregisterSignal(user, COMSIG_WORK_COMPLETED)
-		protected_people.Remove(user)
-		user.gib()
-	return
 
 /mob/living/simple_animal/hostile/abnormality/fairy_festival/BreachEffect(mob/living/carbon/human/user, breach_type)
 	if(breach_type == BREACH_PINK)
@@ -160,7 +108,7 @@
 	if(istype(attacked_target, /mob/living/simple_animal/hostile/fairy_mass))
 		var/mob/living/L = attacked_target
 		if(L.health > 0)//fairies have to be alive; scarred meat isn't tasty
-			L.gib()
+			L.gib(TRUE,TRUE,TRUE)
 			ProcessKill()
 			playsound(get_turf(src), "sound/abnormalities/fairyfestival/fairyqueen_growl.ogg", 100, FALSE)
 			return
@@ -171,7 +119,7 @@
 			playsound(get_turf(src), "sound/abnormalities/fairyfestival/fairyqueen_growl.ogg", 100, FALSE)
 			if(ishuman(L))
 				ProcessKill()
-			L.gib()
+			L.gib(TRUE,TRUE,TRUE)
 
 //Cannibalism
 /mob/living/simple_animal/hostile/abnormality/fairy_festival/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
@@ -212,6 +160,95 @@
 	playsound(get_turf(src), "sound/abnormalities/fairyfestival/fairyqueen_growl.ogg", 100, FALSE)
 	if(move_to_delay>1)
 		ChangeMoveToDelayBy(-1)
+
+/*------------\
+|Status Effect|
+\------------*/
+/datum/status_effect/fairy_care
+	id = "fairy care"
+	status_type = STATUS_EFFECT_UNIQUE
+	duration = 120 SECONDS
+	tick_interval = 2 SECONDS
+	alert_type = null
+	on_remove_on_mob_delete = TRUE
+	var/heal_amount = 0.05
+	var/leftover_duration
+	var/healing = TRUE
+	var/image/fairy_overlay
+
+/datum/status_effect/fairy_care/on_apply()
+	. = ..()
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	ApplyFairyOverlay()
+	RegisterSignal(status_holder, COMSIG_WORK_STARTED, PROC_REF(FairyPause))
+	RegisterSignal(status_holder, COMSIG_WORK_COMPLETED, PROC_REF(FairyRestart))
+	to_chat(status_holder, span_nicegreen("You feel at peace under the fairies' care."))
+	playsound(get_turf(status_holder), 'sound/abnormalities/fairyfestival/fairylaugh.ogg', 50, 0, 2)
+
+/datum/status_effect/fairy_care/tick()
+	if(owner.stat != DEAD)
+		if(healing)
+			var/mob/living/L = owner
+			var/our_max_health = L.getMaxHealth()
+			L.adjustBruteLoss(-heal_amount*our_max_health)
+			L.adjustFireLoss(-heal_amount*our_max_health)
+			return
+		var/list/ominous_warnings = list("Some light green fluid drips onto your shoulder.",
+			"Out of the corner of your vision you see a fairy staring at you with its mouth hanging open.",
+			"You occasionally hear the fluttering of fairy wings as they reposition themselves on your shoulder.",
+			"Very faintly you hear a gurgle.",
+			"Some of the fairies follow close to the back of your ankles while you work.",
+			"You stumble and for a moment the beating of fairy wings grows louder.",
+			"")
+		if(prob(15))
+			to_chat(owner, span_notice("[pick(ominous_warnings)]"))
+	return ..()
+
+/datum/status_effect/fairy_care/on_remove()
+	. = ..()
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	RemoveFairyOverlay()
+	to_chat(status_holder, span_notice("The fairies giggle before returning to their queen."))
+	UnregisterSignal(status_holder, COMSIG_WORK_STARTED)
+	UnregisterSignal(status_holder, COMSIG_WORK_COMPLETED)
+
+/datum/status_effect/fairy_care/proc/ApplyFairyOverlay()
+	fairy_overlay = mutable_appearance('ModularLobotomy/_Lobotomyicons/tegu_effects.dmi',"fairy_heal", -HALO_LAYER)
+	var/mob/living/L = owner
+	L.add_overlay(fairy_overlay)
+
+/datum/status_effect/fairy_care/proc/RemoveFairyOverlay()
+	var/mob/living/L = owner
+	L.cut_overlay(fairy_overlay)
+	fairy_overlay = null
+
+/datum/status_effect/fairy_care/proc/FairyPause(datum/source, datum/abnormality/datum_sent, mob/living/carbon/human/user, work_type)
+	SIGNAL_HANDLER
+	//sloppy i know -IP
+	healing = FALSE
+	leftover_duration = duration - world.time
+	duration = world.time + 5 MINUTES
+	to_chat(user, span_notice("The fairies suddenly go eerily quiet."))
+
+/datum/status_effect/fairy_care/proc/FairyRestart(datum/source, datum/abnormality/datum_sent, mob/living/carbon/human/user, work_type)
+	SIGNAL_HANDLER
+	healing = TRUE
+	to_chat(user, span_nicegreen("The fairies start giggling and playing once more."))
+	playsound(get_turf(user), 'sound/abnormalities/fairyfestival/fairylaugh.ogg', 50, 0, 2)
+	duration = world.time + leftover_duration
+
+/* not called by anything anymore, left here if somebody wants to readd it later for any reason.
+/datum/status_effect/fairy_care/proc/FairyGib(datum/source, datum/abnormality/datum_sent, mob/living/carbon/human/user, work_type)
+	SIGNAL_HANDLER
+	if(!(GODMODE in user.status_flags))
+		to_chat(user, span_userdanger("With a beat of their wings, the fairies pounce on you and ravenously consume your body!"))
+		playsound(get_turf(user), 'sound/magic/demon_consume.ogg', 75, 0)
+		user.gib(TRUE,TRUE,TRUE)
+*/
 
 /datum/reagent/abnormality/fairy_festival
 	name = "Nectar of an Unknown Flower"

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
@@ -45,7 +45,7 @@
 	var/sealed = TRUE
 	var/hammer_present = TRUE
 	var/hammer_used = FALSE
-	var/list/spawned_mobs = list()
+	//Uses Ckeys
 	var/list/banned = list()
 	var/mob/living/carbon/human/current_user = null
 	var/obj/item/ego_weapon/chosen_arms = null
@@ -64,6 +64,10 @@
 		'sound/abnormalities/lighthammer/hammer_usable1.ogg',
 		'sound/abnormalities/lighthammer/hammer_usable2.ogg',
 	)
+
+/mob/living/simple_animal/hostile/abnormality/hammer_light/Destroy()
+	RecoverHammer()
+	return ..()
 
 // Work Mechanic
 /mob/living/simple_animal/hostile/abnormality/hammer_light/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
@@ -200,8 +204,10 @@
 		RecoverHammer()
 
 /mob/living/simple_animal/hostile/abnormality/hammer_light/proc/RecoverHammer()
-	UnregisterSignal(current_user, COMSIG_LIVING_DEATH)
-	qdel(chosen_arms)
+	if(current_user)
+		UnregisterSignal(current_user, COMSIG_LIVING_DEATH)
+	if(chosen_arms)
+		qdel(chosen_arms)
 	chosen_arms = null
 	current_user = null
 	sealed = TRUE
@@ -210,9 +216,9 @@
 	update_icon()
 
 /mob/living/simple_animal/hostile/abnormality/hammer_light/proc/UserDeath(mob/living/carbon/human/user)
-	if(!QDELETED(current_user)) // in case they died without being dusted
-		current_user.dust()
 	RecoverHammer()
+	if(!QDELETED(user)) // in case they died without being dusted
+		user.dust()
 
 // Pink Midnight
 /mob/living/simple_animal/hostile/abnormality/hammer_light/BreachEffect(mob/living/carbon/human/user, breach_type = BREACH_NORMAL)
@@ -270,6 +276,10 @@
 	var/datum/action/spell_action/ability/item/A = AS.action
 	A.SetItem(src)
 
+/obj/item/ego_weapon/hammer_light/Destroy()
+	UnregisterAll()
+	return ..()
+
 /obj/item/ego_weapon/hammer_light/CanUseEgo(mob/living/carbon/human/user)
 	. = ..()
 	var/datum/status_effect/evening_twilight/E = user.has_status_effect(/datum/status_effect/evening_twilight)
@@ -289,23 +299,27 @@
 	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 
 /obj/item/ego_weapon/hammer_light/attack_self(mob/user)
+	var/list/light_turfs = orange(1,get_turf(user))
+	var/list/our_mobs = spawned_mobs.Copy()
+	var/turf/T = pick_n_take(light_turfs)
 	if(!CanUseEgo(user))
 		return
 	if(spawn_cooldown >= world.time)
 		return
 	spawn_cooldown = world.time + spawn_cooldown_time
-	if(LAZYLEN(spawned_mobs))
-		for(var/mob/living/L in spawned_mobs)
-			qdel(L)
-	listclearnulls(spawned_mobs)
-	var/directions = GLOB.cardinals.Copy()
 	for(var/i=spawned_mob_max, i>=1, i--)	// This counts down.
-		var/turf/T = (get_step(user,pick_n_take(directions)))
-		var/mob/living/simple_animal/hostile/lighthammer/V = new(T)
+		T = pick_n_take(light_turfs)
+		if(LAZYLEN(our_mobs))
+			//Reduce Reuse and Recycling
+			var/mob/living/L = pop(our_mobs)
+			L.forceMove(T)
+		else
+			var/mob/living/simple_animal/hostile/lighthammer/V = new(T)
+			RegisterMob(V)
+			V.summoned = TRUE
+			V.faction = user.faction.Copy()
 		new /obj/effect/temp_visual/beam_in(T)
-		V.summoned = TRUE
-		spawned_mobs+=V
-		V.faction = user.faction.Copy()
+
 	playsound(user, 'sound/weapons/black_silence/snap.ogg', 50, FALSE)
 
 /obj/item/ego_weapon/hammer_light/attack(mob/living/target, mob/living/carbon/human/user)
@@ -324,12 +338,25 @@
 	if(faction_check(target))	 // Brute damage causes runtimes, and this thing does INSANE, unblockable damage. I dont want people getting unfairly killed
 		force = 5
 		to_chat(user, span_warning("The [src] rejects the attempted killing of [target] this way!"))
-	..()
+	. = ..()
 	force = initial(force)
 	damtype = initial(damtype)
 
 /obj/item/ego_weapon/hammer_light/get_clamped_volume()
 	return 40
+
+/obj/item/ego_weapon/hammer_light/proc/RegisterMob(mob/living/L)
+	RegisterSignal(L, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMob))
+	spawned_mobs += L
+
+/obj/item/ego_weapon/hammer_light/proc/UnregisterMob(mob/living/L)
+	UnregisterSignal(L, list(COMSIG_PARENT_QDELETING))
+	spawned_mobs -= L
+
+/obj/item/ego_weapon/hammer_light/proc/UnregisterAll()
+	for(var/mob/living/L in spawned_mobs)
+		UnregisterMob(L)
+	QDEL_LIST(spawned_mobs)
 
 // Item's teleport ability
 /obj/effect/proc_holder/ability/evening_twilight
@@ -352,8 +379,9 @@
 			continue
 		if(H.status_flags & GODMODE)
 			continue
-		if(user.faction_check_mob(H, FALSE))
-			continue
+		if(user)
+			if(user.faction_check_mob(H))
+				continue
 		if(H in view(7, user))
 			continue
 		var/t_dist = get_dist(user, H)
@@ -383,11 +411,11 @@
 	duration = 5 MINUTES // max duration
 	alert_type = null
 	var/attribute_bonus = 0
-	var/mob/living/simple_animal/hostile/abnormality/hammer_light/parent
+	var/datum/weakref/parent
 
 /datum/status_effect/evening_twilight/on_creation(mob/living/new_owner, hammer)
 	. = ..()
-	parent = hammer
+	parent = WEAKREF(hammer)
 
 /datum/status_effect/evening_twilight/on_apply()
 	if(!ishuman(owner))
@@ -409,7 +437,10 @@
 /datum/status_effect/evening_twilight/on_remove()
 	if(!ishuman(owner))
 		return
-	parent.RecoverHammer()
+
+	var/mob/living/simple_animal/hostile/abnormality/hammer_light/hammer = parent?.resolve()
+	if(hammer)
+		hammer.RecoverHammer()
 	var/mob/living/carbon/human/status_holder = owner
 	REMOVE_TRAIT(status_holder, TRAIT_COMBATFEAR_IMMUNE, "Abnormality")
 	REMOVE_TRAIT(status_holder, TRAIT_WORK_FORBIDDEN, "Abnormality")


### PR DESCRIPTION
## About The Pull Request
Fixes more hard delete code.
Major Changes:
- Adds "GetCurrent" proc to abno datum to return the current abno.
- Replaces blue shep and red buddy's hard refrences with a .GetCurrent() from their datums.
- Refactors blue shep and red buddy to have most of the tracking and "awakening" code be in blue shep. Blue shep is also the only one of the pair that continues to exist after the other perishes.
- Road Home now uses weakrefs for her status effects but now monitors the status effects applied rather than the mobs its applied to.
- woodsmans chained_target is now a weakref to avoid hard deletes if gibbed during chaining.
- hurt_teddy now has a weakref to the person it is currently hugging.
- bigwolf now calls mercenary.GivePriorityTarget(src)
- Burrowing Heaven now reuses their spawned creatures instead of spawning new ones if the previous ones had survived.
- Dreaming Current reuses its own hit mob list in the proc.
- Pygmalion now SculptorDeathOrInsane on Destroy
- Spiral of Contempt appears to handle hard deletes already but needed to have its stuff moved to Destroy
- Changes fairy festivals fairies into a status effect rather than a monitor from the abnormality.
- Mermaid has been heavily refactored to use signals.

Testing doesnt seem to cause any issues...
Hammer of Light still works.

Adds Register Mob:
- Doomsday Calender
- The Loathesome Pinnochio
- Puss in Boots
- Singing Machine
- Faelantern
- Babayaga
- Judgement Bird
- my_form_empties
- Nosferatu
- rose_sign 
- Wrath Servant
- Hammer of Light

## Why It's Good For The Game
Hopefully improves preformance.

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [ ] This PR compiles
* [ ] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
code: improves some code to prevent hard deletes among abnormalities.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
