### PR TITLE
Distorted Form Fixes [DONE]

### DIFF
--- a/ModularLobotomy/_abno_abilities.dm
+++ b/ModularLobotomy/_abno_abilities.dm
@@ -231,6 +231,12 @@
 				flicks  = TRUE
 	return ..()
 
+/obj/effect/proc_holder/ability/aimed/dash/spear_apostle/AbnoInteraction(mob/living/user)
+	if(!istype(user, /mob/living/simple_animal/hostile/abnormality/distortedform))
+		return
+	var/mob/living/simple_animal/hostile/abnormality/distortedform/abno = user
+	ToggleAct(abno,TRUE)
+	abno.endCharge()
 
 /obj/effect/proc_holder/ability/aimed/dash/big_wolf
 	name = "big wolf dash"

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
@@ -450,6 +450,9 @@
 			call(src, special_attack)()
 	return
 
+/mob/living/simple_animal/hostile/abnormality/distortedform/proc/endCharge()
+	ScytheAttack()
+
 /mob/living/simple_animal/hostile/abnormality/distortedform/proc/ChangeForm(form)
 	new /obj/effect/temp_visual/distortedform_shift(get_turf(src))
 	TurnNormal() //reset offsets/icon/resistances
@@ -1983,37 +1986,38 @@
 
 /obj/effect/temp_visual/remnant_of_time/proc/FormulateExplode(dir_to_target)
 	. = list()
-	var/turf/source_turf = get_turf(src)
-	var/list/middle_line = list()
-	var/list/directional_list  = list(NORTH,SOUTH,EAST,WEST)
 	//Default is North/South
-	var/right_dir = EAST
-	var/left_dir = WEST
-	if(dir_to_target ==  EAST || dir_to_target == WEST)
-		right_dir =  NORTH
-		left_dir = SOUTH
+	//We need 2 numbers. The lower left and the upper right of the square.
+	//Lower Left
+	var/offsetx1 = 0
+	var/offsety1 = 0
+	//Upper Right
+	var/offsetx2 = 0
+	var/offsety2 = 0
+	//Give me where theoretically the center of the turf we would be hitting be.
+	switch(dir_to_target)
+		if(EAST)
+			offsetx1 = 1
+			offsety1 = -slash_width
+			offsetx2 = slash_length
+			offsety2 = slash_width
+		if(WEST)
+			offsetx1 = -slash_length
+			offsety1 = -slash_width
+			offsetx2 = -1
+			offsety2 = slash_width
+		if(SOUTH)
+			offsetx1 = -slash_width
+			offsety1 = -slash_length
+			offsetx2 = slash_width
+			offsety2 = -1
+		if(NORTH)
+			offsetx1 = -slash_width
+			offsety1 = 1
+			offsetx2 = slash_width
+			offsety2 = slash_length
+		else
+			return list()
 
-	if(dir_to_target in directional_list)
-		middle_line = getline(source_turf, get_ranged_target_turf(source_turf, NORTH, slash_length))
-		for(var/turf/T in middle_line)
-			if(T.density)
-				break
-			for(var/turf/Y in getline(T, get_ranged_target_turf(T, right_dir, slash_width)))
-				if (Y.density)
-					break
-				if (Y in .)
-					continue
-				. += Y
-			for(var/turf/U in getline(T, get_ranged_target_turf(T, left_dir, slash_width)))
-				if (U.density)
-					break
-				if (U in .)
-					continue
-				. += U
-	else
-		for(var/turf/T in view(1, src))
-			if (T.density)
-				break
-			if (T in .)
-				continue
-			. |= T
+	//Give me ONLY the turfs between these cords
+	return block(x+offsetx1,y+offsety1,z,x+offsetx2,y+offsety2)


### PR DESCRIPTION
## About The Pull Request
Distorted forms price of silence attack was all wonky, this should fix it by replacing the area calc code with something similar to blue shepherds cleave.
Distorted forms scythe attack after dashing is now back.

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [x] This PR compiles
* [x] This PR runs fine in a local test
* [x] This PR does not produce runtimes
* [x] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
fix: distorted forms dash scythe attack and price of silence attack.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
