### PR TITLE
Fixes eternal wet floors and reagent dispenser explosion splash radius

### DIFF
--- a/code/datums/components/wet_floor.dm
+++ b/code/datums/components/wet_floor.dm
@@ -112,7 +112,7 @@
 
 /datum/component/wet_floor/process()
 	// var/turf/open/T = parent
-	// var/diff = world.time - last_process
+	var/diff = world.time - last_process
 	var/decrease = 0
 	// Atmos Purge: Removed due to Atmos handling of temperature.
 /* 	var/t = T.GetTemperature()
@@ -130,6 +130,10 @@
 				O.make_unfrozen()
 		add_wet(TURF_WET_WATER, max_time_left())
 		dry(null, TURF_WET_ICE) */
+
+	// POST-ATMOS-REFACTOR BANDAID: Decrease is calculated under the assumption that all air is at 20C.
+	decrease = ((293.15 - 273.15) / SSwet_floors.temperature_coeff) * (diff / SSwet_floors.time_ratio)
+
 	dry(null, ALL, FALSE, decrease)
 	check()
 	last_process = world.time

--- a/code/modules/reagents/chem_splash.dm
+++ b/code/modules/reagents/chem_splash.dm
@@ -50,8 +50,13 @@
 					continue
 				for(var/thing in T.reachableAdjacentTurfs())
 					var/turf/NT = thing
-					if(!(NT in accessible))
+
+					// Note: I have no idea what the original intention behind this code was. This code was originally if(!(NT in accessible)) which I interpret as "if the next turf isn't accessible, move to the next adjacent turf"
+					// BUT, LIKE, NOTHING BEFORE THIS CODE ADDS ANYTHING BUT THE EPICENTER INTO ACCESSIBLE
+					// I was half tempted to just port TG's new chem_splash but ultimately this works just fine. I guess.
+					if((NT in accessible))
 						continue
+
 					if(!(get_dir(T,NT) in GLOB.cardinals))
 						continue
 					accessible[T] = 1


### PR DESCRIPTION
## About The Pull Request
So basically the atmos refactor accidentally nuked the drying of wet floors, this fixes that. 
Also somehow, at some point, I don't understand **why**, the destruction of reagent dispensers (see: water cooler) went from a pretty big splash to only a single tile at its epicenter. I simply don't understand the why of this, and my fix to it was very sus (we might want to port the new TG chemsplash code instead) but it DOES work I guarantee it (It Works On My Machine)
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I can use paper cups in combat without getting yelled at by staff for permawetting floors
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
fix: Wet floors will once again dry over time
fix: Reagent dispensers will now expose their intended radius of turfs to their chems on destruction as opposed to only the epicenter
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
