### PR TITLE
Make Painting frames hold Paintings

### DIFF
--- a/_maps/map_files/Iota/iotacorp.dmm
+++ b/_maps/map_files/Iota/iotacorp.dmm
@@ -1679,8 +1679,9 @@
 /area/facility_hallway/west)
 "fq" = (
 /obj/machinery/vending/lobotomyheadset,
-/obj/item/wallframe/painting{
-	pixel_y = 26
+/obj/structure/sign/painting/library{
+	pixel_y = 32;
+	pixel_x = 0
 	},
 /turf/open/floor/facility/dark{
 	color = "#ccc8c0"
@@ -5245,8 +5246,9 @@
 /area/department_main/information)
 "pS" = (
 /obj/machinery/vending/lobotomyuniform,
-/obj/item/wallframe/painting{
-	pixel_y = 26
+/obj/structure/sign/painting/library{
+	pixel_y = 32;
+	pixel_x = 0
 	},
 /turf/open/floor/facility/dark{
 	color = "#ccc8c0"
@@ -5549,8 +5551,9 @@
 /area/facility_hallway/discipline)
 "qV" = (
 /obj/machinery/vending/cigarette,
-/obj/item/wallframe/painting{
-	pixel_y = 26
+/obj/structure/sign/painting/library{
+	pixel_y = 32;
+	pixel_x = 0
 	},
 /turf/open/floor/facility/dark{
 	color = "#ccc8c0"
@@ -9855,8 +9858,9 @@
 /turf/open/floor/plasteel/dark,
 /area/department_main/discipline)
 "Ed" = (
-/obj/item/wallframe/painting{
-	pixel_y = 26
+/obj/structure/sign/painting/library{
+	pixel_y = 32;
+	pixel_x = 0
 	},
 /turf/open/floor/facility/dark{
 	color = "#ccc8c0"
@@ -14801,8 +14805,9 @@
 /area/facility_hallway/training)
 "Ve" = (
 /obj/machinery/vending/snack/teal,
-/obj/item/wallframe/painting{
-	pixel_y = 26
+/obj/structure/sign/painting/library{
+	pixel_y = 32;
+	pixel_x = 0
 	},
 /turf/open/floor/facility/dark{
 	color = "#ccc8c0"
@@ -15946,8 +15951,9 @@
 /area/facility_hallway/west)
 "Zd" = (
 /obj/machinery/vending/lobotomyarmband,
-/obj/item/wallframe/painting{
-	pixel_y = 26
+/obj/structure/sign/painting/library{
+	pixel_y = 32;
+	pixel_x = 0
 	},
 /turf/open/floor/facility/dark{
 	color = "#ccc8c0"


### PR DESCRIPTION
**DO NOT MERGE.** More fixes will be added with time.

## About The Pull Request

Map makers keep forgetting that the painting frames are not item/wallframe/painting, But actually sign/painting/library. So they don't have an inventory to store player's artworks.
For now, This will be to fix old painting frames in maps, But if I feel like it, I might go about preventing these mistakes again by finding a way to ensure map makers use the correct frame.

## Why It's Good For The Game

For an example, Someone puts their heart and soul into a painting of an abnormality, And goes to place it on a painting frame.
In a normal map, It would be put up and promptly saved to the database where it will show up in future shifts.
However, In some old maps, The painting frames are not exhibits, But rather ordinary painting frames, Meaning the art is not stored and gets erased once the map changes.
This heartbreak is something I have experienced myself with the skits maps, Having lost a painting of the Snow Queen abnormality. Having seen this occur a few times with other players, I intend to prevent these further issues.

### Did you test this PR?

* [ ] This PR compiles
* [ ] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

## Changelog
:cl:
fix: Botanical's painting frames have been changed to be the correct frames.
/:cl: