### PR TITLE
Fixes EGO Tags on Seven S4 weapon datums

### DIFF
--- a/ModularLobotomy/ego_weapons/melee/city/_cityweapons_datums.dm
+++ b/ModularLobotomy/ego_weapons/melee/city/_cityweapons_datums.dm
@@ -219,7 +219,7 @@ Association gear is mostly HE for grunts, low WAW for veterans and high WAW for 
 /datum/ego_datum/weapon/city/seven_south_s4_foil
 	item_path = /obj/item/ego_weapon/city/seven_s4_foil
 	cost = 60
-	ego_tags = (EGO_TAG_DEBUFFER)
+	ego_tags = list(EGO_TAG_DEBUFFER)
 /// Seven South Section 4 Veteran Fencing Foil
 /datum/ego_datum/weapon/city/seven_south_s4_foil/vet
 	item_path = /obj/item/ego_weapon/city/seven_s4_foil/vet
@@ -234,7 +234,7 @@ Association gear is mostly HE for grunts, low WAW for veterans and high WAW for 
 /datum/ego_datum/weapon/city/seven_south_s4_adaptive
 	item_path = /obj/item/ego_weapon/city/seven_s4_blade
 	cost = 60
-	ego_tags = (EGO_TAG_VERSATILE_DAMAGE)
+	ego_tags = list(EGO_TAG_VERSATILE_DAMAGE)
 /// Seven South Section 4 Veteran Blade
 /datum/ego_datum/weapon/city/seven_south_s4_adaptive/vet
 	item_path = /obj/item/ego_weapon/city/seven_s4_blade/vet


### PR DESCRIPTION
## About The Pull Request
Was causing crashing on Ender's Refraction Railway because it doesn't automatically make non-list ego_tags into lists like Test Range does, so it was trying to run join on a non-list in the .js which made it crash. Sorry!
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Don't crash stuff
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?
This is the first PR that I'm simply not going to test because, I mean, just look at the code, it's obvious what the issue was
* [ ] This PR compiles
* [ ] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
fix: Seven S4 weapon datums' ego_tags var value is now a list
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
