### PR TITLE
Tags and Simple Stuff [DONE]

### DIFF
--- a/code/game/objects/effects/abnormality.dm
+++ b/code/game/objects/effects/abnormality.dm
@@ -175,7 +175,6 @@
 	movement_type = PHASING | FLYING
 	pixel_y = -32
 	pixel_x = -32
-	var/list/damaged = list()
 	animate_movement = SLIDE_STEPS
 	var/clickety = 0
 	var/noise = 0

--- a/code/modules/mob/living/simple_animal/abnormality/he/drifting_fox.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/drifting_fox.dm
@@ -71,6 +71,7 @@
 			It seemed to reprimand your attitude of pursuing resolution without forethought."),
 	)
 
+	//Uses tags
 	var/list/pet = list()
 	pet_bonus = "yips"
 	var/umbrella_spawn_number = 1
@@ -78,6 +79,9 @@
 	var/umbrella_spawn_limit = 4
 	var/list/spawned_mobs = list()
 	var/initial_mobs_spawned
+	//Cooldown for teleporting unbrellas
+	var/teleport_cooldown_time = 10 SECONDS
+	var/teleport_cooldown
 
 /mob/living/simple_animal/hostile/abnormality/drifting_fox/Login()
 	. = ..()
@@ -91,29 +95,29 @@
 		However, if the umbrellas are broken you will lose 5% for each umbrella broken.<br></b>")
 
 /mob/living/simple_animal/hostile/abnormality/drifting_fox/funpet(mob/petter)
-	pet |= petter
+	pet |= petter.tag
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/drifting_fox/AttemptWork(mob/living/carbon/human/user, work_type)
-	if(user in pet)
+	if(user.tag in pet)
 		if(work_type == ABNORMALITY_WORK_ATTACHMENT)
 			to_chat(user, span_notice("The abnormality seems to like this type of work more than usual!"))
 		else
 			to_chat(user, span_warning("The abnormality does not seem happy with your choice of work."))
-	. = ..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/drifting_fox/WorkChance(mob/living/carbon/human/user, chance, work_type)
-	if(user in pet)
+	if(user.tag in pet)
 		if(work_type == ABNORMALITY_WORK_ATTACHMENT)
 			chance += 30
 		else
 			chance -= 10
 		return chance
-	. = ..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/drifting_fox/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
-	if(user in pet)
-		pet -= user
+	if(user.tag in pet)
+		pet -= user.tag
 	if(get_attribute_level(user, TEMPERANCE_ATTRIBUTE) < 40)
 		datum_reference.qliphoth_change(-1)
 	return
@@ -128,6 +132,10 @@
 	icon_state = icon_living
 	pixel_y = -6
 
+/mob/living/simple_animal/hostile/abnormality/drifting_fox/Destroy()
+	UnregisterAll()
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/drifting_fox/death(gibbed)
 	icon = 'ModularLobotomy/_Lobotomyicons/abno_cores/he.dmi'
 	pixel_x = -16
@@ -135,7 +143,7 @@
 	density = FALSE
 	animate(src, alpha = 0, time = 10 SECONDS)
 	QDEL_IN(src, 10 SECONDS)
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/drifting_fox/Life()
 	. = ..()
@@ -148,12 +156,17 @@
 		for(var/i=4, i>=1, i--) //spawn 4 umbrellas right off the bat
 			var/mob/living/simple_animal/hostile/umbrella/newmob = new(get_turf(src))
 			newmob.faction = faction
-			spawned_mobs+=newmob
-			newmob.friend = src
+			RegisterMob(newmob)
 			newmob.GoToFox()
 			newmob.ranged_cooldown_time = rand(20,80)
 			move_to_delay = clamp(move_to_delay - 1, 3, 7) //Speed up
 			UpdateSpeed()
+	if(length(spawned_mobs) && teleport_cooldown <= world.time)
+		for(var/mob/living/simple_animal/hostile/umbrella/L in spawned_mobs)
+			if(!L)
+				continue
+			L.GoToFox(src)
+		teleport_cooldown = world.time + teleport_cooldown_time
 
 /mob/living/simple_animal/hostile/abnormality/drifting_fox/AttackingTarget(atom/attacked_target)
 	..()
@@ -166,16 +179,11 @@
 		Dodge()
 
 /mob/living/simple_animal/hostile/abnormality/drifting_fox/proc/UmbrellaLoop()
-	listclearnulls(spawned_mobs)
-	for(var/mob/living/L in spawned_mobs)
-		if(L.stat == DEAD)
-			spawned_mobs -= L
-	if(length(spawned_mobs) > umbrella_spawn_limit)
+	if(length(spawned_mobs) >= umbrella_spawn_limit)
 		return
 	var/mob/living/simple_animal/hostile/umbrella/newmob = new(get_turf(src))
-	newmob.faction = faction
-	spawned_mobs+=newmob
-	newmob.friend = src
+	newmob.faction = faction.Copy()
+	RegisterMob(newmob)
 	newmob.GoToFox()
 	newmob.ranged_cooldown_time = rand(20,80)
 	move_to_delay = clamp(move_to_delay - 1, 3, 7) //Speed up
@@ -188,8 +196,8 @@
 	if(length(spawned_mobs) < umbrella_spawn_limit)
 		var/mob/living/simple_animal/hostile/umbrella/newmob = new(get_turf(src))
 		newmob.faction = faction
-		spawned_mobs+=newmob
-		newmob.friend = src
+		RegisterMob(newmob)
+		newmob.friends += tag
 		newmob.GoToFox()
 		newmob.ranged_cooldown_time = rand(20,80)
 
@@ -218,6 +226,23 @@
 
 	density = TRUE
 
+/mob/living/simple_animal/hostile/abnormality/drifting_fox/proc/RegisterMob(mob/living/L)
+	RegisterSignal(L, list(COMSIG_PARENT_QDELETING), PROC_REF(UnregisterMob))
+	spawned_mobs += L
+
+/mob/living/simple_animal/hostile/abnormality/drifting_fox/proc/UnregisterMob(mob/living/L)
+	UnregisterSignal(L, list(COMSIG_PARENT_QDELETING))
+	if(istype(L, /mob/living/simple_animal/hostile/umbrella) && stat != DEAD)
+		deal_damage(100, BLACK_DAMAGE, flags = (DAMAGE_FORCED | DAMAGE_UNTRACKABLE), attack_type = (ATTACK_TYPE_SPECIAL))
+		move_to_delay = clamp(move_to_delay + 1, 3, 7) //Slowdown
+	spawned_mobs -= L
+
+/mob/living/simple_animal/hostile/abnormality/drifting_fox/proc/UnregisterAll()
+	for(var/mob/living/L in spawned_mobs)
+		UnregisterMob(L)
+		if(!QDELETED(L))
+			L.death()
+	spawned_mobs.Cut()
 
 //Summons
 /mob/living/simple_animal/hostile/umbrella
@@ -235,36 +260,18 @@
 	del_on_death = FALSE
 	ranged = TRUE
 	ranged_cooldown_time = 3 SECONDS
-	var/teleport_cooldown_time = 10 SECONDS
-	var/teleport_cooldown
-	/// The drifting fox
-	var/mob/living/simple_animal/hostile/abnormality/friend
 
 /// Deal damge to the fox
 /mob/living/simple_animal/hostile/umbrella/death(gibbed)
 	visible_message(span_notice("[src] falls to the ground as the umbrella closes in on itself!"))
-	if(friend)
-		friend.deal_damage(100, BLACK_DAMAGE, flags = (DAMAGE_FORCED | DAMAGE_UNTRACKABLE), attack_type = (ATTACK_TYPE_SPECIAL))
-		friend.move_to_delay = clamp(move_to_delay + 1, 3, 7) //Slowdown
 	animate(src, alpha = 0, time = 10 SECONDS)
 	QDEL_IN(src, 10 SECONDS)
 	return ..()
 
-///checks if the fox is in view every 10 seconds, and if not teleports to it
-/mob/living/simple_animal/hostile/umbrella/Life()
-	. = ..()
-	if(!friend || stat == DEAD) //for some reason life() works on death ain't that something
-		return
-	if(QDELETED(friend) || friend.status_flags & GODMODE) //Fox died, we're gone too
-		death()
-		return
-	if(teleport_cooldown < world.time)
-		teleport_cooldown = world.time + teleport_cooldown_time
-		if(!can_see(src, friend, vision_range))
-			GoToFox()
-
-/mob/living/simple_animal/hostile/umbrella/proc/GoToFox()
+/mob/living/simple_animal/hostile/umbrella/proc/GoToFox(mob/living/friend)
 	if(!friend)
+		return
+	if(can_see(src, friend, vision_range))
 		return
 	var/turf/move_turf = get_step(friend, pick(1,2,4,5,6,8,9,10))
 	if(!isopenturf(move_turf))

--- a/code/modules/mob/living/simple_animal/abnormality/he/fan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/fan.dm
@@ -39,6 +39,7 @@
 		"Set it to 2" = list(FALSE, "You can barely feel a breeze, you just need a little more..."),
 	)
 
+	//uses tags
 	var/list/safe = list()
 	var/list/warning = list()
 	var/list/danger = list()
@@ -73,7 +74,7 @@
 		if(user.mind.fan_triggers >= 5)
 			user.client?.give_award(/datum/award/achievement/abno/fan_trigger, user)
 
-	if(user in danger)
+	if(user.tag in danger)
 		if(safework)
 			to_chat(user, span_notice("You don't feel quite as tempted this time."))
 			safework = FALSE
@@ -84,16 +85,16 @@
 		playsound(loc, 'sound/machines/juicer.ogg', 100, TRUE)
 		user.gib()
 
-	else if(user in warning)
-		danger+=user
+	else if(user.tag in warning)
+		danger+=user.tag
 		to_chat(user, span_nicegreen("You feel elated."))
 
-	else if(user in safe)
-		warning+=user
+	else if(user.tag in safe)
+		warning+=user.tag
 		to_chat(user, span_nicegreen("You feel refreshed."))
 
 	else
-		safe+=user
+		safe+=user.tag
 		to_chat(user, span_nicegreen("You could use some more."))
 
 //Meltdown

--- a/code/modules/mob/living/simple_animal/abnormality/he/funeral.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/funeral.dm
@@ -179,7 +179,6 @@
 		i++
 	SLEEP_CHECK_DEATH(10 SECONDS)
 	icon_state = icon_living
-	swarm_killed = list()
 	can_act = TRUE
 	swarm_cooldown = world.time + swarm_cooldown_time
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/galaxy_child.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/galaxy_child.dm
@@ -165,16 +165,14 @@
 	galaxy_friends -= dead_friend
 	datum_reference.qliphoth_change(-4)
 	dead_friend.remove_status_effect(STATUS_EFFECT_FRIENDSHIP)
-	UnregisterSignal(dead_friend, COMSIG_LIVING_DEATH)
-	UnregisterSignal(dead_friend, COMSIG_PARENT_QDELETING)
+	UnregisterSignal(dead_friend, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING))
 	new /obj/effect/temp_visual/pebblecrack(get_turf(dead_friend))
 	playsound(dead_friend, "shatter", 50, TRUE)
 	to_chat(src, span_userdanger("You sense that one of your friends has perished and feel your heart ache."))
 
 /mob/living/simple_animal/hostile/abnormality/galaxy_child/proc/on_friend_deletion(mob/deleted_friend)
 	SIGNAL_HANDLER
-	UnregisterSignal(deleted_friend, COMSIG_LIVING_DEATH)
-	UnregisterSignal(deleted_friend, COMSIG_PARENT_QDELETING)
+	UnregisterSignal(deleted_friend, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_QDELETING))
 	galaxy_friends -= deleted_friend
 
 /datum/action/cooldown/friend_gift

--- a/code/modules/mob/living/simple_animal/abnormality/he/happy_teddy_bear.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/happy_teddy_bear.dm
@@ -114,8 +114,8 @@
 /mob/living/simple_animal/hostile/abnormality/happyteddybear/AttemptWork(mob/living/carbon/human/user, work_type)
 	if(hugging) // can't work while someone is being killed by it
 		return FALSE
-	if(user == last_worker)
+	if(user.tag == last_worker)
 		Strangle(user)
 		return FALSE
-	last_worker = user
+	last_worker = user.tag
 	return TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/he/headless_ichthys.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/headless_ichthys.dm
@@ -86,6 +86,11 @@
 	chosen_message = span_colossus("You will now fire a blood cannon.")
 	chosen_attack_num = 2
 
+/mob/living/simple_animal/hostile/abnormality/headless_ichthys/Destroy()
+	if(current_beam)
+		QDEL_NULL(current_beam)
+	return ..()
+
 // Attacks
 /mob/living/simple_animal/hostile/abnormality/headless_ichthys/proc/IchthysJump(mob/living/target)
 	if(!isliving(target) && !ismecha(target) || !can_act)

--- a/code/modules/mob/living/simple_animal/abnormality/he/highway_devotee.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/highway_devotee.dm
@@ -68,14 +68,12 @@
 		talk = TRUE
 		break
 
-/mob/living/simple_animal/hostile/abnormality/highway_devotee/death(gibbed)
-	for(var/obj/Y in structures)
-		qdel(Y)
-	..()
+/mob/living/simple_animal/hostile/abnormality/highway_devotee/Destroy()
+	QDEL_LIST(structures)
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/highway_devotee/proc/KillYourself()
-	for(var/obj/Y in structures)
-		qdel(Y)
+	QDEL_LIST(structures)
 	QDEL_NULL(src)
 
 /* Work effects */

--- a/code/modules/mob/living/simple_animal/abnormality/he/nameless_fetus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/nameless_fetus.dm
@@ -41,7 +41,7 @@
 			You plugged your ears silently. <br>No sound is heard."),
 	)
 
-	var/mob/living/carbon/human/calling = null
+	var/calling_tag
 	var/criesleft = 2
 
 
@@ -54,23 +54,23 @@
 	addtimer(CALLBACK(src, PROC_REF(IncreaseCries)), 3 MINUTES)
 	criesleft++
 
-
 /mob/living/simple_animal/hostile/abnormality/fetus/ZeroQliphoth(mob/living/carbon/human/user)
 	check_players()
 	check_range()
 
 	//Are they nearby?
 /mob/living/simple_animal/hostile/abnormality/fetus/proc/check_range()
-	if(calling && Adjacent(calling))
-		calling.gib()
-		calling = null
+	for(var/mob/living/carbon/human/L in orange(get_turf(src),1))
+		if(L.tag == calling_tag)
+			L.gib(TRUE,TRUE,TRUE)
 
-		for(var/mob/living/carbon/human/H in GLOB.player_list)
-			to_chat(H, span_userdanger("The creature is satisfied."))
+			for(var/mob/living/carbon/human/H in GLOB.player_list)
+				to_chat(H, span_userdanger("The creature is satisfied."))
 
-		notify_ghosts("The nameless fetus is satisfied.", source = src, action = NOTIFY_ORBIT, header="Something Interesting!") // bless this mess
-		datum_reference.qliphoth_change(1)
-		return
+			notify_ghosts("The nameless fetus is satisfied.", source = src, action = NOTIFY_ORBIT, header="Something Interesting!") // bless this mess
+			datum_reference.qliphoth_change(1)
+			calling_tag = null
+			return
 
 	addtimer(CALLBACK(src, PROC_REF(check_range)), 2 SECONDS)
 
@@ -92,7 +92,8 @@
 		if(H.z == z && H.stat != DEAD)
 			checking +=H
 	if(LAZYLEN(checking))
-		calling = pick(checking)
+		var/mob/living/calling = pick(checking)
+		calling_tag = calling.tag
 
 		//and make a global announce
 		for(var/mob/living/carbon/human/H in GLOB.player_list)

--- a/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
@@ -56,7 +56,7 @@
 	)
 
 	//the agent that started work on porccubus
-	var/agent_ckey
+	var/agent_tag
 	var/teleport_cooldown_time = 5 MINUTES
 	var/teleport_cooldown
 	var/damage_taken = FALSE
@@ -95,12 +95,12 @@
 /mob/living/simple_animal/hostile/abnormality/porccubus/AttemptWork(mob/living/carbon/human/user, work_type)
 	. = ..()
 	if(.)
-		agent_ckey = user //just in case the agent goes insane midwork
+		agent_tag = user.tag //just in case the agent goes insane midwork
 
 /mob/living/simple_animal/hostile/abnormality/porccubus/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(user.sanity_lost) //if the person is driven insane mid work
-		DrugOverdose(user, agent_ckey)
-	agent_ckey = null
+		DrugOverdose(user, agent_tag)
+	agent_tag = null
 
 /mob/living/simple_animal/hostile/abnormality/porccubus/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(1)
@@ -108,12 +108,12 @@
 
 	if(PA)
 		PA.IncreaseTolerance()
-	else if(get_attribute_level(user, TEMPERANCE_ATTRIBUTE) < 60 || work_type == "Touch")
-		if(LAZYFIND(datum_reference.transferable_var, agent_ckey )) //if they were already drugged before we basically drug them to death for trying to pull that shit again
-			DrugOverdose(user, agent_ckey)
+	else if(user && (get_attribute_level(user, TEMPERANCE_ATTRIBUTE) < 60 || work_type == "Touch"))
+		if(LAZYFIND(datum_reference.transferable_var, agent_tag)) //if they were already drugged before we basically drug them to death for trying to pull that shit again
+			DrugOverdose(user, agent_tag)
 			return ..()
 		user.apply_status_effect(STATUS_EFFECT_ADDICTION) //psst, you want some happiness?
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/porccubus/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	. = ..()
@@ -130,12 +130,12 @@
 
 	if(!datum_reference)
 		return
-	if(LAZYFIND(datum_reference.transferable_var, ckey))
+	if(LAZYFIND(datum_reference.transferable_var, agent_tag))
 		previous_addict = TRUE
-	LAZYREMOVE(datum_reference.transferable_var, ckey) //otherwise they will just puke it out
+	LAZYREMOVE(datum_reference.transferable_var, agent_tag) //otherwise they will just puke it out
 	PA = addict.apply_status_effect(STATUS_EFFECT_ADDICTION)
 	if(previous_addict)
-		LAZYADD(datum_reference.transferable_var, ckey) //we take them out of the list after if they weren't already part of the list because it doesn't really "count" as a real drug dose
+		LAZYADD(datum_reference.transferable_var, agent_tag) //we take them out of the list after if they weren't already part of the list because it doesn't really "count" as a real drug dose
 	OverdoseEffect(PA,nirvana)
 
 /mob/living/simple_animal/hostile/abnormality/porccubus/proc/OverdoseEffect(datum/status_effect/porccubus_addiction/PA, nirvana)
@@ -302,7 +302,6 @@
 	var/sanity_gain = 60
 	var/attribute_gain = 30
 	var/previous_addict = FALSE
-	var/mob/living/carbon/human/addict
 
 /atom/movable/screen/alert/status_effect/porccubus_addiction
 	name = "Indescribable pleasure"
@@ -321,7 +320,7 @@
 		owner.remove_status_effect(src)
 		return
 
-	addict = owner
+	var/mob/living/carbon/human/addict = owner
 	if(!porc_datum || LAZYFIND(porc_datum?.transferable_var, addict.ckey) && !isnull(addict.ckey)) //we don't allow the same person to drug themselves again even after respawn
 		previous_addict = TRUE
 		addict.remove_status_effect(src)
@@ -336,6 +335,7 @@
 
 //wow this sure feels great I sure do hope there are no negative consequences for my hubris
 /datum/status_effect/porccubus_addiction/tick()
+	var/mob/living/carbon/human/addict = owner
 	if(withdrawal_cooldown < world.time)
 		addict.adjustSanityLoss(-sanity_gain)
 		addict.adjust_all_attribute_buffs(-1)
@@ -348,6 +348,7 @@
 
 //every time you take another hit the effects decrease
 /datum/status_effect/porccubus_addiction/proc/IncreaseTolerance(extra_attribute = TRUE, tolerance_amount = 0)
+	var/mob/living/carbon/human/addict = owner
 	for(var/i = 0 to tolerance_amount)
 		if(withdrawal_cooldown_time > 30 SECONDS)
 			withdrawal_cooldown_time -= 25 SECONDS //"I can stop whenever I want"
@@ -369,6 +370,7 @@
 	. = ..()
 	if(!ishuman(owner))
 		return
+	var/mob/living/carbon/human/addict = owner
 	if(previous_addict)
 		to_chat(addict, span_userdanger("Your body has a sudden allergic reaction to the substance!"))
 		addict.vomit()
@@ -397,6 +399,7 @@
 
 //we copy the head icon and apply it as a vis content. because while overlays can't be animated, visual objects that have overlays on them can
 /datum/status_effect/porccubus_addiction/proc/HeadExplode(obj/item/bodypart/head/head)
+	var/mob/living/carbon/human/addict = owner
 	var/obj/expanding_head = new()
 	expanding_head.layer = -BODY_FRONT_LAYER
 	expanding_head.plane = FLOAT_PLANE

--- a/code/modules/mob/living/simple_animal/abnormality/he/rubber_duck.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/rubber_duck.dm
@@ -38,6 +38,10 @@
 		/mob/living/simple_animal/hostile/abnormality/training_rabbit,
 	)
 
+/mob/living/simple_animal/hostile/abnormality/rubber_duck/Destroy()
+	looking_players = null
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/rubber_duck/Move()
 	return FALSE
 
@@ -46,14 +50,13 @@
 	if(status_flags & GODMODE)
 		return
 
-	for(var/mob/living/carbon/human/H in looking_players)
-		if(get_dist(src, H) > 7)	//You're now out of range.
+	for(var/mob/living/carbon/human/H in view(7, src))
+		if(H.tag in looking_players)
+			looking_players -= H.tag
 			H.adjustSanityLoss(H.maxSanity * 0.3) // take 30% of your Sanity
-			looking_players-=H
 			to_chat(H, span_warning("Aren't you forgetting something?"))
-
-	for(var/mob/living/carbon/human/H in view(6, src))
-		looking_players |=H
+		if(get_dist(src, H) <= 6)
+			LAZYOR(looking_players,H.tag)
 
 /* Work effects */
 /mob/living/simple_animal/hostile/abnormality/rubber_duck/BreachEffect(mob/living/carbon/human/user, breach_type)

--- a/code/modules/mob/living/simple_animal/abnormality/he/watchman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/watchman.dm
@@ -93,6 +93,7 @@
 		"This darkness is not for you and you alone, monster!",
 	)
 	// Breached Abno tracker.
+	// Remembers enemies by their tag.
 	var/list/dangers = list()
 
 /mob/living/simple_animal/hostile/abnormality/watchman/FailureEffect(mob/living/carbon/human/user, work_type, pe)
@@ -143,32 +144,32 @@
 			say(pick(speak_attacked_monster))
 
 /mob/living/simple_animal/hostile/abnormality/watchman/proc/HandleSpeech()
+	// End cleaning up the list.
+	if(speak_chance)
+		GaspWhatWasThat()
+		if(prob(speak_chance))
+			if(length(dangers))
+				say(pick(speak_alert))
+			else
+				say(pick(speak_normal))
+
+/mob/living/simple_animal/hostile/abnormality/watchman/proc/GaspWhatWasThat()
+	//Havent seen them in a while
+	popleft(dangers)
 	// Add new threats.
 	for(var/mob/living/simple_animal/hostile/H in view(7, src))
 		if(H == src)
+			continue
+		if(H.stat == DEAD)
+			//Welp, rest in piss beast.
+			dangers -= H.tag
 			continue
 		if(istype(H, /mob/living/simple_animal/hostile/abnormality))
 			var/mob/living/simple_animal/hostile/abnormality/A = H
 			if(A.IsContained())
 				continue
-		dangers |= H
-	// Begin cleaning the list up.
-	var/prune_list = dangers.Copy()
-	for(var/mob/living/simple_animal/hostile/H in dangers)
-		if(QDELETED(H) || H.stat == DEAD || !istype(H))
-			prune_list -= H
-	for(var/mob/living/simple_animal/hostile/abnormality/A in dangers)
-		if(!A.IsContained())
-			continue
-		prune_list -= A
-	dangers = prune_list
-	// End cleaning up the list.
-	if(speak_chance)
-		if(prob(speak_chance))
-			if(dangers.len)
-				say(pick(speak_alert))
-			else
-				say(pick(speak_normal))
+		LAZYOR(dangers,H.tag)
+	return dangers
 
 /mob/living/simple_animal/hostile/abnormality/watchman/handle_automated_action()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/he/will_you_play.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/will_you_play.dm
@@ -34,7 +34,7 @@
 		janken = 0
 	else
 		janken = pick(1,2)
-	if(user == last_worked)
+	if(user.tag == last_worked)
 		say("You again? Fine. We'll play again.")
 	else
 		say("I'll go fer scissors. How 'bout you?")
@@ -113,7 +113,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/willyouplay/proc/Lose(mob/living/carbon/human/user, work_type)
 	var/statgain
-	if(user == last_worked)
+	if(user.tag == last_worked)
 		statgain = -2
 
 	if(janken == 0)
@@ -137,4 +137,4 @@
 				user.adjust_attribute_level(A, 1)
 			continue
 		user.adjust_attribute_level(A, statgain)
-	last_worked = user
+	last_worked = user.tag

--- a/code/modules/mob/living/simple_animal/abnormality/teth/cinderella.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/cinderella.dm
@@ -49,10 +49,16 @@
 
 	var/freshness = 0
 	//Breach stuff
-	var/maxSegments = 1
+	var/max_segments = 1
+	//Segments of the carriage
 	var/list/segments = list()
+	//Entities damaged by the carriage. Uses tags.
 	var/list/damaged = list()
 	var/already_breached
+
+/mob/living/simple_animal/hostile/abnormality/cinderella/Destroy()
+	segments = null
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/cinderella/examine(mob/user)
 	. = ..()
@@ -105,8 +111,7 @@
 	addtimer(CALLBACK(src, PROC_REF(death)), 45 SECONDS)
 
 /mob/living/simple_animal/hostile/abnormality/cinderella/proc/GoToTheBall()
-	for(var/mob/living/M in damaged)
-		damaged -= M
+	damaged.Cut()
 	var/turf/aimTurf = pick(GLOB.department_centers)
 	FireCarriage(aimTurf.y, pick(EAST, WEST), aimTurf.z)
 
@@ -146,9 +151,9 @@
 				coveredTurfs |= T
 		for(var/turf/T in coveredTurfs)
 			for(var/mob/living/M in T.contents)
-				if(M in src.damaged)
+				if(M.tag in damaged)
 					continue
-				src.damaged += M
+				damaged += M.tag
 				if(!seg.noise)
 					if(rand())
 						playsound(get_turf(seg), 'sound/abnormalities/cinderella/horse1.ogg', 100, 0, 40)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/door_to_nowhere.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/door_to_nowhere.dm
@@ -245,6 +245,10 @@ GLOBAL_LIST_EMPTY(repentance_spawn_points)            // Valid spawn locations i
 	// Track who has received their first tape recorder
 	var/list/workers_with_recorders = list()
 
+/mob/living/simple_animal/hostile/abnormality/door_to_nowhere/Destroy()
+	workers_with_recorders = null
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/door_to_nowhere/Initialize()
 	. = ..()
 	// Grant abilities
@@ -707,6 +711,7 @@ GLOBAL_LIST_EMPTY(repentance_spawn_points)            // Valid spawn locations i
 /obj/structure/regret_door/Destroy()
 	if(associated_spirit)
 		qdel(associated_spirit)
+	associated_spirit = null
 	return ..()
 
 /obj/structure/regret_door/custom
@@ -754,6 +759,11 @@ GLOBAL_LIST_EMPTY(repentance_spawn_points)            // Valid spawn locations i
 	death_message = "lets out a final, mournful wail before fading into nothingness..."
 	var/obj/structure/regret_door/associated_door
 	var/list/regret_phrases = list()
+
+
+/mob/living/simple_animal/hostile/regret_spirit/Destroy()
+	associated_door = null
+	return ..()
 
 /mob/living/simple_animal/hostile/regret_spirit/Initialize()
 	. = ..()
@@ -1081,6 +1091,7 @@ GLOBAL_LIST_EMPTY(repentance_spawn_points)            // Valid spawn locations i
 
 /datum/status_effect/regret_stacks/on_remove()
 	UnregisterSignal(owner, COMSIG_LIVING_DEATH)
+	source_door = null
 	to_chat(owner, span_notice("The weight of regret lifts from your soul."))
 
 /datum/status_effect/regret_stacks/tick()
@@ -1138,6 +1149,10 @@ GLOBAL_LIST_EMPTY(repentance_spawn_points)            // Valid spawn locations i
 	var/mob/living/simple_animal/hostile/abnormality/door_to_nowhere/source_door
 	del_on_death = TRUE
 
+/mob/living/simple_animal/hostile/regret_spirit/projection/Destroy()
+	source_door = null
+	return ..()
+
 /mob/living/simple_animal/hostile/regret_spirit/projection/death(gibbed)
 	if(source_door && !QDELETED(source_door))
 		source_door.recall_spirit(src, source_door)
@@ -1165,6 +1180,8 @@ GLOBAL_LIST_EMPTY(repentance_spawn_points)            // Valid spawn locations i
 
 /obj/machinery/tape_archive/Destroy()
 	LAZYREMOVE(SSpersistence.tape_archive_machines, src)
+	users_who_archived = null
+	stored_tapes = null
 	return ..()
 
 /obj/machinery/tape_archive/attackby(obj/item/I, mob/user, params)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/forsaken_employee.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/forsaken_employee.dm
@@ -24,8 +24,6 @@
 	abnormality_origin = ABNORMALITY_ORIGIN_LIMBUS
 	chem_type = /datum/reagent/abnormality/sin/gloom
 
-	var/list/blackout_list = list()
-
 	//Observation is mostly mirror dungeon but with some changed phrasing
 	observation_prompt = "The sound of plastic crashing is accompanied by the sloshing of a liquid. <br>\
 		It looks like something that used to be a fellow employee. <br>\
@@ -41,6 +39,13 @@
 		"Don't cut the ring" = list(FALSE, "Tang- Tang- Tang- The ramming at the door and the sloshing continue. <br>\
 			I keep watching and listening. A more attentive hearing reveals that the sounds have a rhythm. Perhaps there is delight to be found in it."),
 	)
+
+	//Records areas
+	var/list/blackout_list = list()
+
+/mob/living/simple_animal/hostile/abnormality/forsaken_employee/Destroy()
+	blackout_list = null
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/forsaken_employee/FailureEffect(mob/living/carbon/human/user, work_type, pe, work_time, canceled)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/my_sweet_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/my_sweet_home.dm
@@ -64,7 +64,6 @@
 	var/slam_cooldown = 10 SECONDS
 	var/slam_cooldown_time
 
-
 /mob/living/simple_animal/hostile/abnormality/my_sweet_home/Moved()
 	. = ..()
 	if(!(status_flags & GODMODE)) // This thing's big, it should make some noise.
@@ -86,18 +85,18 @@
 
 /mob/living/simple_animal/hostile/abnormality/my_sweet_home/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time) //grabbed from FAN
 	if(work_type == ABNORMALITY_WORK_ATTACHMENT)
-		if(user in counter2)
+		if(user.tag in counter2)
 			to_chat(user, span_danger("You grip the key and approach."))
 			user.Stun(10 SECONDS)
 			SLEEP_CHECK_DEATH(3)
 			user.gib()
 			datum_reference.qliphoth_change(-1)
 			BreachEffect(user)
-		else if(user in counter1)
-			counter2+=user
+		else if(user.tag in counter1)
+			counter2+=user.tag
 			to_chat(user, span_danger("It speaks in your mind, reassuring you, you feel safe."))
 		else
-			counter1+=user
+			counter1+=user.tag
 	return
 
 /mob/living/simple_animal/hostile/abnormality/my_sweet_home/proc/AoeAttack()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
@@ -53,7 +53,8 @@
 	var/teleport_cooldown
 	var/teleport_cooldown_time = 30 SECONDS
 	//attack
-	var/mob/living/set_target
+	//uses  tags
+	var/set_target
 	var/pulse_range = 11 //fairly large area - enough to breach several abnormalities
 	var/fog_damage = 3
 	var/ash_damage = 20
@@ -183,7 +184,7 @@
 		return FALSE
 	if(H.has_status_effect(/datum/status_effect/mortis)) //find something else to chase or go idle
 		return FALSE
-	set_target = H
+	set_target = H.tag
 	return ..()
 
 //Copied MOSB corpse-seeking behavior
@@ -253,12 +254,16 @@
 //If it's not our target, we ignore it
 /mob/living/simple_animal/hostile/abnormality/pale_horse/CanAllowThrough(atom/movable/mover, turf/target)
 	. = ..()
-	if(mover == set_target)
-		return FALSE
-	if(istype(mover, /obj/projectile))
-		var/obj/projectile/P = mover
-		if(P.firer == set_target)
+	if(isliving(mover))
+		var/mob/living/dude = mover
+		if(dude.tag == set_target)
 			return FALSE
+		if(istype(mover, /obj/projectile))
+			var/obj/projectile/P = mover
+			if(isliving(P.firer))
+				var/mob/living/L = P.firer
+				if(L.tag == set_target)
+					return FALSE
 
 //objects
 /obj/effect/temp_visual/palefog

--- a/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
@@ -69,6 +69,7 @@
 
 	var/list/enemies = list()
 	var/list/pecking_targets = list()
+	//uses tags
 	var/list/already_punished = list()
 	var/bird_angry = FALSE
 	/// Melee damage done to simple mobs when enraged
@@ -87,6 +88,9 @@
 /mob/living/simple_animal/hostile/abnormality/punishing_bird/Destroy()
 	UnregisterSignal(SSdcs, COMSIG_GLOB_WORK_STARTED)
 	UnregisterSignal(SSdcs, COMSIG_GLOB_HUMAN_INSANE)
+	enemies = null
+	pecking_targets = null
+	already_punished = null
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/punishing_bird/proc/TransformRed()
@@ -158,15 +162,15 @@
 			if(H.mind && !faction_check_mob(H))
 				if(H.sanity_lost)
 					priority_mobs += H
-				else if(!(H in already_punished) && prob(10))
+				else if(!(H.tag in already_punished) && prob(10))
 					potential_mobs += H
 
 		if(LAZYLEN(priority_mobs))
 			var/mob/living/carbon/le_target = pick(priority_mobs)
-			pecking_targets |= le_target
+			LAZYOR(pecking_targets,le_target.tag)
 		else if(LAZYLEN(potential_mobs))
 			var/mob/living/carbon/le_target = pick(potential_mobs)
-			pecking_targets |= le_target
+			LAZYOR(pecking_targets, le_target.tag)
 
 /mob/living/simple_animal/hostile/abnormality/punishing_bird/AttackingTarget(atom/attacked_target)
 	if(ishuman(attacked_target) && bird_angry)
@@ -201,11 +205,11 @@
 					H.adjustSanityLoss(-10) // Heal sanity
 					return
 			if(prob(5) || L.health < L.maxHealth*0.5)
-				if(L in enemies)
+				if(L.tag in enemies)
 					enemies -= L
-				if(L in pecking_targets)
-					pecking_targets -= L
-					already_punished |= L
+				if(L.tag in pecking_targets)
+					pecking_targets -= L.tag
+					already_punished |= L.tag
 				LoseTarget(FALSE)
 		else if(L.health <= 0)
 			visible_message(span_danger("\The [src] devours [L]!"))
@@ -237,11 +241,10 @@
 		return list()
 	var/list/see = ..()
 	var/list/targeting = list()
-	targeting += enemies
-	if(obj_damage <= 0)
-		targeting |= pecking_targets
-	see &= targeting // Remove all entries that aren't in enemies
-	return see
+	for(var/mob/living/L in see)
+		if((L.tag in enemies) || (L.tag in pecking_targets))
+			targeting += L
+	return targeting
 
 /mob/living/simple_animal/hostile/abnormality/punishing_bird/RegisterAttackAggro(damage_amount, damage_type, source)
 	if(omw_to_apoc) // Ts ain't nothin to me man

--- a/code/modules/mob/living/simple_animal/abnormality/waw/contract.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/contract.dm
@@ -46,6 +46,7 @@
 			Perhaps you should have read the fine print."),
 	)
 
+	//uses tags
 	var/list/total_havers = list()
 	var/list/fort_havers = list()
 	var/list/prud_havers = list()
@@ -82,7 +83,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/contract/WorkChance(mob/living/carbon/human/user, chance, work_type)
 	. = chance
-	if(!(user in total_havers))
+	if(!(user.tag in total_havers))
 		return
 
 	if(ContractedUser(user, work_type))
@@ -94,7 +95,7 @@
 	work_damage_amount = initial(work_damage_amount)
 	if(ContractedUser(user, work_type) && .)
 		work_damage_amount /= 3
-	if(user in total_havers)
+	if(user.tag in total_havers)
 		work_damage_amount /= 1.2
 		say("Yes, yes... I remember the contract.")
 
@@ -103,59 +104,59 @@
 
 /mob/living/simple_animal/hostile/abnormality/contract/proc/ContractedUser(mob/living/carbon/human/user, work_type)
 	. = FALSE
-	if(!(user in total_havers))
+	if(!(user.tag in total_havers))
 		return
 
 	switch(work_type)
 		if(ABNORMALITY_WORK_INSTINCT)
-			if(user in fort_havers)
+			if(user.tag in fort_havers)
 				return TRUE
 
 		if(ABNORMALITY_WORK_INSIGHT)
-			if(user in prud_havers)
+			if(user.tag in prud_havers)
 				return TRUE
 
 		if(ABNORMALITY_WORK_ATTACHMENT)
-			if(user in temp_havers)
+			if(user.tag in temp_havers)
 				return TRUE
 
 		if(ABNORMALITY_WORK_REPRESSION)
-			if(user in just_havers)
+			if(user.tag in just_havers)
 				return TRUE
 
 /mob/living/simple_animal/hostile/abnormality/contract/proc/NewContract(mob/living/carbon/human/user, work_type)
-	if((user in total_havers))
+	if((user.tag in total_havers))
 		return
 	switch(work_type)
 		if(ABNORMALITY_WORK_INSTINCT)
 			if(fort_havers.len < total_per_contract)
 				user.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, (fort_havers.len - 4)*-1 )
-				fort_havers |= user
+				fort_havers |= user.tag
 			else
 				return
 
 		if(ABNORMALITY_WORK_INSIGHT)
 			if(prud_havers.len < total_per_contract)
 				user.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, (prud_havers.len - 4)*-1 )
-				prud_havers |= user
+				prud_havers |= user.tag
 			else
 				return
 
 		if(ABNORMALITY_WORK_ATTACHMENT)
 			if(temp_havers.len < total_per_contract)
 				user.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, (temp_havers.len - 4)*-1 )
-				temp_havers |= user
+				temp_havers |= user.tag
 			else
 				return
 
 		if(ABNORMALITY_WORK_REPRESSION)
 			if(just_havers.len < total_per_contract)
 				user.adjust_attribute_buff(JUSTICE_ATTRIBUTE, (just_havers.len - 4)*-1 )
-				just_havers |= user
+				just_havers |= user.tag
 			else
 				return
 
-	total_havers |= user
+	total_havers |= user.tag
 	say("Just sign here on the dotted line... and I'll take care of the rest.")
 	return
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
@@ -101,6 +101,11 @@
 	despair_knight.give_blessing()
 	return TRUE
 
+/mob/living/simple_animal/hostile/abnormality/despair_knight/Destroy()
+	blessed_human = null
+	UnregisterSignal(blessed_human, list(COMSIG_LIVING_DEATH,COMSIG_HUMAN_INSANE))
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/despair_knight/proc/give_blessing()
 	var/list/nearby = viewers(7, src) // first call viewers to get all mobs that see us
 	if(SSmaptype.maptype == "limbus_labs")

--- a/code/modules/mob/living/simple_animal/abnormality/waw/express_train.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/express_train.dm
@@ -42,10 +42,14 @@
 	var/meltdown_tick = 60 SECONDS
 	var/meltdown_timer
 	var/lightscount = 0
-	var/list/tickets = list()
-	var/maxSegments = 5
+	var/max_segments = 5
 	var/list/segments = list()
 	var/list/damaged = list()
+
+/mob/living/simple_animal/hostile/abnormality/express_train/Destroy()
+	segments = null
+	damaged = null
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/express_train/Initialize()
 	meltdown_timer = world.time + meltdown_tick
@@ -68,27 +72,29 @@
 
 /mob/living/simple_animal/hostile/abnormality/express_train/AttemptWork(mob/living/carbon/human/user, work_type)
 	meltdown_timer += 100 SECONDS
-	switch(datum_reference.qliphoth_meter)
-		if(0)
-			for(var/mob/living/carbon/human/H in GLOB.mob_living_list)
-				H.adjustSanityLoss(-50)
-				H.adjustBruteLoss(-50)
-			tickets |= user
-		if(1)
-			for(var/mob/living/carbon/human/H in livinginrange(30))
-				H.adjustSanityLoss(-50)
-				H.adjustBruteLoss(-50)
-			tickets |= user
-		if(2)
-			user.adjustSanityLoss(-80)
-			user.adjustBruteLoss(-80)
-			tickets |= user
-		if(3)
-			user.adjustSanityLoss(-40)
-			user.adjustBruteLoss(-40)
-			tickets |= user
-		if(4)
-			say("No tickets available. Thank you for your interest.")
+	var/qliphoth_level = datum_reference.qliphoth_meter
+	var/san_loss = -50
+	var/bru_loss = -50
+	var/effected_list = list(user)
+	if(qliphoth_level >= 4)
+		say("No tickets available. Thank you for your interest.")
+		return ..()
+	if(qliphoth_level == 0)
+		effected_list = GLOB.mob_living_list
+	if(qliphoth_level == 1)
+		effected_list = livinginrange(30)
+	if(qliphoth_level == 2)
+		san_loss = -80
+		bru_loss = -80
+	if(qliphoth_level == 3)
+		san_loss = -40
+		bru_loss = -40
+
+	//Unsure if this is a redundant refactor on my part -IP
+	for(var/mob/living/carbon/human/H in effected_list)
+		H.adjustSanityLoss(san_loss)
+		H.adjustBruteLoss(bru_loss)
+
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/express_train/WorkChance(mob/living/carbon/human/user, chance)
@@ -129,7 +135,7 @@
 		spawnX = 214
 		xIncrement = 4
 	var/spawnPoint = locate(spawnX, aimpoint, aimZ)
-	for(var/i = 0, i < maxSegments * 2, i++)
+	for(var/i = 0, i < max_segments * 2, i++)
 		if(!(i % 2)) // True whenever i is even- this is the start of each segment
 			persX += xIncrement*0.75 // Makes persX (effectively) one smaller for this iteration
 		else

--- a/code/modules/mob/living/simple_animal/abnormality/waw/generalb.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/generalb.dm
@@ -70,8 +70,6 @@
 	var/combat_map = FALSE
 	var/datum/action/innate/toggle_artillery_sight/sight_ability
 
-	var/list/beespawn = list()
-
 	attack_action_types = list(
 		/datum/action/innate/change_icon_gbee,
 	)
@@ -112,10 +110,8 @@
 		combat_map = TRUE
 		sight_ability.new_sight = SEE_TURFS
 		if(SSmaptype.maptype == "limbus_labs")
-			var/mob/living/simple_animal/hostile/soldier_bee/V = new(get_turf(src))
-			beespawn+=V
-			V = new(get_turf(src))
-			beespawn+=V
+			new /mob/living/simple_animal/hostile/soldier_bee/(get_turf(src))
+			new /mob/living/simple_animal/hostile/soldier_bee/(get_turf(src))
 	else
 		sight_ability.new_sight = SEE_TURFS | SEE_THRU
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/yin.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/yin.dm
@@ -77,6 +77,7 @@
 
 	var/busy = FALSE
 
+	//Uses mob.tag and xyz identifiers
 	var/list/hit_people = list()
 	var/list/spawned_effects = list()
 	var/list/prohibitted_flips = list(
@@ -178,8 +179,7 @@
 	icon_state = icon_breach
 
 /mob/living/simple_animal/hostile/abnormality/yin/Destroy()
-	for(var/atom/AT in spawned_effects)
-		qdel(AT)
+	QDEL_LIST(spawned_effects)
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/yin/WorkChance(mob/living/carbon/human/user, chance, work_type)
@@ -249,8 +249,7 @@
 		beam.redrawing()
 		sleep(1)
 		new /obj/effect/temp_visual/revenant/cracks/yin(OT)
-	for(var/obj/effect/FX in spawned_effects)
-		qdel(FX)
+	QDEL_LIST(spawned_effects)
 	qdel(beam)
 	COOLDOWN_START(src, beam, beam_cooldown)
 	busy = FALSE
@@ -316,7 +315,8 @@
 
 /mob/living/simple_animal/hostile/abnormality/yin/proc/DragonFlip(obj/effect/yinyang_dragon/DP)
 	for(var/obj/machinery/computer/abnormality/AC in range(2, DP))
-		if(AC in hit_people)
+		var/identifier = "[AC.x],[AC.y],[AC.z]"
+		if(identifier in hit_people)
 			continue
 		if(!AC.datum_reference.current)
 			continue
@@ -325,9 +325,9 @@
 			continue
 		AC.datum_reference.qliphoth_change(999)
 		AC.datum_reference.qliphoth_change(-qlip)
-		hit_people += AC
+		hit_people += identifier
 	for(var/mob/living/L in range(2, DP))
-		if(L in hit_people)
+		if(L.tag in hit_people)
 			continue
 		if(L.type in prohibitted_flips)
 			continue
@@ -339,7 +339,7 @@
 			damage = H.sanityhealth
 			H.adjustSanityLoss(-H.maxSanity)
 			H.adjustSanityLoss(damage)
-		hit_people += L
+		hit_people += L.tag
 		to_chat(L, span_userdanger("All that is shall become all that isn't."))
 
 /mob/living/simple_animal/hostile/abnormality/yin/proc/YangCheck()

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/bald.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/bald.dm
@@ -47,6 +47,7 @@
 		"No" = list(FALSE, "Come back after watching the fast and the furious 7 five more times."),
 	)
 
+	//uses ckeys
 	var/bald_users = list()
 	chem_type = /datum/reagent/abnormality/bald
 

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm
@@ -84,7 +84,8 @@
 	var/jump_cooldown
 	var/jump_cooldown_time = 6 SECONDS
 	var/retreating = FALSE
-	var/mob/living/idiot = null
+	var/idiot_tag
+	var/idiot_name
 	var/transformed = FALSE
 	var/broken = FALSE
 	var/persistant = FALSE
@@ -164,10 +165,13 @@
 	QDEL_NULL(src)
 
 /mob/living/simple_animal/hostile/abnormality/blubbering_toad/proc/SetIdiot(mob/living/L)
-	idiot = L
-	if(idiot)
-		to_chat(src, span_notice("You current target is [idiot]!"))
+	if(L)
+		idiot_tag = L.tag
+		idiot_name = L.real_name
+		to_chat(src, span_notice("You current target is [idiot_name]!"))
 	else
+		idiot_tag = null
+		idiot_name = null
 		to_chat(src, span_notice("Your work here is done, you should now return to your cell."))
 
 /mob/living/simple_animal/hostile/abnormality/blubbering_toad/death() //EGG! just kidding no egg....
@@ -175,12 +179,14 @@
 	playsound(src, 'sound/effects/limbus_death.ogg', 40, 0, FALSE)
 	animate(src, alpha = 0, time = 5 SECONDS)
 	QDEL_IN(src, 5 SECONDS)
-	..()
+	return ..()
 
 //Attacks
 /mob/living/simple_animal/hostile/abnormality/blubbering_toad/OpenFire()
-	if(target != idiot && !angry)
-		return
+	if(isliving(target))
+		var/mob/living/L = target
+		if(L.tag != idiot_tag && !angry)
+			return
 	var/dist = get_dist(target, src)
 	if((dist > 2) && (dist < 5))
 		TongueAttack(target)
@@ -202,13 +208,15 @@
 		for(var/turf/T in turfs_to_hit)
 			if(T.density)
 				break
-			if(idiot in T)
-				idiot.deal_damage(tongue_damage, BLACK_DAMAGE, src, attack_type = (ATTACK_TYPE_RANGED | ATTACK_TYPE_SPECIAL))
-				new /obj/effect/temp_visual/dir_setting/bloodsplatter(get_turf(idiot), pick(GLOB.alldirs))
-				if(!idiot.anchored)
+			for(var/mob/living/L in T)
+				if(L.tag != idiot_tag)
+					continue
+				L.deal_damage(tongue_damage, BLACK_DAMAGE, src, attack_type = (ATTACK_TYPE_RANGED | ATTACK_TYPE_SPECIAL))
+				new /obj/effect/temp_visual/dir_setting/bloodsplatter(T, pick(GLOB.alldirs))
+				if(!L.anchored)
 					var/whack_speed = (prob(60) ? 1 : 4)
-					idiot.throw_at(MT, rand(1, 2), whack_speed, src)
-		sleep(5)
+					L.throw_at(MT, rand(1, 2), whack_speed, src)
+		SLEEP_CHECK_DEATH(5)
 		tongue_cooldown = world.time + tongue_cooldown_time
 		can_act = TRUE
 		icon_state = icon_living
@@ -238,48 +246,52 @@
 	if(!can_act)
 		return FALSE
 	update_icon_state() //prevents icons from getting stuck
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/blubbering_toad/AttackingTarget(atom/attacked_target)
 	if(angry)
 		return ..()
 	if(!ishuman(attacked_target))
 		return
-	if(attacked_target != idiot)
+	var/mob/living/carbon/human/H = attacked_target
+	if(H.tag != idiot_tag)
 		LoseTarget(attacked_target)
 		return
-	..()
-	var/mob/living/carbon/human/H = attacked_target
+	. = ..()
 	// Achievement for dying to Blubbering Toad
 	if(H.stat == DEAD && H.client)
 		H.client.player_details.achievements.unlock(/datum/award/achievement/abno/die_to_toad, H)
 	if(H.sanity_lost) //prevents hitting the same guy in an infinite loop
 		melee_damage_type = BLACK_DAMAGE
 	if(H.health < 0)
-		H.gib()
+		H.gib(FALSE,FALSE,TRUE)
 		if(!persistant)
 			addtimer(CALLBACK(src, PROC_REF(ReturnCell)), 10 SECONDS)
 			return
-		idiot = null
+		idiot_tag = null
+		idiot_name = null
+		var/mob/living/new_idiot
 		for(var/mob/living/carbon/human/HU in GLOB.player_list)
 			if(HU.z != z)
 				continue
 			if(HU.stat == DEAD)
 				continue
-			if(isnull(idiot))
-				idiot = HU
-			if(idiot.health > HU.health)
-				idiot = HU
-		if(isnull(idiot))
+			if(isnull(idiot_tag))
+				new_idiot = HU
+			if(new_idiot)
+				if(new_idiot.health > HU.health)
+					new_idiot = HU
+		if(isnull(new_idiot))
 			addtimer(CALLBACK(src, PROC_REF(ReturnCell)), 10 SECONDS)
 			return
-		SetIdiot(idiot)
+		SetIdiot(new_idiot)
 
 
 /mob/living/simple_animal/hostile/abnormality/blubbering_toad/ListTargets()
 	. = ..()
-	if(idiot in .)
-		return list(idiot)
+	for(var/mob/living/carbon/C in .)
+		if(C.tag == idiot_tag)
+			return list(C)
 	return
 
 //Transformation
@@ -325,14 +337,14 @@
 
 /datum/status_effect/blue_resin/on_apply()
 	. = ..()
-	if(ishuman(owner))
+	if(!ishuman(owner))
 		return
 	var/mob/living/carbon/human/status_holder = owner
 	status_holder.physiology.black_mod *= 0.9
 
 /datum/status_effect/blue_resin/on_remove()
 	. = ..()
-	if(ishuman(owner))
+	if(!ishuman(owner))
 		return
 	var/mob/living/carbon/human/status_holder = owner
 	status_holder.physiology.black_mod /= 0.9

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/fallen_amurdad.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/fallen_amurdad.dm
@@ -329,7 +329,6 @@
 	armor = list(RED_DAMAGE = 0, WHITE_DAMAGE = 50, BLACK_DAMAGE = 30, PALE_DAMAGE = 0)
 	var/stage = 0
 	var/grow_interval = 5 SECONDS
-	var/list/protected_plants = list()
 
 /obj/structure/amurdad_bomb/Initialize()
 	. = ..()
@@ -338,12 +337,8 @@
 
 /obj/structure/amurdad_bomb/proc/ProtectPlants()
 	for(var/obj/structure/spreading/apple_vine/AV in view(2, src))
-		if(AV in protected_plants)
-			AV.obj_integrity += 50
-			continue
-		protected_plants += AV
 		AV.max_integrity = 300
-		AV.obj_integrity = 300
+		AV.obj_integrity = clamp(AV.obj_integrity + 30,0,300)
 
 /obj/structure/amurdad_bomb/proc/Grow()
 	stage = stage + 1 > 5 ? 5 : stage + 1

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/gold/dusk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/gold/dusk.dm
@@ -110,12 +110,12 @@
 		AdjustCharge(-20)
 		Recharge()
 		return FALSE
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/ordeal/centipede_corrosion/deal_damage(damage_amount, damage_type, source, flags, attack_type, blocked, def_zone, wound_bonus, bare_wound_bonus, sharpness)
 	if(!can_act) //Prevents killing during recharge
 		return FALSE
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/ordeal/centipede_corrosion/proc/Recharge()
 	can_act = FALSE
@@ -190,7 +190,8 @@
 		AdjustCharge(1)
 
 /mob/living/simple_animal/hostile/ordeal/thunderbird_corrosion/Destroy()
-	QDEL_NULL(current_beam)
+	if(current_beam)
+		QDEL_NULL(current_beam)
 	return ..()
 
 /mob/living/simple_animal/hostile/ordeal/thunderbird_corrosion/OpenFire(atom/A)
@@ -261,6 +262,7 @@
 		C.name = "[H.real_name]"//applies the target's name and adds the name to its description
 		C.desc = "What appears to be [H.real_name], only charred and screaming incoherently..."
 		C.gender = H.gender
+		C.faction = src.faction
 		C.LinkSoul(src)
 		H.gib(TRUE,TRUE,TRUE)
 


### PR DESCRIPTION
## About The Pull Request
Optimizes some code so that it uses tags instead of hard references.

- refactors drifting fox to have most of its code connected to itself rather than the umbrellas. Also changes pet entities to mob.tag
- Refactors fan to use tags.
- Removes a unused swarm_killed list from funeral.
- Makes galaxy childs unregistered signals into one proc.
- Changes last_worker from a hard ref to a mob.tag
- Deletes headless icthys beam upon destruction.
- refactors highway devotees structure delete into QDEL_LIST(structures)
- nameless fetus now checks if you have the mob tag it wants instead of checking a hard ref.
- Porccubus now checks user tag instead of hard ref.
- rubber duck now remembers the tags of the people in the room before PUNISHING THEM for being within range.
- Watchman now only reports on dangers he has encountered rather than automatically knowing every danger in the facility. Every time he speaks however he forgets a danger he has encountered.
- will_you_play now uses tags.
- cinderella now uses tags for its damaged segments. unsure what this changes.
- door to nowhere cleans up its hard refs.
- forsaken employee forgets the areas it has blacked out when destroyed
- my sweet home uses tags now
- pale horse now tracks its targets tag.
- punishing bird now uses tags
- contract now tracks tag.
- despair knight now unregisters its blessed human properly.
- general bee has a unused beespawn list.
- yin now tracks hit people and abnormality consoles by xyz and tags.
- blubbering toad has been refactored to use less hard refs.
- fallen amurdads synergy with apple_vines has been cleaned up.
- thunderbird corrosions current_beam now deletes itself on destroy. 

<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Should help prevent Hard Deletes

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [x] This PR compiles
* [ ] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
refactor: Several hard refrences are replaced with mob tags.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
