### PR TITLE
Minor Update: Achievement Specialization UI Update [DONE]

### DIFF
--- a/ModularLobotomy/debug_items.dm
+++ b/ModularLobotomy/debug_items.dm
@@ -395,3 +395,78 @@
 		return
 	target.BreachEffect(user, breach_type)
 	to_chat(user, span_nicegreen("You triggered a [breach_type] breach!"))
+
+/**
+ * Opens the Achievement Specialization TGUI (the same window used by character
+ * preferences) populated with hardcoded fake achievements. Achievement data
+ * normally requires a database connection, which is unavailable on local/dev
+ * servers, so this lets a developer preview the UI layout without one.
+ */
+/obj/item/lc_debug/achievement_spec_demo
+	name = "achievement spec previewer"
+	desc = "Opens the Achievement Specialization UI with fake achievements so the layout can be previewed without a database connection."
+	icon_state = "watch_cobalt"
+	/// Currently selected fake achievement "type" key, drives the card outline
+	var/chosen = null
+
+/obj/item/lc_debug/achievement_spec_demo/attack_self(mob/user)
+	. = ..()
+	ui_interact(user)
+
+/obj/item/lc_debug/achievement_spec_demo/ui_state(mob/user)
+	return GLOB.inventory_state
+
+/obj/item/lc_debug/achievement_spec_demo/ui_assets(mob/user)
+	return list(
+		get_asset_datum(/datum/asset/spritesheet/simple/achievements),
+	)
+
+/obj/item/lc_debug/achievement_spec_demo/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "AchievementSpec")
+		ui.open()
+
+/obj/item/lc_debug/achievement_spec_demo/ui_data(mob/user)
+	var/datum/asset/spritesheet/simple/assets = get_asset_datum(/datum/asset/spritesheet/simple/achievements)
+	var/list/data = list()
+	data["chosen"] = chosen
+	data["achievements"] = list()
+
+	// Each entry mirrors the real ui_data shape. Difficulty colors/orders match
+	// get_difficulty_color()/get_difficulty_order() in _awards.dm. Icon keys are
+	// real spritesheet entries so the badges render.
+	var/list/fakes = list(
+		list("type" = "fake_easy", "name" = "First Day", "desc" = "Survived your very first shift.", "title" = "the Newcomer", "difficulty" = ACHIEVEMENT_EASY, "color" = "#ADD8E6", "order" = 1, "icon" = "default"),
+		list("type" = "fake_normal", "name" = "Steady Hands", "desc" = "Completed a full day without a single casualty.", "title" = "the Reliable", "difficulty" = ACHIEVEMENT_NORMAL, "color" = "#00FF00", "order" = 2, "icon" = "jackpot"),
+		list("type" = "fake_hard", "name" = "Containment Specialist", "desc" = "Suppressed a major breach single-handedly.", "title" = "the Suppressor", "difficulty" = ACHIEVEMENT_HARD, "color" = "#FF0000", "order" = 3, "icon" = "legion"),
+		list("type" = "fake_veryhard", "name" = "Against All Odds", "desc" = "Cleared an Ordeal with the whole team alive.", "title" = "the Unbroken", "difficulty" = ACHIEVEMENT_VERYHARD, "color" = "#800080", "order" = 4, "icon" = "meteors"),
+		list("type" = "fake_hardest", "name" = "Light of the Facility", "desc" = "Defeated a core suppression boss.", "title" = "the Light Seeker", "difficulty" = ACHIEVEMENT_HARDEST, "color" = "#FFA500", "order" = 5, "icon" = "colossus"),
+		list("type" = "fake_hardest2", "name" = "Feat of Strength", "desc" = "Did something almost nobody manages to do.", "title" = "the Legend", "difficulty" = ACHIEVEMENT_HARDEST, "color" = "#FFA500", "order" = 5, "icon" = "featofstrength"),
+	)
+
+	for(var/list/fake in fakes)
+		data["achievements"] += list(list(
+			"type" = fake["type"],
+			"name" = fake["name"],
+			"desc" = fake["desc"],
+			"title" = fake["title"],
+			"difficulty" = fake["difficulty"],
+			"difficulty_color" = fake["color"],
+			"difficulty_order" = fake["order"],
+			"icon_class" = assets.icon_class_name(fake["icon"]),
+		))
+
+	return data
+
+/obj/item/lc_debug/achievement_spec_demo/ui_act(action, list/params)
+	. = ..()
+	if(.)
+		return
+	switch(action)
+		if("select")
+			chosen = params["type"]
+			return TRUE
+		if("none")
+			chosen = null
+			return TRUE

--- a/code/datums/achievements/_awards.dm
+++ b/code/datums/achievements/_awards.dm
@@ -108,6 +108,22 @@
 		else
 			return "#00FF00" // Default to green
 
+/// Returns a sortable numeric rank for this achievement's difficulty
+/datum/award/achievement/proc/get_difficulty_order()
+	switch(difficulty)
+		if(ACHIEVEMENT_EASY)
+			return 1
+		if(ACHIEVEMENT_NORMAL)
+			return 2
+		if(ACHIEVEMENT_HARD)
+			return 3
+		if(ACHIEVEMENT_VERYHARD)
+			return 4
+		if(ACHIEVEMENT_HARDEST)
+			return 5
+		else
+			return 2 // Default to normal
+
 ///Scores are for leaderboarded things, such as killcount of a specific boss
 /datum/award/score
 	desc = "you did it sooo many times."

--- a/code/datums/achievements/achievement_spec_menu.dm
+++ b/code/datums/achievements/achievement_spec_menu.dm
@@ -1,0 +1,71 @@
+/// TGUI menu used by the character preferences to pick which unlocked
+/// achievement is displayed as the player's specialization on examine.
+/datum/achievement_spec_menu
+	/// The preferences datum this menu edits.
+	var/datum/preferences/prefs
+
+/datum/achievement_spec_menu/New(datum/preferences/P)
+	. = ..()
+	prefs = P
+
+/datum/achievement_spec_menu/Destroy()
+	prefs = null
+	return ..()
+
+/datum/achievement_spec_menu/ui_assets(mob/user)
+	return list(
+		get_asset_datum(/datum/asset/spritesheet/simple/achievements),
+	)
+
+/datum/achievement_spec_menu/ui_state(mob/user)
+	return GLOB.always_state
+
+/datum/achievement_spec_menu/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "AchievementSpec")
+		ui.open()
+
+/datum/achievement_spec_menu/ui_data(mob/user)
+	var/list/data = list()
+	data["chosen"] = prefs?.chosen_achievement ? "[prefs.chosen_achievement]" : null
+	data["achievements"] = list()
+	if(!prefs)
+		return data
+
+	var/datum/asset/spritesheet/simple/assets = get_asset_datum(/datum/asset/spritesheet/simple/achievements)
+	for(var/achievement_type in prefs.get_unlocked_achievements())
+		var/datum/award/achievement/A = SSachievements.achievements[achievement_type]
+		if(!A || !A.name)
+			continue
+		var/list/this = list(
+			"type" = "[achievement_type]",
+			"name" = A.name,
+			"desc" = A.desc,
+			"title" = A.title ? A.title : A.name,
+			"difficulty" = A.difficulty,
+			"difficulty_color" = A.get_difficulty_color(),
+			"difficulty_order" = A.get_difficulty_order(),
+			"icon_class" = assets.icon_class_name(A.icon),
+		)
+		data["achievements"] += list(this)
+
+	return data
+
+/datum/achievement_spec_menu/ui_act(action, list/params)
+	. = ..()
+	if(.)
+		return
+	if(!prefs)
+		return
+	switch(action)
+		if("select")
+			var/chosen_type = text2path(params["type"])
+			if(chosen_type && (chosen_type in prefs.get_unlocked_achievements()))
+				prefs.chosen_achievement = chosen_type
+				prefs.ShowChoices(usr)
+			return TRUE
+		if("none")
+			prefs.chosen_achievement = null
+			prefs.ShowChoices(usr)
+			return TRUE

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -174,6 +174,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/broadcast_login_logout = TRUE
 	///Selected achievement to display as specialization
 	var/chosen_achievement = null
+	///Lazily-created TGUI menu for picking the achievement specialization
+	var/datum/achievement_spec_menu/achievement_spec_menu
 	///What outfit typepaths we've favorited in the SelectEquipment menu
 	var/list/favorite_outfits = list()
 	///Language that will be used for some of the strings
@@ -219,6 +221,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	save_character() //let's save this new random character so it doesn't keep generating new ones.
 	menuoptions = list()
 	return
+
+/datum/preferences/Destroy(force, ...)
+	QDEL_NULL(achievement_spec_menu)
+	return ..()
 
 #define APPEARANCE_CATEGORY_COLUMN "<td valign='top' width='14%'>"
 #define MAX_MUTANT_ROWS 4
@@ -1743,26 +1749,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						to_chat(user, "<span class='warning'>You have no unlocked achievements!</span>")
 						return
 
-					var/list/choices = list("None")
-					var/list/achievement_map = list()
-
-					for(var/achievement_type in unlocked)
-						var/datum/award/achievement/A = SSachievements.achievements[achievement_type]
-						if(!A || !A.name)
-							continue
-						var/color = A.get_difficulty_color()
-						var/display_name = "<font color='[color]'>[A.name] ([A.difficulty])</font>"
-						choices += display_name
-						achievement_map[display_name] = achievement_type
-
-					var/choice = input(user, "Choose your achievement specialization:", "Achievement Specialization") as null|anything in choices
-					if(!choice)
-						return
-
-					if(choice == "None")
-						chosen_achievement = null
-					else
-						chosen_achievement = achievement_map[choice]
+					if(!achievement_spec_menu)
+						achievement_spec_menu = new(src)
+					achievement_spec_menu.ui_interact(user)
 
 				// The lore stuff
 				if("govrelation")

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -466,6 +466,7 @@
 #include "code\datums\abnormality\datum\abnormality.dm"
 #include "code\datums\achievements\_achievement_data.dm"
 #include "code\datums\achievements\_awards.dm"
+#include "code\datums\achievements\achievement_spec_menu.dm"
 #include "code\datums\achievements\abno_achievements.dm"
 #include "code\datums\achievements\city_achievements.dm"
 #include "code\datums\achievements\clerk_achievements.dm"

--- a/tgui/packages/tgui/interfaces/AchievementSpec.js
+++ b/tgui/packages/tgui/interfaces/AchievementSpec.js
@@ -1,0 +1,114 @@
+import { useBackend, useLocalState } from '../backend';
+import { Box, Button, Flex, Section } from '../components';
+import { Window } from '../layouts';
+
+export const AchievementSpec = (props, context) => {
+  const { act, data } = useBackend(context);
+  const { chosen } = data;
+  const achievements = data.achievements || [];
+  const [sortMode, setSortMode] = useLocalState(
+    context, 'sortMode', 'name');
+
+  const sorted = [...achievements].sort((a, b) => {
+    if (sortMode === 'difficulty'
+      && b.difficulty_order !== a.difficulty_order) {
+      return b.difficulty_order - a.difficulty_order;
+    }
+    return a.name.localeCompare(b.name);
+  });
+
+  return (
+    <Window
+      title="Achievement Specialization"
+      width={520}
+      height={640}>
+      <Window.Content scrollable>
+        <Section
+          title="Select a Specialization"
+          buttons={(
+            <>
+              <Button
+                icon="sort-alpha-down"
+                selected={sortMode === 'name'}
+                onClick={() => setSortMode('name')}>
+                Name
+              </Button>
+              <Button
+                icon="signal"
+                selected={sortMode === 'difficulty'}
+                onClick={() => setSortMode('difficulty')}>
+                Difficulty
+              </Button>
+              <Button
+                icon="ban"
+                color="bad"
+                selected={!chosen}
+                onClick={() => act('none')}>
+                None
+              </Button>
+            </>
+          )}>
+          {sorted.length === 0 && (
+            <Box color="label">
+              You have no unlocked achievements.
+            </Box>
+          ) || (
+            sorted.map(ach => (
+              <AchievementCard
+                key={ach.type}
+                achievement={ach}
+                selected={ach.type === chosen} />
+            ))
+          )}
+        </Section>
+      </Window.Content>
+    </Window>
+  );
+};
+
+const AchievementCard = (props, context) => {
+  const { act } = useBackend(context);
+  const { achievement, selected } = props;
+  const {
+    type,
+    name,
+    desc,
+    title,
+    difficulty,
+    difficulty_color,
+    icon_class,
+  } = achievement;
+  const borderColor = selected ? difficulty_color : 'transparent';
+  return (
+    <Box
+      mb={1}
+      p={1}
+      backgroundColor="rgba(0, 0, 0, 0.25)"
+      onClick={() => act('select', { type })}
+      style={{
+        'border': '2px solid ' + borderColor,
+        'border-radius': '3px',
+        'cursor': 'pointer',
+      }}>
+      <Flex align="center">
+        <Flex.Item>
+          <Box className={icon_class} />
+        </Flex.Item>
+        <Flex.Item grow={1} ml={1}>
+          <Box bold fontSize="1.25rem" color={difficulty_color}>
+            {name}
+          </Box>
+          <Box fontSize="0.8rem" color="label" mt={0.5}>
+            {desc}
+          </Box>
+          <Box fontSize="1rem" mt={0.5} italic>
+            {title}
+          </Box>
+        </Flex.Item>
+        <Flex.Item color="label" ml={1}>
+          {difficulty}
+        </Flex.Item>
+      </Flex>
+    </Box>
+  );
+};


### PR DESCRIPTION
## About The Pull Request

Reworks the **Achievement Specialization** picker in the character preferences
menu and adds a debug tool for previewing it.

Previously, choosing which unlocked achievement to display as your
specialization (on examine) used a plain BYOND `input()` dropdown — a single
text list with no badges, descriptions, or sorting. This PR replaces that with
a dedicated TGUI window.

 **New `AchievementSpec` TGUI window** (`tgui/.../interfaces/AchievementSpec.js`).
  Each unlocked achievement is shown as a card: its badge on the left, and on
  the right the achievement name (largest, colored by difficulty), the
  description (smaller, muted), and the specialization title (mid-size) at the
  bottom — with the difficulty label on the far right. The list is scrollable.

## Why It's Good For The Game

The achievement specialization is a small flex players show off on examine, and
the old dropdown made it awkward to pick one — you couldn't see what any
achievement actually was, what it looked like, or how rare it was. The new
window makes the choice visual and informative (badge, description, difficulty
color, and the title that will appear on examine) and lets you sort to find what
you want.

### Did you test this PR?

* [X] This PR compiles
* [ ] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

## Changelog
:cl:
add: Added a debug "achievement spec previewer" item for previewing the achievement specialization UI locally.
tweak: The achievement specialization picker in character preferences is now a visual menu with badges, descriptions, difficulty colors, and sorting, instead of a plain dropdown.
/:cl:
