### PR TITLE
Experimental Projectile Fix Port From TG

### DIFF
--- a/code/__HELPERS/view.dm
+++ b/code/__HELPERS/view.dm
@@ -11,3 +11,13 @@
 	var/turf/source = get_turf(user)
 	var/turf/target = get_turf(A)
 	return ISINRANGE(target.x, source.x - view_range[1], source.x + view_range[1]) && ISINRANGE(target.y, source.y - view_range[1], source.y + view_range[1])
+
+// PORTED FROM TGSTATION: PR #65180
+/// Takes a string or num view, and converts it to pixel width/height in a list(pixel_width, pixel_height)
+/proc/view_to_pixels(view)
+	if(!view)
+		return list(0, 0)
+	var/list/view_info = getviewsize(view)
+	view_info[1] *= 32
+	view_info[2] *= 32
+	return view_info

--- a/code/game/objects/structures/manned_turret.dm
+++ b/code/game/objects/structures/manned_turret.dm
@@ -100,7 +100,7 @@
 		var/turf/target_turf = get_turf(target_atom)
 		if(istype(target_turf)) //They're hovering over something in the map.
 			direction_track(controller, target_turf)
-			calculated_projectile_vars = calculate_projectile_angle_and_pixel_offsets(controller, modifiers)
+			calculated_projectile_vars = calculate_projectile_angle_and_pixel_offsets(controller, target_atom, modifiers)
 
 /obj/machinery/manned_turret/proc/direction_track(mob/user, atom/targeted)
 	if(user.incapacitated())
@@ -223,6 +223,6 @@
 	. = ..()
 	var/modifiers = params2list(params)
 	var/obj/machinery/manned_turret/E = user.buckled
-	E.calculated_projectile_vars = calculate_projectile_angle_and_pixel_offsets(user, modifiers)
+	E.calculated_projectile_vars = calculate_projectile_angle_and_pixel_offsets(user, targeted_atom, modifiers)
 	E.direction_track(user, targeted_atom)
 	E.checkfire(targeted_atom, user)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -833,7 +833,8 @@
 		return
 	var/C = user.client
 	if(ishuman(user) && C)
-		var/list/angle_vector = calculate_projectile_angle_and_pixel_offsets(user, params)
+		var/list/modifiers = params2list(params)
+		var/list/angle_vector = calculate_projectile_angle_and_pixel_offsets(user, A, modifiers)
 		angle = angle_vector[1]
 	else
 		qdel(src)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -509,7 +509,7 @@
 			user.pixel_x = 8
 			user.pixel_y = -12
 
-	E.last_projectile_params = calculate_projectile_angle_and_pixel_offsets(user, clickparams)
+	E.last_projectile_params = calculate_projectile_angle_and_pixel_offsets(user, targeted_atom, clickparams)
 
 	if(E.charge >= 10 && world.time > delay)
 		E.charge -= 10

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -881,54 +881,63 @@
 	trajectory_ignore_forcemove = FALSE
 	starting = get_turf(source)
 	original = target
-	if(targloc || !params)
-		yo = targloc.y - curloc.y
-		xo = targloc.x - curloc.x
-		set_angle(Get_Angle(src, targloc) + spread)
 
 	if(isliving(source) && params)
-		var/list/calculated = calculate_projectile_angle_and_pixel_offsets(source, params)
+		var/list/modifiers = params2list(params)
+		var/list/calculated = calculate_projectile_angle_and_pixel_offsets(source, target, modifiers)
 		p_x = calculated[2]
 		p_y = calculated[3]
 
 		set_angle(calculated[1] + spread)
+		return
+
 	else if(targloc)
 		yo = targloc.y - curloc.y
 		xo = targloc.x - curloc.x
 		set_angle(Get_Angle(src, targloc) + spread)
+
 	else
 		stack_trace("WARNING: Projectile [type] fired without either mouse parameters, or a target atom to aim at!")
 		qdel(src)
 
-/proc/calculate_projectile_angle_and_pixel_offsets(mob/user, params)
-	var/list/modifiers = params2list(params)
-	var/p_x = 0
-	var/p_y = 0
+// PORTED FROM TGSTATION. There is no individual PR to point to; however the latest one to modify this proc was commit bbb7a41 ('Guncode Agony 4').
+/proc/calculate_projectile_angle_and_pixel_offsets(atom/source, atom/target, list/modifiers)
 	var/angle = 0
-	if(LAZYACCESS(modifiers, ICON_X))
-		p_x = text2num(LAZYACCESS(modifiers, ICON_X))
-	if(LAZYACCESS(modifiers, ICON_Y))
-		p_y = text2num(LAZYACCESS(modifiers, ICON_Y))
-	if(LAZYACCESS(modifiers, SCREEN_LOC))
-		//Split screen-loc up into X+Pixel_X and Y+Pixel_Y
-		var/list/screen_loc_params = splittext(LAZYACCESS(modifiers, SCREEN_LOC), ",")
+	var/p_x = LAZYACCESS(modifiers, ICON_X) ? text2num(LAZYACCESS(modifiers, ICON_X)) : 32 / 2 // ICON_(X|Y) are measured from the bottom left corner of the icon.
+	var/p_y = LAZYACCESS(modifiers, ICON_Y) ? text2num(LAZYACCESS(modifiers, ICON_Y)) : 32 / 2 // This centers the target if params aren't passed.
 
-		//Split X+Pixel_X up into list(X, Pixel_X)
-		var/list/screen_loc_X = splittext(screen_loc_params[1],":")
+	if(target)
+		var/turf/source_loc = get_turf(source)
+		var/turf/target_loc = get_turf(target)
+		var/dx = ((target_loc.x - source_loc.x) * 32) + (target.pixel_x - source.pixel_x) + (p_x - (32 / 2))
+		var/dy = ((target_loc.y - source_loc.y) * 32) + (target.pixel_y - source.pixel_y) + (p_y - (32 / 2))
 
-		//Split Y+Pixel_Y up into list(Y, Pixel_Y)
-		var/list/screen_loc_Y = splittext(screen_loc_params[2],":")
-		var/x = text2num(screen_loc_X[1]) * 32 + text2num(screen_loc_X[2]) - 32
-		var/y = text2num(screen_loc_Y[1]) * 32 + text2num(screen_loc_Y[2]) - 32
+		angle = ATAN2(dy, dx)
+		return list(angle, p_x, p_y)
 
-		//Calculate the "resolution" of screen based on client's view and world's icon size. This will work if the user can view more tiles than average.
-		var/list/screenview = getviewsize(user.client.view)
-		var/screenviewX = screenview[1] * world.icon_size
-		var/screenviewY = screenview[2] * world.icon_size
+	if(!ismob(source) || !LAZYACCESS(modifiers, SCREEN_LOC))
+		CRASH("Can't make trajectory calculations without a target or click params and a client.")
 
-		var/ox = round(screenviewX/2) - user.client.pixel_x //"origin" x
-		var/oy = round(screenviewY/2) - user.client.pixel_y //"origin" y
-		angle = ATAN2(y - oy, x - ox)
+	var/mob/user = source
+	if(!user.client)
+		CRASH("Can't make trajectory calculations without a target or click params and a client.")
+
+	//Split screen-loc up into X+Pixel_X and Y+Pixel_Y
+	var/list/screen_loc_params = splittext(LAZYACCESS(modifiers, SCREEN_LOC), ",")
+	//Split X+Pixel_X up into list(X, Pixel_X)
+	var/list/screen_loc_X = splittext(screen_loc_params[1],":")
+	//Split Y+Pixel_Y up into list(Y, Pixel_Y)
+	var/list/screen_loc_Y = splittext(screen_loc_params[2],":")
+
+	var/tx = (text2num(screen_loc_X[1]) - 1) * 32 + text2num(screen_loc_X[2])
+	var/ty = (text2num(screen_loc_Y[1]) - 1) * 32 + text2num(screen_loc_Y[2])
+
+	//Calculate the "resolution" of screen based on client's view and world's icon size. This will work if the user can view more tiles than average.
+	var/list/screenview = view_to_pixels(user.client.view)
+
+	var/ox = round(screenview[1] * 0.5) - user.client.pixel_x //"origin" x
+	var/oy = round(screenview[2] * 0.5) - user.client.pixel_y //"origin" y
+	angle = ATAN2(tx - oy, ty - ox)
 	return list(angle, p_x, p_y)
 
 /obj/projectile/Destroy()


### PR DESCRIPTION
## About The Pull Request
# The Issue
So basically there's this ISSUE with projectiles that people have continuously tried to gaslight me about ("no, Destrok, they're fine, you just have to spriteclick on them maaaan"), wherein firing at any turf, object or enemy on the move will result in missing. This is especially easy to spot when moving in a perpendicular line to your target and clicking directly on them. It feels like your "momentum" is being added to your projectile, and this is definitely a bug - I have NEVER seen this behaviour on any other server.

# The Fix
I looked at the differences between our projectile code and TGs (a codebase I know has working projectiles). There's a lot, obviously, but the most important is that we're always calculating our projectile angles based on the user's screen location even if we have a target available to calculate against. I think calculating based on screen location leads to issues while moving, because of how your viewport glides.... well, I think, at least.

This ports some stuff from TGStation; the helper proc view_to_pixels() from #65180 and specifically the /proc/calculate_projectile_angle_and_pixel_offsets() from commit bbb7a41 ('Guncode Agony 4'). I didn't port the entirety of their projectile code since it's not relevant to fixing this issue.

<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I like being able to hit things I click on
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here
[Streamable link: Before and After Comparison](https://streamable.com/1ickgo)
<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution
[TGStation](https://github.com/tgstation/tgstation/) (PR #65180 and commit bbb7a41)

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
code: Ports view_to_pixel() helper proc from TGStation PR #65180.
refactor: Ports calculate_projectile_angle_and_pixel_offsets() proc updates from TGStation commit bbb7a41. This makes our projectile aiming work correctly now, even on the move!
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
