### PR TITLE
 Fixes Harmony Alt fire sprite and Blue Star Containment

### DIFF
--- a/ModularLobotomy/ego_weapons/ranged/ego_bullets/he.dm
+++ b/ModularLobotomy/ego_weapons/ranged/ego_bullets/he.dm
@@ -80,7 +80,7 @@
 
 /obj/projectile/ego_bullet/ego_harmonyfast
 	name = "Musical Addiction"
-	icon_state = "harmony_fast"
+	icon_state = "harmony"
 	damage = 16
 	damage_type = WHITE_DAMAGE
 	speed = 0.5

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
@@ -95,7 +95,6 @@
 /mob/living/simple_animal/hostile/abnormality/bluestar/Life()
 	//If you have a supplies crate nearby, delete it, spawn a new one, and set the things proper
 	for(var/obj/structure/blue_core/Y in range(2, src))
-		to_chat(world, "Found core: [Y]")
 		qdel(Y)
 		buff_cooldown = world.time + buff_cooldown_time
 		work_damage_amount = 16

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
@@ -93,23 +93,25 @@
 	return FALSE
 
 /mob/living/simple_animal/hostile/abnormality/bluestar/Life()
-	. = ..()
-	if(!.) // Dead
-		return FALSE
-	if((pulse_cooldown < world.time) && !(status_flags & GODMODE))
-		BluePulse()
-
-	if((buff_cooldown < world.time) && (status_flags & GODMODE))
-		work_damage_amount = initial(work_damage_amount)
-
 	//If you have a supplies crate nearby, delete it, spawn a new one, and set the things proper
 	for(var/obj/structure/blue_core/Y in range(2, src))
+		to_chat(world, "Found core: [Y]")
 		qdel(Y)
 		buff_cooldown = world.time + buff_cooldown_time
 		work_damage_amount = 16
 		pulse_damage = initial(pulse_damage)
 		var/turf/W = pick(GLOB.xeno_spawn)
 		new /obj/structure/blue_core (get_turf(W))
+
+	. = ..()
+	if(!.) // Dead
+		return FALSE
+
+	if((pulse_cooldown < world.time) && !(status_flags & GODMODE))
+		BluePulse()
+
+	if((buff_cooldown < world.time) && (status_flags & GODMODE))
+		work_damage_amount = initial(work_damage_amount)
 
 /mob/living/simple_animal/hostile/abnormality/bluestar/CanAttack(atom/the_target)
 	return FALSE


### PR DESCRIPTION
## About The Pull Request
Fixes Harmony Alt fire sprite
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [x] This PR compiles
* [ ] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [x] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
fix: spritefix
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
