### PR TITLE
Fixes duplicate entries in PDA/CrewSensor from respawning

### DIFF
--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -160,6 +160,13 @@
 
 	//Start with uniform,suit,backpack for additional slots
 	if(uniform)
+
+		// On Facility mode, remove our human's previous bodies from the suit sensors list when equipping them with an outfit... I think it's cleaner to put this here than in the code that runs every time you equip an uniform.
+		if((SSmaptype.maptype in SSmaptype.lc_maps) || SSmaptype.maptype == "mini")
+			for(var/mob/living/carbon/human/ded in GLOB.suit_sensors_list)
+				if(ded.stat >= DEAD && ded.real_name == H.real_name)
+					GLOB.suit_sensors_list -= ded
+
 		H.equip_to_slot_or_del(new uniform(H),ITEM_SLOT_ICLOTHING, TRUE)
 	if(suit)
 		H.equip_to_slot_or_del(new suit(H),ITEM_SLOT_OCLOTHING, TRUE)

--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -40,6 +40,7 @@
 
 	for(var/P in typesof(/obj/item/pda) - blocked)
 		var/obj/item/pda/D = new P
+		GLOB.PDAs -= D
 
 		//D.name = "PDA Style [colorlist.len+1]" //Gotta set the name, otherwise it all comes up as "PDA"
 		D.name = D.icon_state //PDAs don't have unique names, but using the sprite names works.

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -393,6 +393,16 @@
 	var/obj/item/pda/PDA = H.get_item_by_slot(pda_slot)
 	if(istype(PDA))
 		PDA.owner = H.real_name
+
+		// When a person spawns in, if there already exist PDAs with their name on it, remove them from the global PDAs list to make them unavailable to reach via messenger.
+		// But only on facility mode! This is a very arcadey fix to the issue of duplicate entries in the messenger tab, and so it should remain on the most arcadey mode.
+		if((SSmaptype.maptype in SSmaptype.lc_maps) || SSmaptype.maptype == "mini")
+			for(var/obj/item/pda/could_this_be_our_echo_from_a_past_life in GLOB.PDAs)
+				if(could_this_be_our_echo_from_a_past_life == PDA)
+					continue
+				if(could_this_be_our_echo_from_a_past_life.owner == PDA.owner)
+					GLOB.PDAs -= could_this_be_our_echo_from_a_past_life
+
 		// Tegu edit - Alt job titles
 		if(preference_source && preference_source.prefs && preference_source.prefs.alt_titles_preferences[J.title])
 			PDA.ownjob = preference_source.prefs.alt_titles_preferences[J.title]


### PR DESCRIPTION
## About The Pull Request
Specifically on Facility mode, when you spawn in, PDAs with your name on them will be taken off the PDA list (used for messaging) and your previous dead bodies will be taken off the suit sensors list.
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Kirie asked for it
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
tweak: Spawning in on Facility mode will remove your prior dead bodies from the crew sensors global list, and your PDAs from the PDAs global list.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
