### PR TITLE
Fixes Hemorrhage (Crimson Lust) display icon lingering on refresh

### DIFF
--- a/ModularLobotomy/ego_weapons/melee/abnormality/waw.dm
+++ b/ModularLobotomy/ego_weapons/melee/abnormality/waw.dm
@@ -534,7 +534,9 @@
 
 /datum/status_effect/display/crimlust_hemorrhage/be_replaced()
 	if(icon_overlay)
-		owner.cut_overlay(icon_overlay) // Need to put this here 'cause apparently on_remove and be_replaced are different, which makes sense honestly but if I don't do this the overlay sticks forever
+		remove_image_from_clients(icon_overlay)
+		GLOB.status_display_icons -= icon_overlay
+		icon_overlay = null
 	. = ..()
 
 /// Called when the mob dies or when it's hit by a Hollowpoint Shell


### PR DESCRIPTION
## About The Pull Request
What it says on the tin.
(Hemorrhage's display icon used to be stuck onto mobs forever if you reapplied it before consuming it.)
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
fix: Hemorrhage (Crimson Lust) display icon now correctly removed after consuming a replaced instance
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
