### PR TITLE
Select Patrol Location refactored into its own proc. [DONE]

### DIFF
--- a/ModularLobotomy/!extra_abnos/branch12/waw/dead_man.dm
+++ b/ModularLobotomy/!extra_abnos/branch12/waw/dead_man.dm
@@ -151,12 +151,11 @@
 		say("My job here is done.")
 		death()
 
-/mob/living/simple_animal/hostile/abnormality/branch12/deadman/patrol_select()
+/mob/living/simple_animal/hostile/abnormality/branch12/deadman/SelectPatrolLocation()
 	var/patrol_turf = get_turf(marked_man)
 
 	var/turf/target_turf = get_closest_atom(/turf/open, patrol_turf, src)
 
 	if(istype(target_turf))
-		patrol_path = get_path_to(src, target_turf, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
-		return
+		return target_turf
 	return ..()

--- a/ModularLobotomy/!extra_abnos/branch12/waw/joe_shmoe.dm
+++ b/ModularLobotomy/!extra_abnos/branch12/waw/joe_shmoe.dm
@@ -150,7 +150,7 @@
 	if(masterjoe.marked)
 		FindTarget() // KILL HIM, KILL HIM NOW
 
-/mob/living/simple_animal/hostile/subjoe/patrol_select()
+/mob/living/simple_animal/hostile/subjoe/SelectPatrolLocation()
 	if(!masterjoe.marked)
 		return
 
@@ -159,6 +159,6 @@
 	var/turf/target_turf = get_closest_atom(/turf/open, patrol_turf, src)
 
 	if(istype(target_turf))
-		patrol_path = get_path_to(src, target_turf, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
-		return
+		return target_turf
+
 	return ..()

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
@@ -322,7 +322,7 @@
 	. = ..()
 	FindTarget() // Start eating corpses IMMEDIATELLY
 
-/mob/living/simple_animal/hostile/abnormality/mountain/patrol_select()
+/mob/living/simple_animal/hostile/abnormality/mountain/SelectPatrolLocation()
 	if(phase >= 3) // Ignore dead stuff from now on
 		return ..()
 
@@ -357,8 +357,8 @@
 		target_turf = get_closest_atom(/turf/open, low_priority_turfs, src)
 
 	if(istype(target_turf))
-		patrol_path = get_path_to(src, target_turf, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
-		return
+		return target_turf
+
 	return ..()
 
 /* Abnormality work */

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm
@@ -662,15 +662,12 @@
 			return
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/nobody_is/patrol_select() //Hunt down the chosen one
+/mob/living/simple_animal/hostile/abnormality/nobody_is/SelectPatrolLocation() //Hunt down the chosen one
 	if(shelled) // We don't need a chosen anymore, or any special pathfinding behavior
 		return ..()
 	var/mob/living/carbon/chosen = chosen_memory ? chosen_memory.resolve() : null
 	if(chosen) //YOU'RE MINE
-		SEND_SIGNAL(src, COMSIG_PATROL_START, src, get_turf(chosen)) //Overrides the usual proc to target a specific tile
-		SEND_GLOBAL_SIGNAL(src, COMSIG_GLOB_PATROL_START, src, get_turf(chosen))
-		patrol_path = get_path_to(src, get_turf(chosen), TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
-		return
+		return get_turf(chosen)
 	else
 		ChangeReflection()
 	return ..()

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
@@ -412,12 +412,16 @@ GLOBAL_LIST_EMPTY(apostles)
 		return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/apostle/scythe/guardian/patrol_select()
+/mob/living/simple_animal/hostile/apostle/scythe/guardian/SelectPatrolLocation()
 	var/mob/living/simple_animal/hostile/abnormality/white_night/WN = locate() in GLOB.abnormality_mob_list
 	if(!istype(WN))
 		return
-	var/turf/target_turf = pick(RANGE_TURFS(2, WN))
-	patrol_path = get_path_to(src, target_turf, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
+	return pick(RANGE_TURFS(2, WN))
+
+/mob/living/simple_animal/hostile/apostle/scythe/guardian/PatrolSelect()
+	. = ..()
+	if(.)
+		return
 	playsound(get_turf(src), 'sound/abnormalities/whitenight/apostle_growl.ogg', 75, FALSE)
 	TemporarySpeedChange(-4, 5 SECONDS) // OUT OF MY WAY
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/better_memories.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/better_memories.dm
@@ -251,7 +251,7 @@
 	retreat_distance = 4
 	minimum_distance = 4
 
-/mob/living/simple_animal/hostile/better_memories_minion/patrol_select()
+/mob/living/simple_animal/hostile/better_memories_minion/SelectPatrolLocation()
 	//Due to some weird thing the values in hunt_target become null so this empty's the list out before it gets too long.
 	if(hunt_targets.len > 5)
 		hunt_targets.Cut()
@@ -262,8 +262,7 @@
 		hunt_targets += target_turf
 
 	if(istype(target_turf))
-		patrol_path = get_path_to(src, target_turf, /turf/proc/Distance_cardinal, 0, 200)
-		return
+		return target_turf
 	return ..()
 
 /mob/living/simple_animal/hostile/better_memories_minion/patrol_reset()

--- a/code/modules/mob/living/simple_animal/abnormality/he/eris.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/eris.dm
@@ -101,7 +101,7 @@
 	healpulse()
 
 //Okay, but here's the patrolling stuff
-/mob/living/simple_animal/hostile/abnormality/eris/patrol_select()
+/mob/living/simple_animal/hostile/abnormality/eris/SelectPatrolLocation()
 	var/list/target_turfs = list() // Stolen from Punishing Bird
 	for(var/mob/living/carbon/human/H in GLOB.human_list)
 		if(H.z != z) // Not on our level
@@ -112,8 +112,7 @@
 
 	var/turf/target_turf = get_closest_atom(/turf/open, target_turfs, src)
 	if(istype(target_turf))
-		patrol_path = get_path_to(src, target_turf, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
-		return
+		return target_turf
 	return ..()
 
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
@@ -187,7 +187,7 @@
 	return ..()
 
 //Copied MOSB corpse-seeking behavior
-/mob/living/simple_animal/hostile/abnormality/pale_horse/patrol_select()
+/mob/living/simple_animal/hostile/abnormality/pale_horse/SelectPatrolLocation()
 	var/list/low_priority_turfs = list() // Oh, you're wounded, how nice.
 	var/list/medium_priority_turfs = list() // You're about to die and you are close? Splendid.
 	var/list/high_priority_turfs = list() // IS THAT A DEAD BODY?
@@ -217,8 +217,7 @@
 		target_turf = get_closest_atom(/turf/open, low_priority_turfs, src)
 
 	if(istype(target_turf))
-		patrol_path = get_path_to(src, target_turf, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
-		return
+		return target_turf
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/pale_horse/Goto(target, delay, minimum_distance)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
@@ -339,7 +339,7 @@
 		death_timer = addtimer(CALLBACK(src, PROC_REF(kill_bird)), 60 SECONDS, TIMER_STOPPABLE)
 
 // Modified patrolling
-/mob/living/simple_animal/hostile/abnormality/punishing_bird/patrol_select()
+/mob/living/simple_animal/hostile/abnormality/punishing_bird/SelectPatrolLocation()
 	if(obj_damage > 0) // Already transformed
 		return ..()
 
@@ -358,8 +358,7 @@
 
 	var/turf/target_turf = get_closest_atom(/turf/open, target_turfs, src)
 	if(istype(target_turf))
-		patrol_path = get_path_to(src, target_turf, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
-		return
+		return target_turf
 	return ..()
 
 /* Work effects */

--- a/code/modules/mob/living/simple_animal/abnormality/teth/scorched_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/scorched_girl.dm
@@ -79,7 +79,7 @@
 		owner.icon_state = "scorched_breach"
 		active = 0
 
-/mob/living/simple_animal/hostile/abnormality/scorched_girl/patrol_select()
+/mob/living/simple_animal/hostile/abnormality/scorched_girl/SelectPatrolLocation()
 	var/turf/target_center
 	var/highestcount = 0
 	for(var/turf/T in GLOB.department_centers)
@@ -90,10 +90,9 @@
 		if(targets_at_tile > highestcount)
 			target_center = T
 			highestcount = targets_at_tile
-	if(!target_center)
-		..()
-	else
-		patrol_path = get_path_to(src, target_center, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
+	if(target_center)
+		return target_center
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/scorched_girl/OpenFire()
 	if(client)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/clown_smiling.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/clown_smiling.dm
@@ -164,7 +164,7 @@
 	return ..()
 
 // Modified patrolling
-/mob/living/simple_animal/hostile/abnormality/clown/patrol_select()
+/mob/living/simple_animal/hostile/abnormality/clown/SelectPatrolLocation()
 	var/list/target_turfs = list() // Stolen from Punishing Bird
 	for(var/mob/living/carbon/human/H in GLOB.human_list)
 		if(H.z != z) // Not on our level
@@ -175,8 +175,7 @@
 
 	var/turf/target_turf = get_closest_atom(/turf/open, target_turfs, src)
 	if(istype(target_turf))
-		patrol_path = get_path_to(src, target_turf, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
-		return
+		return target_turf
 	return ..()
 
 //When the work result was good...

--- a/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
@@ -249,7 +249,7 @@
 			return
 		L.dropItemToGround(held) //Drop weapon
 
-/mob/living/simple_animal/hostile/runawaybird/patrol_select()
+/mob/living/simple_animal/hostile/runawaybird/SelectPatrolLocation()
 	var/list/target_turfs = list()
 	for(var/mob/living/simple_animal/hostile/abnormality/judgement_bird/J in GLOB.mob_list)
 		if(J.z != z) // Not on our level
@@ -261,8 +261,7 @@
 		return ..()
 	var/turf/target_turf = pick(target_turfs)
 	if(istype(target_turf))
-		patrol_path = get_path_to(src, target_turf, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
-		return
+		return target_turf
 	return ..()
 
 //On-kill visual effect

--- a/code/modules/mob/living/simple_animal/abnormality/waw/red_riding_mercenary.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/red_riding_mercenary.dm
@@ -612,14 +612,11 @@ It has now been over four months. Now we get her for real. -Coxswain
 		ContractComplete()
 		return
 
-/mob/living/simple_animal/hostile/abnormality/red_hood/patrol_select() //Path right to our target
+/mob/living/simple_animal/hostile/abnormality/red_hood/SelectPatrolLocation() //Path right to our target
 	if(out_on_request || priority_target)
 		if(!priority_target) //For some reason we never got one
 			return ..()
-		SEND_SIGNAL(src, COMSIG_PATROL_START, src, get_turf(priority_target))
-		SEND_GLOBAL_SIGNAL(src, COMSIG_GLOB_PATROL_START, src, get_turf(priority_target))
-		patrol_path = get_path_to(src, get_turf(priority_target), TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
-		return
+		return get_turf(priority_target)
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/red_hood/proc/ContractComplete()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/screenwriter.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/screenwriter.dm
@@ -297,7 +297,7 @@
 	add_overlay(mutable_appearance('icons/effects/32x64.dmi', "abandoned", -ABOVE_MOB_LAYER))
 
 // Patrol Code
-/mob/living/simple_animal/hostile/actor/patrol_select() //Hunt down the "victim"s
+/mob/living/simple_animal/hostile/actor/SelectPatrolLocation() //Hunt down the "victim"s
 	var/mob/living/carbon/human/potential_target
 	for(var/mob/living/carbon/human/L in GLOB.player_list)
 		if(faction_check_mob(L, FALSE) || L.stat >= HARD_CRIT || L.sanity_lost || z != L.z) // Dead or in hard crit, insane, or on a different Z level.
@@ -307,13 +307,11 @@
 			continue
 		potential_target = L
 		if(S.role == "victim") //We found 'em!
-			patrol_to(get_turf(L))
-			return
+			return get_turf(L)
 	if(potential_target)
 		var/datum/status_effect/actor/S = potential_target.has_status_effect(/datum/status_effect/actor)
 		S.ChangeToVictim()
-		patrol_to(get_turf(potential_target))
-		return
+		return get_turf(potential_target)
 	return ..()
 
 /mob/living/simple_animal/hostile/actor/PickTarget(list/Targets)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
@@ -68,7 +68,7 @@
 	var/finishing = FALSE
 	var/locked_in = FALSE
 	var/mob/living/hooligan
-	var/AreasToPatrol = list()
+	var/areas_to_patrol = list()
 	var/breach_time = 3 MINUTES
 
 	// Frustration + Release mechanics
@@ -151,7 +151,7 @@
 /mob/living/simple_animal/hostile/abnormality/warden/Destroy()
 	UnregisterSignal(SSdcs, COMSIG_GLOB_ABNORMALITY_BREACH)
 	QDEL_NULL(soul_names) // It WOULD be fun if Warden saved all soul names that it has consumed but I cannot be assed to figure that out.
-	QDEL_NULL(AreasToPatrol)
+	QDEL_NULL(areas_to_patrol)
 	for(var/mob/living/carbon/human/L in GLOB.player_list) // Cleanse debuffs
 		if(faction_check_mob(L, FALSE) || L.stat == DEAD) // Dead? Fuck them
 			continue
@@ -442,7 +442,7 @@
 		for(var/mob/living/simple_animal/hostile/soulless/husk in indoctrinated_morons)
 			husk.Agitate(rand(4, 15))
 
-/mob/living/simple_animal/hostile/abnormality/warden/patrol_select()
+/mob/living/simple_animal/hostile/abnormality/warden/SelectPatrolLocation()
 	if(SSmaptype.maptype in SSmaptype.autopossess)
 		return
 	if(hooligan) // Lets just fucking copy this from NI, I am tired.
@@ -450,23 +450,18 @@
 		if(!trytorun)
 			hooligan = null
 			return
-		SEND_SIGNAL(src, COMSIG_PATROL_START, src, trytorun) //Overrides the usual proc to target a specific tile
-		SEND_GLOBAL_SIGNAL(src, COMSIG_GLOB_PATROL_START, src, trytorun)
-		patrol_to(trytorun)
-		return
+		return trytorun
 	if(!LAZYLEN(GLOB.department_centers))
 		return
 	var/turf/target_center
-	if(!LAZYLEN(AreasToPatrol))
+	if(!LAZYLEN(areas_to_patrol))
 		for(var/pos_targ in GLOB.department_centers)
 			var/possible_center_distance = get_dist(src, pos_targ)
 			if(possible_center_distance > 4 && possible_center_distance < 60)
-				AreasToPatrol += pos_targ
-	target_center = pick(AreasToPatrol)
-	SEND_SIGNAL(src, COMSIG_PATROL_START, src, target_center)
-	SEND_GLOBAL_SIGNAL(src, COMSIG_GLOB_PATROL_START, src, target_center)
-	patrol_path = get_path_to(src, target_center, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
-	AreasToPatrol -= target_center
+				areas_to_patrol |= pos_targ
+	target_center = pick(areas_to_patrol)
+	areas_to_patrol -= target_center
+	return target_center
 
 /mob/living/simple_animal/hostile/abnormality/warden/Life()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -239,11 +239,10 @@ GLOBAL_LIST_EMPTY(marked_players)
 		patrol_reset()
 		return
 	if(CanStartPatrol())
-		if(patrol_cooldown <= world.time)
-			if(!patrol_path || !patrol_path.len)
-				patrol_select()
-				if(patrol_path.len)
-					patrol_move(patrol_path[patrol_path.len])
+		if(!patrol_path || !length(patrol_path))
+			PatrolSelect()
+			if(length(patrol_path))
+				patrol_move(patrol_path[patrol_path.len])
 
 	/*		AIStatus
 	AI_ON will have the npcpool subsystem call handle_automated_action(),
@@ -384,7 +383,7 @@ GLOBAL_LIST_EMPTY(marked_players)
 	target_memory.Cut()
 	attack_is_on_cooldown = FALSE
 	LoseTarget()
-	..(gibbed)
+	return ..(gibbed)
 
 /mob/living/simple_animal/hostile/update_stamina()
 	if(staminaloss == 0)
@@ -547,6 +546,7 @@ GLOBAL_LIST_EMPTY(marked_players)
 /mob/living/simple_animal/hostile/proc/ListTargets(max_range = vision_range) //Step 1, find out what we can see
 	if(!can_act)
 		return list()
+
 	//The thorough mode, rarely used
 	if(search_objects)
 		. = oview(max_range, targets_from)
@@ -1359,6 +1359,8 @@ GLOBAL_LIST_EMPTY(marked_players)
 /mob/living/simple_animal/hostile/proc/CanStartPatrol()
 	if(!can_act)
 		return FALSE
+	if(patrol_cooldown > world.time)
+		return FALSE
 	return AIStatus == AI_IDLE //if AI is idle, begin checking for patrol
 
 /mob/living/simple_animal/hostile/proc/patrol_to(turf/target_location = null)
@@ -1371,26 +1373,36 @@ GLOBAL_LIST_EMPTY(marked_players)
 	patrol_move(patrol_path[patrol_path.len])
 	return TRUE
 
-/mob/living/simple_animal/hostile/proc/patrol_select()
+/mob/living/simple_animal/hostile/proc/PatrolSelect()
 	//Mobs should stay unpatroled on maps where they're intended to be possessed.
 	if(SSmaptype.maptype in SSmaptype.autopossess)
-		return
+		return FALSE
+
+	var/turf/target_center = SelectPatrolLocation()
+	if(!isturf(target_center))
+		target_center = get_turf(target_center)
+	if(!target_center)
+		return FALSE
+
+	SEND_SIGNAL(src, COMSIG_PATROL_START, src, target_center)
+	SEND_GLOBAL_SIGNAL(src, COMSIG_GLOB_PATROL_START, src, target_center)
+	var/temp_patrol_path = get_path_to(src, target_center, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
+	patrol_path = temp_patrol_path
+	return temp_patrol_path
+
+/mob/living/simple_animal/hostile/proc/SelectPatrolLocation()
 	if(!LAZYLEN(GLOB.department_centers))
 		return
 
-	var/turf/target_center
 	var/list/potential_centers = list()
 	for(var/pos_targ in GLOB.department_centers)
 		var/possible_center_distance = get_dist(src, pos_targ)
 		if(possible_center_distance > 4 && possible_center_distance < 46)
 			potential_centers += pos_targ
 	if(LAZYLEN(potential_centers))
-		target_center = pick(potential_centers)
+		return pick(potential_centers)
 	else
-		target_center = pick(GLOB.department_centers)
-	SEND_SIGNAL(src, COMSIG_PATROL_START, src, target_center)
-	SEND_GLOBAL_SIGNAL(src, COMSIG_GLOB_PATROL_START, src, target_center)
-	patrol_path = get_path_to(src, target_center, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
+		return pick(GLOB.department_centers)
 
 /mob/living/simple_animal/hostile/proc/patrol_reset()
 	patrol_path = list()

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/indigo/midnight.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/indigo/midnight.dm
@@ -376,7 +376,13 @@ Some other overrides like AttackingTarget() are in the Combat section instead.
 	. = ..()
 	FindTarget() // Start eating corpses IMMEDIATELLY
 
-/mob/living/simple_animal/hostile/ordeal/indigo_midnight/patrol_select()
+/mob/living/simple_animal/hostile/ordeal/indigo_midnight/PatrolSelect()
+	. = ..()
+	if(!.)
+		//unsure if this patrol reset will cause the patrol cooldown even if there is not patrol path.
+		patrol_reset()
+
+/mob/living/simple_animal/hostile/ordeal/indigo_midnight/SelectPatrolLocation()
 	var/list/low_priority_turfs = list() // Oh, you're wounded, how nice.
 	var/list/medium_priority_turfs = list() // You're about to die and you are close? Splendid.
 	var/list/high_priority_turfs = list() // IS THAT A DEAD BODY?
@@ -405,16 +411,7 @@ Some other overrides like AttackingTarget() are in the Combat section instead.
 		target_turf = get_closest_atom(/turf/open, low_priority_turfs, src)
 
 	if(istype(target_turf))
-		patrol_path = get_path_to(src, target_turf, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
-		var/turf/the_promised_land = patrol_path[patrol_path.len] // Yes yes I know .len is bad but if I use length(patrol_path) here it runtimes. For some reason...?
-		if(istype(the_promised_land))
-			SEND_SIGNAL(src, COMSIG_PATROL_START, the_promised_land) // LET'S FUCKING GOOOOOOOOOOOOOO (this makes our leadership component tell our goons to come with us)
-		return TRUE
-	//unsure if this patrol reset will cause the patrol cooldown even if there is not patrol path.
-	patrol_reset()
-	return FALSE
-
-
+		return target_turf
 
 
 /*

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/shrimps.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/shrimps.dm
@@ -293,7 +293,7 @@
 	color = COLOR_PURPLE
 
 // Modified patrolling
-/mob/living/simple_animal/hostile/ordeal/salmon_dusk/black/patrol_select()
+/mob/living/simple_animal/hostile/ordeal/salmon_dusk/black/SelectPatrolLocation()
 	fast_mode = TRUE
 	var/list/target_turfs = list()
 	for(var/mob/living/carbon/human/H in GLOB.human_list)
@@ -305,8 +305,7 @@
 
 	var/turf/target_turf = get_closest_atom(/turf/open, target_turfs, src)
 	if(istype(target_turf))
-		patrol_path = get_path_to(src, target_turf, /turf/proc/Distance_cardinal, 0, 200)
-		return
+		return target_turf
 	return ..()
 
 /mob/living/simple_animal/hostile/ordeal/salmon_dusk/black/MoveToTarget(list/possible_targets)

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/steel/manager.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/steel/manager.dm
@@ -71,10 +71,12 @@
 			else
 				Command(pick(2,3))
 
-/mob/living/simple_animal/hostile/ordeal/steel_dusk/patrol_select()
+/mob/living/simple_animal/hostile/ordeal/steel_dusk/PatrolSelect()
+	. = ..()
+	if(!.)
+		return
 	if(prob(25))
 		say("Nothin here. Lets move on.")
-	..()
 
 /mob/living/simple_animal/hostile/ordeal/steel_dusk/Aggro()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Makes it so that patrol select handles the signal code and SelectPatrolLocation be deferred to handle finding the location.

## Why It's Good For The Game
Makes overriding the patrol location easier.

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [x] This PR compiles
* [x] This PR runs fine in a local test
* [x] This PR does not produce runtimes
* [x] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
refactor: patrol location selection code IE SelectPatrolLocation
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
