### PR TITLE
Makes Cryopods not announce irrelevant employee storage and not delete data for the funnies

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -242,6 +242,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 			// Reset
 			open_machine()
 			name = initial(name)
+			return
 
 		// If we reach this point we're dealing with someone genuinely in the round.
 		// Handle job slot/tater cleanup.

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -218,7 +218,32 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 
 	crew_member["name"] = mob_occupant.real_name
 
+	var/list/these_roles_arent_actually_in_the_round = list(
+		"Test Range Agent", // Test Range
+		"Lobotomy Corporation Records Librarian", // Records Library
+		"Lobotomy Corporation Intern", // Tutorial
+		"Refraction Railway Agent", // Refraction Railway
+	)
+
 	if(mob_occupant.mind && mob_occupant.mind?.assigned_role)
+		// If we're dealing with a person who's one of the listed roles which aren't really in the round, end the proc early without announcing their storage and all that.
+		if(mob_occupant.mind.assigned_role in these_roles_arent_actually_in_the_round)
+			// Message
+			visible_message(span_notice("[src] hums and hisses as it moves [mob_occupant.real_name] into storage."))
+			// Drop items
+			for(var/obj/item/item_content as anything in mob_occupant)
+				if(!istype(item_content) || HAS_TRAIT(item_content, TRAIT_NODROP))
+					continue
+				if (issilicon(mob_occupant) && istype(item_content, /obj/item/mmi))
+					continue
+				mob_occupant.transferItemToLoc(item_content, drop_location(), force = TRUE, silent = TRUE)
+			// Delete
+			QDEL_NULL(occupant)
+			// Reset
+			open_machine()
+			name = initial(name)
+
+		// If we reach this point we're dealing with someone genuinely in the round.
 		// Handle job slot/tater cleanup.
 		var/job = mob_occupant.mind.assigned_role
 		crew_member["job"] = job


### PR DESCRIPTION
## About The Pull Request
The issues:
- Cryopods will announce whenever a Test Range Agent, Records Librarian, Tutorial Intern or Refraction Railway Agent cryo.
- If the real name of one of these irrelevant goofballs matches the real name of a character who actually was/is in the round, the cryopod pulls all their data from medical/sec/whatever records, uses it for its announcement and then deletes all the data related to the real person AND FREES UP THEIR JOBSLOT!!! (so a Test Range Agent called Tim Lobotomy cryoing will result in the game assuming the Tim Lobotomy currently playing as Disciplinary Officer cryo'd, delete them from the crew manifest and open up a DO slot)

Cryopods will now avoid these undesirable behaviours for people with mind.assigned_role set to Test Range Agent, Lobotomy Corporation Records Librarian, Lobotomy Corporation Intern or Refraction Railway Agent.
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfix?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
fix: Cryopods will no longer announce the storage of Test Range Agents, Tutorial Agents, Records Librarians or Refraction Railway Agents. In addition, when these people are stored, it will not attempt to match their real name to existing records in the data core and try to free up a slot for their job if it finds a match.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
