### PR TITLE
Staining Rose Update (Desc WIP)

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
@@ -12,13 +12,13 @@
 	health = 10			//It's a rose lol
 	threat_level = ALEPH_LEVEL
 	work_chances = list(
-		ABNORMALITY_WORK_INSTINCT = 0,
-		ABNORMALITY_WORK_INSIGHT = list(0, 0, 0, 30, 40),
+		ABNORMALITY_WORK_INSTINCT = list(0, 0, 0, 30, 40),
+		ABNORMALITY_WORK_INSIGHT = list(0, 0, 0, 35, 45),
 		ABNORMALITY_WORK_ATTACHMENT = 0,
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 0, 45, 50),
 	)
 	start_qliphoth = 1
-	work_damage_amount = 14
+	work_damage_amount = 9
 	work_damage_type = PALE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/pride
 	pixel_x = -16
@@ -44,7 +44,7 @@
 	var/datum/weakref/chosen_memory
 	var/list/sacrificed = list()
 	var/list/heretics = list()
-	var/meltdown_cooldown_time = 15 MINUTES
+	var/meltdown_cooldown_time = 12 MINUTES
 	var/meltdown_cooldown
 	var/safe = FALSE //work on it and you're safe for 15 minutes
 	var/reset_time = 3 MINUTES //Qliphoth resets after this time
@@ -62,30 +62,42 @@
 	heretics = null
 	return ..()
 
+/mob/living/simple_animal/hostile/abnormality/staining_rose/WorktickFailure(mob/living/carbon/human/user)
+	..( )
+	//Worktick failures increase damage given
+	work_damage_amount ++
+	return
+
+
 /mob/living/simple_animal/hostile/abnormality/staining_rose/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
 	safe = TRUE
-	var/mob/living/chosen = chosen_memory ? chosen_memory.resolve() : null
-	if (chosen == null)
-		chosen = user
-		user.visible_message(span_warning("You are now Staining Rose's Chosen."))
-		icon_state = "rose_activated"
+	work_damage_amount = initial(work_damage_amount)
+	if(work_type == ABNORMALITY_WORK_REPRESSION)
+		var/mob/living/chosen = chosen_memory ? chosen_memory.resolve() : null
+		if (chosen == null)
+			chosen = user
+			user.visible_message(span_warning("You are now Staining Rose's Chosen."))
+			icon_state = "rose_activated"
 
-	if (user != chosen)		//Your body starts to wilt.
-		user.visible_message(span_warning("Staining Rose already has a Chosen named [chosen]!"))
-		user.apply_status_effect(STATUS_EFFECT_SCHISMATIC)
-		user.client?.give_award(/datum/award/achievement/abno/schismatic, user)
-		if(!(user in heretics))
-			RegisterMob(user, heretics)
-		pissed()
-	else
-		user.visible_message(span_warning("Staining Rose is content."))
+		if (user != chosen)		//Your body starts to wilt.
+			user.visible_message(span_warning("Staining Rose already has a Chosen named [chosen]!"))
+			user.apply_status_effect(STATUS_EFFECT_SCHISMATIC)
+			user.client?.give_award(/datum/award/achievement/abno/schismatic, user)
+			if(!(user in heretics))
+				RegisterMob(user, heretics)
+			pissed()
+		else
+			user.visible_message(span_warning("Staining Rose is content."))
 
 	if(get_attribute_level(user, JUSTICE_ATTRIBUTE) < 100)
 		user.apply_status_effect(STATUS_EFFECT_SACRIFICE)
 		if(!(user in sacrificed))
 			RegisterMob(user, sacrificed)
-			user.visible_message(span_warning("Staining Rose drains your strength, and it is born anew."))
-			meltdown_cooldown = world.time + meltdown_cooldown_time	//There we go!
+			user.visible_message(span_warning("Staining Rose weakens your defenses and gives you strength. It is born anew."))
+			user.adjust_all_attribute_levels(3)
+
+			meltdown_cooldown_time = 17 MINUTES	//Sure, big bonus for it.
+			meltdown_cooldown = world.time + meltdown_cooldown_time	//Resets too.
 		pissed()
 
 /mob/living/simple_animal/hostile/abnormality/staining_rose/Life()
@@ -187,6 +199,7 @@
 	status_holder.physiology.white_mod /= 0.5
 	status_holder.physiology.black_mod /= 0.5
 	status_holder.physiology.pale_mod /= 0.5
+	status_holder.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, -30)
 
 /datum/status_effect/wilting/on_remove()
 	. = ..()
@@ -197,6 +210,7 @@
 	status_holder.physiology.white_mod *= 0.5
 	status_holder.physiology.black_mod *= 0.5
 	status_holder.physiology.pale_mod *= 0.5
+	status_holder.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, 30)
 
 
 //SCHISMATIC
@@ -218,20 +232,22 @@
 	if(!ishuman(owner))
 		return
 	var/mob/living/carbon/human/status_holder = owner
-	status_holder.physiology.red_mod /= 0.8
-	status_holder.physiology.white_mod /= 0.8
-	status_holder.physiology.black_mod /= 0.8
-	status_holder.physiology.pale_mod /= 0.8
+	status_holder.physiology.red_mod /= 0.93
+	status_holder.physiology.white_mod /= 0.93
+	status_holder.physiology.black_mod /= 0.93
+	status_holder.physiology.pale_mod /= 0.93
+	status_holder.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, 15)
 
 /datum/status_effect/schismatic/on_remove()
 	. = ..()
 	if(!ishuman(owner))
 		return
 	var/mob/living/carbon/human/status_holder = owner
-	status_holder.physiology.red_mod *= 0.8
-	status_holder.physiology.white_mod *= 0.8
-	status_holder.physiology.black_mod *= 0.8
-	status_holder.physiology.pale_mod *= 0.8
+	status_holder.physiology.red_mod *= 0.93
+	status_holder.physiology.white_mod *= 0.93
+	status_holder.physiology.black_mod *= 0.93
+	status_holder.physiology.pale_mod *= 0.93
+	status_holder.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, -15)
 
 
 //SACRIFICE
@@ -253,20 +269,22 @@
 	if(!ishuman(owner))
 		return
 	var/mob/living/carbon/human/status_holder = owner
-	status_holder.physiology.red_mod /= 0.7
-	status_holder.physiology.white_mod /= 0.7
-	status_holder.physiology.black_mod /= 0.7
-	status_holder.physiology.pale_mod /= 0.7
+	status_holder.physiology.red_mod /= 0.9
+	status_holder.physiology.white_mod /= 0.9
+	status_holder.physiology.black_mod /= 0.9
+	status_holder.physiology.pale_mod /= 0.9
 
 /datum/status_effect/sacrifice/on_remove()
 	. = ..()
 	if(!ishuman(owner))
 		return
 	var/mob/living/carbon/human/status_holder = owner
-	status_holder.physiology.red_mod *= 0.7
-	status_holder.physiology.white_mod *= 0.7
-	status_holder.physiology.black_mod *= 0.7
-	status_holder.physiology.pale_mod *= 0.7
+	status_holder.physiology.red_mod *= 0.9
+	status_holder.physiology.white_mod *= 0.9
+	status_holder.physiology.black_mod *= 0.9
+	status_holder.physiology.pale_mod *= 0.9
+	to_chat(status_holder, span_nicegreen("Through your sacrifice, you gain strength."))
+	status_holder.adjust_all_attribute_levels(3)
 
 #undef STATUS_EFFECT_WILTING
 #undef STATUS_EFFECT_SCHISMATIC

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
@@ -75,7 +75,7 @@
 	if(work_type == ABNORMALITY_WORK_REPRESSION)
 		var/mob/living/chosen = chosen_memory ? chosen_memory.resolve() : null
 		if (chosen == null)
-			chosen = user
+			chosen_memory = WEAKREF(user)
 			user.visible_message(span_warning("You are now Staining Rose's Chosen."))
 			icon_state = "rose_activated"
 

--- a/code/modules/paperwork/records/info/aleph.dm
+++ b/code/modules/paperwork/records/info/aleph.dm
@@ -75,9 +75,10 @@
 	abno_type = /mob/living/simple_animal/hostile/abnormality/staining_rose
 	abno_code = "F-04-116"
 	abno_info = list(
-		"The first employee who works on Staining Rose will resonate with it and become the Chosen.",
-		"If anyone other than the Chosen worked on Staining Rose, they became more vulnerable to damage until Staining Rose wilted.",
+		"The first employee who works Repression on Staining Rose will resonate with it and become the Chosen.",
+		"If anyone other than the Chosen worked Repression on Staining Rose, they became more vulnerable to damage, and gained more damage until Staining Rose wilted.",
 		"When an employee with Justice 4 or lower finished their work, Staining Rose seemed to reset its satisfaction. The employee became more vulnerable to damage until Staining Rose wilted.",
+		"However, this increased the time between breaches, and when the effects wore off, the employee seemed to be stronger.",
 		"Every 15 minutes, the Qliphoth Counter lowered unless Staining Rose was worked on within the time period.",
 		"When the Qliphoth Counter reached 0, Staining Rose shed its petals, and everyone in the facility became more vulnerable to damage.")
 


### PR DESCRIPTION
## About The Pull Request
Updates rose entirely.
  (Major)
  - Meltdown timer decreased 15 > 12
  - Instinct work rates increased 0 > (0,0,0,30,40)
  - Work Damage Decreased 16 > 9
  - Work Damage increases on failed worktick.
  
  (Breach)
    - Lowers power mod by 30
    
  (Sacrifice)
    - When Sacrifice is cleared, increase all stats by 3.
    - Increases time to breach rose 12 > 17 Minutes
    - Defense decrease lowered +42% > +11%
    
  (Schismatic)
    - Activates on only repression work
    - Increases Power mod by 15
    - Defense decrease Lowered 25 > 7.5
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [ ] This PR compiles
* [ ] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
code: CHANGEME
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
