### PR TITLE
More Outskirts Factory tweaks

### DIFF
--- a/ModularLobotomy/extra_mobs/grungeon_boss.dm
+++ b/ModularLobotomy/extra_mobs/grungeon_boss.dm
@@ -17,10 +17,10 @@
 	faction = list("green_ordeal")
 	gender = NEUTER
 	mob_biotypes = MOB_ROBOTIC
-	maxHealth = 20000
-	health = 20000
-	melee_damage_lower = 5
-	melee_damage_upper = 5
+	maxHealth = 12500
+	health = 12500
+	melee_damage_lower = 10
+	melee_damage_upper = 10
 	ranged = TRUE
 	damage_coeff = list(RED_DAMAGE = 0.5, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 1.2, PALE_DAMAGE = 1)
 	butcher_results = list(/obj/item/food/meat/slab/robot = 22)
@@ -28,7 +28,7 @@
 	death_sound = 'sound/effects/ordeals/green/midnight_dead.ogg'
 	offsets_pixel_x = list("south" = -96, "north" = -96, "west" = -96, "east" = -96)
 	damage_effect_scale = 1.25
-	rapid = 40
+	rapid = 50
 	rapid_fire_delay = 0.4
 	ranged_cooldown_time = 15
 	projectilesound = 'sound/weapons/gun/smg/shot.ogg'

--- a/ModularLobotomy/extra_mobs/grungeon_boss.dm
+++ b/ModularLobotomy/extra_mobs/grungeon_boss.dm
@@ -22,7 +22,7 @@
 	melee_damage_lower = 10
 	melee_damage_upper = 10
 	ranged = TRUE
-	damage_coeff = list(RED_DAMAGE = 0.5, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 1.2, PALE_DAMAGE = 1)
+	damage_coeff = list(RED_DAMAGE = 0.6, WHITE_DAMAGE = 1, BLACK_DAMAGE = 1.2, PALE_DAMAGE = 1)
 	butcher_results = list(/obj/item/food/meat/slab/robot = 22)
 	guaranteed_butcher_results = list(/obj/item/food/meat/slab/robot = 16, /obj/item/head_trophy/grungeon_cell = 1, /obj/item/keycard/grungeon = 1)
 	death_sound = 'sound/effects/ordeals/green/midnight_dead.ogg'
@@ -30,7 +30,6 @@
 	damage_effect_scale = 1.25
 	rapid = 50
 	rapid_fire_delay = 0.4
-	ranged_cooldown_time = 15
 	projectilesound = 'sound/weapons/gun/smg/shot.ogg'
 	casingtype = /obj/item/ammo_casing/caseless/soda_mini
 	var/datum/beam/current_beam = null

--- a/ModularLobotomy/extra_mobs/grungeon_boss.dm
+++ b/ModularLobotomy/extra_mobs/grungeon_boss.dm
@@ -24,7 +24,7 @@
 	ranged = TRUE
 	damage_coeff = list(RED_DAMAGE = 0.5, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 1.2, PALE_DAMAGE = 1)
 	butcher_results = list(/obj/item/food/meat/slab/robot = 22)
-	guaranteed_butcher_results = list(/obj/item/food/meat/slab/robot = 16, /obj/item/head_trophy/grungeon_cell = 1)
+	guaranteed_butcher_results = list(/obj/item/food/meat/slab/robot = 16, /obj/item/head_trophy/grungeon_cell = 1, /obj/item/keycard/grungeon = 1)
 	death_sound = 'sound/effects/ordeals/green/midnight_dead.ogg'
 	offsets_pixel_x = list("south" = -96, "north" = -96, "west" = -96, "east" = -96)
 	damage_effect_scale = 1.25
@@ -254,3 +254,8 @@
 	explosion(loc, 0, 0, 1)
 	qdel(D)
 	qdel(src)
+
+/obj/item/keycard/grungeon //Vault door keycard
+	name = "vault keycard"
+	desc = "A keycard, slightly marred by burn marks. Opens the Vault in the Outskirts Factory."
+	puzzle_id = 32

--- a/ModularLobotomy/extra_mobs/grungeon_boss.dm
+++ b/ModularLobotomy/extra_mobs/grungeon_boss.dm
@@ -28,6 +28,7 @@
 	death_sound = 'sound/effects/ordeals/green/midnight_dead.ogg'
 	offsets_pixel_x = list("south" = -96, "north" = -96, "west" = -96, "east" = -96)
 	damage_effect_scale = 1.25
+	ranged_cooldown_time = 30
 	rapid = 50
 	rapid_fire_delay = 0.4
 	projectilesound = 'sound/weapons/gun/smg/shot.ogg'

--- a/ModularLobotomy/extra_mobs/grungeon_enemies.dm
+++ b/ModularLobotomy/extra_mobs/grungeon_enemies.dm
@@ -12,8 +12,8 @@
 	pixel_x = -8
 	base_pixel_x = -8
 	mob_biotypes = MOB_ROBOTIC
-	maxHealth = 500
-	health = 500
+	maxHealth = 600
+	health = 600
 	melee_damage_type = RED_DAMAGE
 	attack_verb_continuous = "lashes"
 	attack_verb_simple = "lash"

--- a/_maps/Quests/green_dungeon.dmm
+++ b/_maps/Quests/green_dungeon.dmm
@@ -861,6 +861,7 @@
 	},
 /area/city/outskirtsfactory)
 "sn" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/item/caution{
 	pixel_y = 7;
 	pixel_x = -3
@@ -1152,7 +1153,7 @@
 	},
 /obj/structure/sigsystem/connector{
 	dir = 1;
-	delay_time = 250
+	delay_time = 200
 	},
 /turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
@@ -4048,7 +4049,7 @@ Pb
 oS
 RK
 dt
-sn
+sJ
 Go
 iA
 wm
@@ -4148,7 +4149,7 @@ RK
 RK
 is
 sJ
-RK
+sn
 UM
 RK
 UC

--- a/_maps/Quests/green_dungeon.dmm
+++ b/_maps/Quests/green_dungeon.dmm
@@ -171,15 +171,6 @@
 /obj/structure/sigsystem/activator,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
-"cs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/destructible/cult/forge{
-	resistance_flags = 64;
-	desc = "A forge used in crafting various parts.";
-	name = "forge"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/city/outskirtsfactory)
 "cw" = (
 /obj/effect/turf_decal/siding/thinplating/light{
 	dir = 8
@@ -836,6 +827,12 @@
 	name = "asphalt"
 	},
 /area/city/outskirtsfactory)
+"qY" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirtsfactory)
 "rf" = (
 /obj/machinery/light/red,
 /turf/open/floor/pod/light,
@@ -1099,6 +1096,19 @@
 "xE" = (
 /turf/closed/indestructible/syndicate,
 /area/city/outskirtsfactory)
+"xH" = (
+/obj/machinery/door/poddoor/shutters/indestructible{
+	lockpickable = 0;
+	resistance_flags = 64;
+	id = "furnaceaccess"
+	},
+/obj/structure/sigsystem/activator,
+/obj/structure/sigsystem/connector{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirtsfactory)
 "xI" = (
 /obj/structure/sigsystem/connector{
 	dir = 4
@@ -1134,9 +1144,14 @@
 /turf/closed/indestructible/syndicate,
 /area/city/outskirtsfactory)
 "yr" = (
-/obj/structure/railing/corner{
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
 	dir = 8
 	},
+/obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "yt" = (
@@ -1473,17 +1488,6 @@
 "EC" = (
 /obj/structure/sigsystem/connector/split,
 /turf/closed/indestructible/syndicate,
-/area/city/outskirtsfactory)
-"EH" = (
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	mouse_opacity = 0;
-	dir = 4
-	},
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "EO" = (
 /obj/effect/turf_decal/siding/green/corner{
@@ -2027,8 +2031,9 @@
 	name = "wing-grade railing";
 	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
 	mouse_opacity = 0;
-	dir = 10
+	dir = 4
 	},
+/obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "Pf" = (
@@ -2066,6 +2071,16 @@
 	},
 /mob/living/simple_animal/hostile/ordeal/green_bot_rocket,
 /turf/open/floor/pod/light,
+/area/city/outskirtsfactory)
+"PP" = (
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
+	dir = 10
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "PZ" = (
 /obj/machinery/door/poddoor/shutters/indestructible{
@@ -2145,6 +2160,15 @@
 	signal_code = 15
 	},
 /turf/closed/indestructible/rock,
+/area/city/outskirtsfactory)
+"Se" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/destructible/cult/forge{
+	resistance_flags = 64;
+	desc = "A forge used in crafting various parts.";
+	name = "forge"
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "Sh" = (
 /obj/machinery/light/red{
@@ -2330,17 +2354,6 @@
 	},
 /obj/effect/turf_decal/siding/red,
 /turf/open/floor/facility/dark,
-/area/city/outskirtsfactory)
-"Us" = (
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	mouse_opacity = 0;
-	dir = 8
-	},
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "Uv" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -3883,7 +3896,7 @@ xE
 Uk
 RK
 UC
-cs
+Se
 xE
 xE
 xE
@@ -3988,8 +4001,8 @@ sJ
 Go
 iA
 wm
-Us
-Pb
+yr
+PP
 TT
 TT
 TT
@@ -4086,7 +4099,7 @@ is
 RK
 Pz
 RK
-yr
+qY
 Xw
 Pf
 Pf
@@ -4175,7 +4188,7 @@ Tt
 sJ
 sJ
 RK
-KU
+xH
 sJ
 RK
 RK
@@ -4279,7 +4292,7 @@ RK
 Go
 wh
 ef
-EH
+Pb
 wh
 UC
 wh

--- a/_maps/Quests/green_dungeon.dmm
+++ b/_maps/Quests/green_dungeon.dmm
@@ -583,12 +583,6 @@
 	name = "asphalt"
 	},
 /area/city/outskirtsfactory)
-"lP" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot,
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/pod/dark,
-/area/city/outskirtsfactory)
 "lW" = (
 /obj/structure/plasticflaps/opaque{
 	resistance_flags = 64
@@ -6223,7 +6217,7 @@ xE
 xE
 mL
 tQ
-lP
+tV
 xE
 Pn
 Pn

--- a/_maps/Quests/green_dungeon.dmm
+++ b/_maps/Quests/green_dungeon.dmm
@@ -108,7 +108,7 @@
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "bw" = (
-/obj/machinery/light/small/red{
+/obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -124,13 +124,13 @@
 /turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
 "bE" = (
-/obj/machinery/light/red{
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/pod/light,
 /area/city/outskirtsfactory)
 "bR" = (
-/obj/machinery/light/red{
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/pod/light,
@@ -181,7 +181,7 @@
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "cB" = (
-/obj/machinery/light/small/red{
+/obj/machinery/light/small{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/green{
@@ -214,7 +214,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/city/outskirtsfactory)
 "dn" = (
-/obj/machinery/light/small/red{
+/obj/machinery/light/small{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -234,7 +234,7 @@
 /turf/open/floor/plating,
 /area/city/outskirtsfactory)
 "dL" = (
-/obj/machinery/light/small/red{
+/obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/pod/dark,
@@ -351,11 +351,11 @@
 /area/city/outskirtsfactory)
 "gG" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small/red,
+/obj/machinery/light/small,
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "gK" = (
-/obj/machinery/light/small/red{
+/obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/pod/dark,
@@ -510,7 +510,7 @@
 /area/city/outskirtsfactory)
 "jY" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/pod/dark,
@@ -660,10 +660,6 @@
 /mob/living/simple_animal/hostile/ordeal/green_bot_rocket,
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
-"oS" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot_big,
-/turf/open/floor/mineral/plastitanium,
-/area/city/outskirtsfactory)
 "pe" = (
 /obj/effect/turf_decal/siding/thinplating/light{
 	dir = 8
@@ -704,7 +700,7 @@
 	dir = 1;
 	happens_once = 1
 	},
-/obj/machinery/light/small/red,
+/obj/machinery/light/small,
 /turf/open/floor/circuit/red,
 /area/city/outskirtsfactory)
 "pY" = (
@@ -789,7 +785,7 @@
 	},
 /area/city/outskirtsfactory)
 "rf" = (
-/obj/machinery/light/red,
+/obj/machinery/light,
 /turf/open/floor/pod/light,
 /area/city/outskirtsfactory)
 "rg" = (
@@ -925,7 +921,7 @@
 /turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
 "uZ" = (
-/obj/machinery/light/red{
+/obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1016,14 +1012,14 @@
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "wY" = (
-/obj/machinery/light/red{
+/obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/city/outskirtsfactory)
 "xs" = (
-/obj/machinery/light/small/red{
+/obj/machinery/light/small{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1061,7 +1057,7 @@
 	},
 /area/city/outskirtsfactory)
 "yh" = (
-/obj/machinery/light/small/red,
+/obj/machinery/light/small,
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "yi" = (
@@ -1179,7 +1175,7 @@
 /turf/open/floor/facility,
 /area/city/outskirtsfactory)
 "Av" = (
-/obj/machinery/light/red{
+/obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes{
@@ -1212,13 +1208,13 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/city/outskirtsfactory)
 "BI" = (
-/obj/machinery/light/red{
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/pod/light,
 /area/city/outskirtsfactory)
 "BK" = (
-/obj/machinery/light/red{
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -1248,7 +1244,7 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 1
 	},
-/obj/machinery/light/small/red{
+/obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/circuit/red,
@@ -1311,14 +1307,14 @@
 /turf/open/floor/plating/asteroid/basalt,
 /area/city/outskirtsfactory)
 "CE" = (
-/obj/machinery/light/red{
+/obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/city/outskirtsfactory)
 "CN" = (
-/obj/machinery/light/small/red{
+/obj/machinery/light/small{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/green{
@@ -1418,7 +1414,7 @@
 /area/city/outskirtsfactory)
 "EQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/pod/dark,
@@ -1529,7 +1525,7 @@
 /turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
 "GE" = (
-/obj/machinery/light/red{
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -1715,13 +1711,13 @@
 /turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
 "Kk" = (
-/obj/machinery/light/small/red{
+/obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/pod/light,
 /area/city/outskirtsfactory)
 "Kl" = (
-/obj/machinery/light/red{
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -1767,18 +1763,8 @@
 /turf/open/floor/plating,
 /area/city/outskirtsfactory)
 "KU" = (
-/obj/machinery/conveyor/auto{
-	dir = 4;
-	resistance_flags = 64;
-	tamperproof = 1
-	},
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	mouse_opacity = 0;
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/ordeal/green_bot,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "KW" = (
@@ -1945,17 +1931,6 @@
 	},
 /area/city/outskirtsfactory)
 "Pb" = (
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	mouse_opacity = 0;
-	dir = 4
-	},
-/obj/item/tresmetal,
-/turf/open/floor/mineral/plastitanium,
-/area/city/outskirtsfactory)
-"Pf" = (
 /obj/machinery/conveyor/auto{
 	dir = 8;
 	resistance_flags = 64;
@@ -1968,6 +1943,17 @@
 	mouse_opacity = 0;
 	dir = 4
 	},
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirtsfactory)
+"Pf" = (
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
+	dir = 4
+	},
+/obj/item/tresmetal,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "Pi" = (
@@ -2037,7 +2023,7 @@
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "Ro" = (
-/obj/machinery/light/red,
+/obj/machinery/light,
 /turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
 "RH" = (
@@ -2067,7 +2053,7 @@
 /turf/closed/indestructible/rock,
 /area/city/outskirtsfactory)
 "Sh" = (
-/obj/machinery/light/red{
+/obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2254,7 +2240,7 @@
 /obj/structure/sigsystem/connector/split{
 	dir = 4
 	},
-/obj/machinery/light/red{
+/obj/machinery/light{
 	dir = 8
 	},
 /obj/structure/closet/crate,
@@ -2409,8 +2395,18 @@
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "Xw" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/ordeal/green_bot,
+/obj/machinery/conveyor/auto{
+	dir = 4;
+	resistance_flags = 64;
+	tamperproof = 1
+	},
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "XC" = (
@@ -2498,7 +2494,7 @@
 /turf/open/floor/circuit,
 /area/city/outskirtsfactory)
 "Zr" = (
-/obj/machinery/light/small/red{
+/obj/machinery/light/small{
 	dir = 1
 	},
 /obj/structure/sigsystem/tower{
@@ -3961,7 +3957,7 @@ xE
 sJ
 GJ
 sJ
-oS
+GJ
 sJ
 sJ
 sJ
@@ -4061,7 +4057,7 @@ sJ
 RK
 sJ
 sJ
-Xw
+KU
 RK
 is
 sJ
@@ -4074,7 +4070,7 @@ RK
 sJ
 xE
 xE
-Lb
+je
 xE
 xE
 xE
@@ -4160,13 +4156,13 @@ sJ
 RK
 gU
 RK
-Pf
+Pb
 wh
 gE
 wh
 wh
-KU
-Pb
+Xw
+Pf
 wh
 gE
 xE

--- a/_maps/Quests/green_dungeon.dmm
+++ b/_maps/Quests/green_dungeon.dmm
@@ -15,11 +15,6 @@
 /area/city/outskirtsfactory)
 "ah" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/destructible/cult/forge{
-	resistance_flags = 64;
-	desc = "A forge used in crafting various parts.";
-	name = "forge"
-	},
 /obj/machinery/light,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
@@ -133,12 +128,6 @@
 	dir = 8
 	},
 /turf/open/floor/pod/light,
-/area/city/outskirtsfactory)
-"bQ" = (
-/obj/structure/sigsystem/connector{
-	happens_once = 1
-	},
-/turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
 "bR" = (
 /obj/machinery/light/red{
@@ -258,18 +247,6 @@
 	dir = 1
 	},
 /turf/open/floor/pod/light,
-/area/city/outskirtsfactory)
-"ef" = (
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	mouse_opacity = 0;
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "et" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -402,10 +379,6 @@
 	pixel_x = 28;
 	signal_code = 09
 	},
-/obj/structure/sigsystem/tower{
-	signal_code = 09;
-	dir = 1
-	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "gX" = (
@@ -484,7 +457,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "iE" = (
@@ -604,12 +576,6 @@
 	name = "asphalt"
 	},
 /area/city/outskirtsfactory)
-"lJ" = (
-/obj/structure/sigsystem/tower{
-	signal_code = 92
-	},
-/turf/open/floor/mineral/gold,
-/area/city/outskirtsfactory)
 "lP" = (
 /mob/living/simple_animal/hostile/ordeal/green_bot,
 /obj/machinery/light,
@@ -678,10 +644,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
-"nI" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/facility,
-/area/city/outskirtsfactory)
 "nQ" = (
 /obj/machinery/light/small/red{
 	dir = 8
@@ -699,12 +661,7 @@
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "oS" = (
-/obj/machinery/door/poddoor/shutters/indestructible{
-	lockpickable = 0;
-	resistance_flags = 64;
-	id = "furnaceaccess"
-	},
-/obj/structure/sigsystem/activator,
+/mob/living/simple_animal/hostile/ordeal/green_bot_big,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "pe" = (
@@ -864,14 +821,6 @@
 	name = "asphalt"
 	},
 /area/city/outskirtsfactory)
-"sn" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/caution{
-	pixel_y = 7;
-	pixel_x = -3
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/city/outskirtsfactory)
 "sp" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 1;
@@ -908,7 +857,6 @@
 /area/city/outskirtsfactory)
 "sI" = (
 /obj/structure/sigsystem/connector{
-	delay_time = 90;
 	dir = 1;
 	happens_once = 1
 	},
@@ -1128,21 +1076,9 @@
 	},
 /turf/closed/indestructible/syndicate,
 /area/city/outskirtsfactory)
-"yr" = (
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	mouse_opacity = 0;
-	dir = 8
-	},
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/mineral/plastitanium,
-/area/city/outskirtsfactory)
 "yt" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sigsystem/connector{
-	delay_time = 90;
 	dir = 1;
 	happens_once = 1
 	},
@@ -1161,7 +1097,7 @@
 	},
 /obj/structure/sigsystem/connector{
 	dir = 1;
-	delay_time = 200
+	delay_time = 150
 	},
 /turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
@@ -1340,16 +1276,6 @@
 	dir = 1
 	},
 /turf/open/floor/pod/light,
-/area/city/outskirtsfactory)
-"Cm" = (
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	mouse_opacity = 0;
-	dir = 10
-	},
-/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "Ct" = (
 /obj/structure/sigsystem/tower{
@@ -1555,12 +1481,6 @@
 	},
 /turf/open/floor/circuit,
 /area/city/outskirtsfactory)
-"FF" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/city/outskirtsfactory)
 "FX" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -1590,7 +1510,7 @@
 	name = "wing-grade railing";
 	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
 	mouse_opacity = 0;
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
@@ -1847,14 +1767,17 @@
 /turf/open/floor/plating,
 /area/city/outskirtsfactory)
 "KU" = (
-/obj/machinery/door/poddoor/shutters/indestructible{
-	lockpickable = 0;
+/obj/machinery/conveyor/auto{
+	dir = 4;
 	resistance_flags = 64;
-	id = "furnaceaccess"
+	tamperproof = 1
 	},
-/obj/structure/sigsystem/activator,
-/obj/structure/sigsystem/connector{
-	dir = 8
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
@@ -2022,12 +1945,19 @@
 	},
 /area/city/outskirtsfactory)
 "Pb" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot,
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
+	dir = 4
+	},
+/obj/item/tresmetal,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "Pf" = (
 /obj/machinery/conveyor/auto{
-	dir = 1;
+	dir = 8;
 	resistance_flags = 64;
 	tamperproof = 1
 	},
@@ -2036,7 +1966,7 @@
 	name = "wing-grade railing";
 	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
 	mouse_opacity = 0;
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
@@ -2049,10 +1979,6 @@
 /area/city/outskirtsfactory)
 "Pn" = (
 /turf/closed/indestructible/rock,
-/area/city/outskirtsfactory)
-"Pz" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "PC" = (
 /obj/effect/turf_decal/siding/green/corner{
@@ -2189,13 +2115,6 @@
 /obj/structure/sigsystem/activator,
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
-"Tc" = (
-/obj/effect/turf_decal/siding/thinplating/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/facility,
-/area/city/outskirtsfactory)
 "Tj" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	resistance_flags = 64;
@@ -2308,17 +2227,6 @@
 	tamperproof = 1
 	},
 /turf/open/floor/pod/dark,
-/area/city/outskirtsfactory)
-"Ui" = (
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	mouse_opacity = 0;
-	dir = 4
-	},
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "Uk" = (
 /obj/effect/mob_spawn/human/corpse/charredskeleton,
@@ -2501,37 +2409,14 @@
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "Xw" = (
-/obj/machinery/conveyor/auto{
-	dir = 4;
-	resistance_flags = 64;
-	tamperproof = 1
-	},
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	mouse_opacity = 0;
-	dir = 8
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/ordeal/green_bot,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "XC" = (
 /obj/structure/sigsystem/connector{
 	dir = 4
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/city/outskirtsfactory)
-"XV" = (
-/obj/machinery/door/poddoor/shutters/indestructible{
-	lockpickable = 0;
-	resistance_flags = 64;
-	id = "furnaceaccess"
-	},
-/obj/structure/sigsystem/activator,
-/obj/structure/sigsystem/connector{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "XW" = (
@@ -2646,14 +2531,6 @@
 /obj/structure/sigsystem/connector/split,
 /obj/structure/sigsystem/activator,
 /turf/open/floor/pod/dark,
-/area/city/outskirtsfactory)
-"ZP" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sigsystem/connector{
-	dir = 1;
-	happens_once = 1
-	},
-/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "ZQ" = (
 /obj/effect/turf_decal/siding/thinplating/light{
@@ -3987,20 +3864,20 @@ xE
 RK
 WH
 UC
-Pb
-oS
+WH
+sJ
 RK
 dt
 sJ
 Go
 iA
 wm
-yr
-Cm
-TT
-TT
-TT
-TT
+wm
+wm
+wm
+wm
+wm
+wm
 xE
 xE
 xE
@@ -4084,20 +3961,20 @@ xE
 sJ
 GJ
 sJ
+oS
 sJ
-KU
 sJ
 sJ
 RK
 is
 RK
-Pz
+sJ
 RK
-FF
-Xw
-Pf
-Pf
-Pf
+sJ
+UC
+ky
+ky
+ky
 lW
 gl
 Uh
@@ -4182,13 +4059,13 @@ Tt
 sJ
 sJ
 RK
-XV
 sJ
-RK
+sJ
+Xw
 RK
 is
 sJ
-sn
+RK
 UM
 RK
 UC
@@ -4197,7 +4074,7 @@ RK
 sJ
 xE
 xE
-je
+Lb
 xE
 xE
 xE
@@ -4276,20 +4153,20 @@ Pn
 Pn
 xE
 jH
-Pz
+sJ
 RK
 RK
-KU
-ZP
+sJ
+RK
 gU
 RK
-Go
+Pf
 wh
-ef
-Ui
+gE
 wh
-UC
 wh
+KU
+Pb
 wh
 gE
 xE
@@ -6859,8 +6736,8 @@ Pn
 xE
 bZ
 Hi
-lJ
-bQ
+Hi
+GV
 eB
 fT
 rr
@@ -7307,7 +7184,7 @@ Pn
 xE
 wF
 cw
-Tc
+cw
 pe
 cw
 cw
@@ -7407,7 +7284,7 @@ YJ
 YJ
 Ar
 YJ
-nI
+YJ
 fA
 xE
 io
@@ -7599,7 +7476,7 @@ xE
 LQ
 Ar
 YJ
-nI
+YJ
 YJ
 YJ
 iE

--- a/_maps/Quests/green_dungeon.dmm
+++ b/_maps/Quests/green_dungeon.dmm
@@ -125,13 +125,15 @@
 /area/city/outskirtsfactory)
 "bE" = (
 /obj/machinery/light{
-	dir = 8
+	dir = 8;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/pod/light,
 /area/city/outskirtsfactory)
 "bR" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/pod/light,
 /area/city/outskirtsfactory)
@@ -150,9 +152,9 @@
 	pixel_x = 9;
 	pixel_y = 8
 	},
-/obj/item/ego_weapon/painprocess{
-	pixel_y = -5;
-	pixel_x = -6
+/obj/item/ego_weapon/ranged/malicedescent{
+	pixel_y = -6;
+	pixel_x = -5
 	},
 /turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
@@ -235,7 +237,8 @@
 /area/city/outskirtsfactory)
 "dL" = (
 /obj/machinery/light/small{
-	dir = 4
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
@@ -351,12 +354,15 @@
 /area/city/outskirtsfactory)
 "gG" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small,
+/obj/machinery/light/small{
+	bulb_colour = "#FF3232"
+	},
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "gK" = (
 /obj/machinery/light/small{
-	dir = 8
+	dir = 8;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
@@ -511,7 +517,8 @@
 "jY" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/machinery/light/small{
-	dir = 4
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
@@ -623,8 +630,9 @@
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "mV" = (
-/obj/machinery/light/small/red{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/city/outskirtsfactory)
@@ -645,8 +653,9 @@
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "nQ" = (
-/obj/machinery/light/small/red{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 8;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/city/outskirtsfactory)
@@ -700,7 +709,9 @@
 	dir = 1;
 	happens_once = 1
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small{
+	bulb_colour = "#FF3232"
+	},
 /turf/open/floor/circuit/red,
 /area/city/outskirtsfactory)
 "pY" = (
@@ -728,12 +739,8 @@
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "qr" = (
-/obj/structure/sigsystem/tower{
-	signal_code = 92
-	},
-/obj/structure/sigsystem/tower{
-	signal_code = 92
-	},
+/obj/structure/sigsystem/tower,
+/obj/structure/sigsystem/tower,
 /obj/structure/sigsystem/tower{
 	signal_code = 55
 	},
@@ -785,7 +792,9 @@
 	},
 /area/city/outskirtsfactory)
 "rf" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	bulb_colour = "#FF3232"
+	},
 /turf/open/floor/pod/light,
 /area/city/outskirtsfactory)
 "rg" = (
@@ -922,7 +931,8 @@
 /area/city/outskirtsfactory)
 "uZ" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
@@ -1013,7 +1023,8 @@
 /area/city/outskirtsfactory)
 "wY" = (
 /obj/machinery/light{
-	dir = 8
+	dir = 8;
+	bulb_colour = "#FF3232"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
@@ -1057,7 +1068,9 @@
 	},
 /area/city/outskirtsfactory)
 "yh" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small{
+	bulb_colour = "#FF3232"
+	},
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "yi" = (
@@ -1176,7 +1189,8 @@
 /area/city/outskirtsfactory)
 "Av" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -1209,13 +1223,15 @@
 /area/city/outskirtsfactory)
 "BI" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/pod/light,
 /area/city/outskirtsfactory)
 "BK" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
@@ -1245,7 +1261,8 @@
 	dir = 1
 	},
 /obj/machinery/light/small{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/circuit/red,
 /area/city/outskirtsfactory)
@@ -1308,7 +1325,8 @@
 /area/city/outskirtsfactory)
 "CE" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
@@ -1323,7 +1341,9 @@
 /turf/open/floor/pod/light,
 /area/city/outskirtsfactory)
 "CZ" = (
-/obj/machinery/light/small/red,
+/obj/machinery/light/small{
+	bulb_colour = "#FF3232"
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/city/outskirtsfactory)
 "De" = (
@@ -1339,8 +1359,9 @@
 /turf/open/floor/plating/asteroid/basalt,
 /area/city/outskirtsfactory)
 "DA" = (
-/obj/machinery/light/red{
-	dir = 1
+/obj/machinery/light{
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/city/outskirtsfactory)
@@ -1415,7 +1436,8 @@
 "EQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
@@ -1506,7 +1528,7 @@
 	name = "wing-grade railing";
 	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
 	mouse_opacity = 0;
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
@@ -1526,7 +1548,8 @@
 /area/city/outskirtsfactory)
 "GE" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
@@ -1558,8 +1581,9 @@
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "Hg" = (
-/obj/machinery/light/small/red{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /obj/structure/sigsystem/connector{
 	dir = 1
@@ -1712,13 +1736,15 @@
 /area/city/outskirtsfactory)
 "Kk" = (
 /obj/machinery/light/small{
-	dir = 8
+	dir = 8;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/pod/light,
 /area/city/outskirtsfactory)
 "Kl" = (
 /obj/machinery/light{
-	dir = 8
+	dir = 8;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
@@ -1761,11 +1787,6 @@
 "KR" = (
 /mob/living/simple_animal/hostile/ordeal/green_bot_rocket,
 /turf/open/floor/plating,
-/area/city/outskirtsfactory)
-"KU" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/ordeal/green_bot,
-/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "KW" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1932,7 +1953,7 @@
 /area/city/outskirtsfactory)
 "Pb" = (
 /obj/machinery/conveyor/auto{
-	dir = 8;
+	dir = 4;
 	resistance_flags = 64;
 	tamperproof = 1
 	},
@@ -1946,14 +1967,18 @@
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "Pf" = (
+/obj/machinery/conveyor/auto{
+	dir = 8;
+	resistance_flags = 64;
+	tamperproof = 1
+	},
 /obj/structure/railing{
 	resistance_flags = 115;
 	name = "wing-grade railing";
 	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
 	mouse_opacity = 0;
-	dir = 4
+	dir = 8
 	},
-/obj/item/tresmetal,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "Pi" = (
@@ -2023,12 +2048,15 @@
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "Ro" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	bulb_colour = "#FF3232"
+	},
 /turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
 "RH" = (
-/obj/machinery/light/small/red{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 8;
+	bulb_colour = "#FF3232"
 	},
 /obj/structure/sigsystem/connector{
 	dir = 1
@@ -2054,7 +2082,8 @@
 /area/city/outskirtsfactory)
 "Sh" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/facility/dark,
@@ -2241,7 +2270,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 8
+	dir = 8;
+	bulb_colour = "#FF3232"
 	},
 /obj/structure/closet/crate,
 /obj/item/tresmetal,
@@ -2395,11 +2425,6 @@
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "Xw" = (
-/obj/machinery/conveyor/auto{
-	dir = 4;
-	resistance_flags = 64;
-	tamperproof = 1
-	},
 /obj/structure/railing{
 	resistance_flags = 115;
 	name = "wing-grade railing";
@@ -2407,6 +2432,7 @@
 	mouse_opacity = 0;
 	dir = 4
 	},
+/obj/item/tresmetal,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "XC" = (
@@ -2495,7 +2521,8 @@
 /area/city/outskirtsfactory)
 "Zr" = (
 /obj/machinery/light/small{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /obj/structure/sigsystem/tower{
 	dir = 8;
@@ -2527,6 +2554,11 @@
 /obj/structure/sigsystem/connector/split,
 /obj/structure/sigsystem/activator,
 /turf/open/floor/pod/dark,
+/area/city/outskirtsfactory)
+"ZP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/ordeal/green_bot,
+/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "ZQ" = (
 /obj/effect/turf_decal/siding/thinplating/light{
@@ -3865,7 +3897,7 @@ sJ
 RK
 dt
 sJ
-Go
+Pf
 iA
 wm
 wm
@@ -4057,7 +4089,7 @@ sJ
 RK
 sJ
 sJ
-KU
+ZP
 RK
 is
 sJ
@@ -4156,13 +4188,13 @@ sJ
 RK
 gU
 RK
-Pb
+Go
 wh
 gE
 wh
 wh
+Pb
 Xw
-Pf
 wh
 gE
 xE

--- a/_maps/Quests/green_dungeon.dmm
+++ b/_maps/Quests/green_dungeon.dmm
@@ -261,6 +261,17 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
+"el" = (
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
+	dir = 8
+	},
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirtsfactory)
 "et" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/dark,
@@ -481,6 +492,12 @@
 /mob/living/simple_animal/hostile/ordeal/green_bot_big,
 /turf/open/floor/facility,
 /area/city/outskirtsfactory)
+"iF" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirtsfactory)
 "iZ" = (
 /obj/machinery/door/poddoor/shutters/indestructible{
 	lockpickable = 0;
@@ -493,6 +510,17 @@
 	tamperproof = 1
 	},
 /turf/open/floor/pod/dark,
+/area/city/outskirtsfactory)
+"jd" = (
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
+	dir = 4
+	},
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "je" = (
 /obj/machinery/conveyor/auto{
@@ -1293,6 +1321,15 @@
 /mob/living/simple_animal/hostile/ordeal/green_bot,
 /turf/open/floor/plating/asteroid/basalt,
 /area/city/outskirtsfactory)
+"BS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/destructible/cult/forge{
+	resistance_flags = 64;
+	desc = "A forge used in crafting various parts.";
+	name = "forge"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirtsfactory)
 "BT" = (
 /obj/structure/railing{
 	dir = 8
@@ -1538,12 +1575,8 @@
 /turf/open/floor/circuit,
 /area/city/outskirtsfactory)
 "FF" = (
-/obj/structure/destructible/cult/forge{
-	resistance_flags = 64;
-	desc = "A forge used in crafting various parts.";
-	name = "forge"
-	},
 /obj/machinery/light,
+/mob/living/simple_animal/hostile/ordeal/green_bot,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "FX" = (
@@ -2007,7 +2040,13 @@
 	},
 /area/city/outskirtsfactory)
 "Pb" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot,
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
+	dir = 10
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "Pf" = (
@@ -3851,10 +3890,10 @@ xE
 Uk
 RK
 UC
-RK
+BS
 xE
-Pn
-Pn
+xE
+xE
 xE
 Mx
 TT
@@ -3949,15 +3988,15 @@ RK
 WH
 UC
 FF
-xE
-xE
-xE
-xE
-Mx
-TT
-TT
-TT
-TT
+oS
+RK
+dt
+sJ
+Go
+iA
+wm
+el
+Pb
 TT
 TT
 TT
@@ -4045,16 +4084,16 @@ xE
 sJ
 GJ
 sJ
-Pb
-oS
-RK
-dt
 sJ
-Go
-iA
-wm
-iA
-wm
+KU
+sJ
+sJ
+RK
+is
+RK
+Pz
+RK
+iF
 Xw
 Pf
 Pf
@@ -4247,7 +4286,7 @@ RK
 Go
 wh
 ef
-wh
+jd
 wh
 UC
 wh

--- a/_maps/Quests/green_dungeon.dmm
+++ b/_maps/Quests/green_dungeon.dmm
@@ -280,10 +280,11 @@
 /turf/open/floor/pod/light,
 /area/city/outskirtsfactory)
 "eB" = (
-/obj/machinery/door/poddoor/shutters/indestructible{
-	lockpickable = 0
+/obj/machinery/door/keycard{
+	puzzle_id = 32;
+	desc = "A high security vault door. This door only opens when a keycard is swiped. It looks virtually indestructable.";
+	name = "vault door"
 	},
-/obj/structure/sigsystem/activator,
 /turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
 "eH" = (
@@ -817,13 +818,6 @@
 	happens_once = 1
 	},
 /turf/open/floor/pod/dark,
-/area/city/outskirtsfactory)
-"qO" = (
-/obj/structure/sigsystem/tower/button{
-	signal_code = 92;
-	signal_range = 3
-	},
-/turf/closed/indestructible/syndicate,
 /area/city/outskirtsfactory)
 "qP" = (
 /obj/structure/sigsystem/connector/split{
@@ -6964,7 +6958,7 @@ YL
 Hi
 Hi
 Ic
-qO
+xE
 fT
 sJ
 fT

--- a/_maps/Quests/green_dungeon.dmm
+++ b/_maps/Quests/green_dungeon.dmm
@@ -13,6 +13,16 @@
 	},
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
+"ah" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/destructible/cult/forge{
+	resistance_flags = 64;
+	desc = "A forge used in crafting various parts.";
+	name = "forge"
+	},
+/obj/machinery/light,
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirtsfactory)
 "ak" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -827,12 +837,6 @@
 	name = "asphalt"
 	},
 /area/city/outskirtsfactory)
-"qY" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/city/outskirtsfactory)
 "rf" = (
 /obj/machinery/light/red,
 /turf/open/floor/pod/light,
@@ -1096,19 +1100,6 @@
 "xE" = (
 /turf/closed/indestructible/syndicate,
 /area/city/outskirtsfactory)
-"xH" = (
-/obj/machinery/door/poddoor/shutters/indestructible{
-	lockpickable = 0;
-	resistance_flags = 64;
-	id = "furnaceaccess"
-	},
-/obj/structure/sigsystem/activator,
-/obj/structure/sigsystem/connector{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/mineral/plastitanium,
-/area/city/outskirtsfactory)
 "xI" = (
 /obj/structure/sigsystem/connector{
 	dir = 4
@@ -1356,6 +1347,16 @@
 	},
 /turf/open/floor/pod/light,
 /area/city/outskirtsfactory)
+"Cm" = (
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
+	dir = 10
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirtsfactory)
 "Ct" = (
 /obj/structure/sigsystem/tower{
 	signal_code = 05;
@@ -1561,8 +1562,9 @@
 /turf/open/floor/circuit,
 /area/city/outskirtsfactory)
 "FF" = (
-/obj/machinery/light,
-/mob/living/simple_animal/hostile/ordeal/green_bot,
+/obj/structure/railing/corner{
+	dir = 8
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "FX" = (
@@ -2026,14 +2028,7 @@
 	},
 /area/city/outskirtsfactory)
 "Pb" = (
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	mouse_opacity = 0;
-	dir = 4
-	},
-/obj/effect/decal/cleanable/oil/slippery,
+/mob/living/simple_animal/hostile/ordeal/green_bot,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "Pf" = (
@@ -2071,16 +2066,6 @@
 	},
 /mob/living/simple_animal/hostile/ordeal/green_bot_rocket,
 /turf/open/floor/pod/light,
-/area/city/outskirtsfactory)
-"PP" = (
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	mouse_opacity = 0;
-	dir = 10
-	},
-/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "PZ" = (
 /obj/machinery/door/poddoor/shutters/indestructible{
@@ -2160,15 +2145,6 @@
 	signal_code = 15
 	},
 /turf/closed/indestructible/rock,
-/area/city/outskirtsfactory)
-"Se" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/destructible/cult/forge{
-	resistance_flags = 64;
-	desc = "A forge used in crafting various parts.";
-	name = "forge"
-	},
-/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "Sh" = (
 /obj/machinery/light/red{
@@ -2338,6 +2314,17 @@
 	tamperproof = 1
 	},
 /turf/open/floor/pod/dark,
+/area/city/outskirtsfactory)
+"Ui" = (
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
+	dir = 4
+	},
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "Uk" = (
 /obj/effect/mob_spawn/human/corpse/charredskeleton,
@@ -2538,6 +2525,19 @@
 /obj/structure/sigsystem/connector{
 	dir = 4
 	},
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirtsfactory)
+"XV" = (
+/obj/machinery/door/poddoor/shutters/indestructible{
+	lockpickable = 0;
+	resistance_flags = 64;
+	id = "furnaceaccess"
+	},
+/obj/structure/sigsystem/activator,
+/obj/structure/sigsystem/connector{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "XW" = (
@@ -3896,7 +3896,7 @@ xE
 Uk
 RK
 UC
-Se
+ah
 xE
 xE
 xE
@@ -3993,7 +3993,7 @@ xE
 RK
 WH
 UC
-FF
+Pb
 oS
 RK
 dt
@@ -4002,7 +4002,7 @@ Go
 iA
 wm
 yr
-PP
+Cm
 TT
 TT
 TT
@@ -4099,7 +4099,7 @@ is
 RK
 Pz
 RK
-qY
+FF
 Xw
 Pf
 Pf
@@ -4188,7 +4188,7 @@ Tt
 sJ
 sJ
 RK
-xH
+XV
 sJ
 RK
 RK
@@ -4292,7 +4292,7 @@ RK
 Go
 wh
 ef
-Pb
+Ui
 wh
 UC
 wh

--- a/_maps/Quests/green_dungeon.dmm
+++ b/_maps/Quests/green_dungeon.dmm
@@ -171,6 +171,15 @@
 /obj/structure/sigsystem/activator,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
+"cs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/destructible/cult/forge{
+	resistance_flags = 64;
+	desc = "A forge used in crafting various parts.";
+	name = "forge"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirtsfactory)
 "cw" = (
 /obj/effect/turf_decal/siding/thinplating/light{
 	dir = 8
@@ -258,17 +267,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/mineral/plastitanium,
-/area/city/outskirtsfactory)
-"el" = (
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	mouse_opacity = 0;
-	dir = 8
-	},
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
@@ -446,7 +444,7 @@
 /area/city/outskirtsfactory)
 "hK" = (
 /obj/structure/sigsystem/connector{
-	delay_time = 100;
+	delay_time = 30;
 	dir = 4
 	},
 /turf/closed/indestructible/syndicate,
@@ -492,12 +490,6 @@
 /mob/living/simple_animal/hostile/ordeal/green_bot_big,
 /turf/open/floor/facility,
 /area/city/outskirtsfactory)
-"iF" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/city/outskirtsfactory)
 "iZ" = (
 /obj/machinery/door/poddoor/shutters/indestructible{
 	lockpickable = 0;
@@ -510,17 +502,6 @@
 	tamperproof = 1
 	},
 /turf/open/floor/pod/dark,
-/area/city/outskirtsfactory)
-"jd" = (
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	mouse_opacity = 0;
-	dir = 4
-	},
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "je" = (
 /obj/machinery/conveyor/auto{
@@ -1153,11 +1134,10 @@
 /turf/closed/indestructible/syndicate,
 /area/city/outskirtsfactory)
 "yr" = (
-/obj/structure/sigsystem/connector{
-	dir = 4;
-	delay_time = 30
+/obj/structure/railing/corner{
+	dir = 8
 	},
-/turf/open/floor/pod/dark,
+/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "yt" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1320,15 +1300,6 @@
 "BR" = (
 /mob/living/simple_animal/hostile/ordeal/green_bot,
 /turf/open/floor/plating/asteroid/basalt,
-/area/city/outskirtsfactory)
-"BS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/destructible/cult/forge{
-	resistance_flags = 64;
-	desc = "A forge used in crafting various parts.";
-	name = "forge"
-	},
-/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "BT" = (
 /obj/structure/railing{
@@ -1502,6 +1473,17 @@
 "EC" = (
 /obj/structure/sigsystem/connector/split,
 /turf/closed/indestructible/syndicate,
+/area/city/outskirtsfactory)
+"EH" = (
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
+	dir = 4
+	},
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "EO" = (
 /obj/effect/turf_decal/siding/green/corner{
@@ -2348,6 +2330,17 @@
 	},
 /obj/effect/turf_decal/siding/red,
 /turf/open/floor/facility/dark,
+/area/city/outskirtsfactory)
+"Us" = (
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
+	dir = 8
+	},
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "Uv" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -3890,7 +3883,7 @@ xE
 Uk
 RK
 UC
-BS
+cs
 xE
 xE
 xE
@@ -3995,7 +3988,7 @@ sJ
 Go
 iA
 wm
-el
+Us
 Pb
 TT
 TT
@@ -4093,7 +4086,7 @@ is
 RK
 Pz
 RK
-iF
+yr
 Xw
 Pf
 Pf
@@ -4286,7 +4279,7 @@ RK
 Go
 wh
 ef
-jd
+EH
 wh
 UC
 wh
@@ -4301,7 +4294,7 @@ xE
 xI
 mE
 tQ
-yr
+YV
 tQ
 et
 cX

--- a/_maps/Quests/green_dungeon.dmm
+++ b/_maps/Quests/green_dungeon.dmm
@@ -152,10 +152,7 @@
 	pixel_x = 9;
 	pixel_y = 8
 	},
-/obj/item/ego_weapon/ranged/malicedescent{
-	pixel_y = -6;
-	pixel_x = -5
-	},
+/obj/item/ego_weapon/painprocess,
 /turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
 "ca" = (

--- a/_maps/map_files/generic/Manager.dmm
+++ b/_maps/map_files/generic/Manager.dmm
@@ -354,12 +354,6 @@
 	},
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
-"cW" = (
-/obj/structure/sigsystem/connector{
-	happens_once = 1
-	},
-/turf/open/floor/facility/dark,
-/area/city/outskirtsfactory)
 "cY" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/dark,
@@ -385,7 +379,7 @@
 /obj/structure/sigsystem/connector/split{
 	dir = 4
 	},
-/obj/machinery/light/red{
+/obj/machinery/light{
 	dir = 8
 	},
 /obj/structure/closet/crate,
@@ -748,17 +742,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/department_main/manager)
-"fL" = (
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	mouse_opacity = 0;
-	dir = 8
-	},
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/mineral/plastitanium,
-/area/city/outskirtsfactory)
 "fU" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -842,12 +825,18 @@
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "gv" = (
-/obj/machinery/door/poddoor/shutters/indestructible{
-	lockpickable = 0;
+/obj/machinery/conveyor/auto{
+	dir = 8;
 	resistance_flags = 64;
-	id = "furnaceaccess"
+	tamperproof = 1
 	},
-/obj/structure/sigsystem/activator,
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "gx" = (
@@ -1184,7 +1173,7 @@
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "jg" = (
-/obj/machinery/light/red{
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/pod/light,
@@ -1261,11 +1250,14 @@
 /turf/closed/indestructible/syndicate,
 /area/city/outskirtsfactory)
 "jI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sigsystem/connector{
-	dir = 1;
-	happens_once = 1
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
+	dir = 8
 	},
+/mob/living/simple_animal/hostile/ordeal/green_bot_big,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "jL" = (
@@ -1690,16 +1682,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/facility_hallway/manager)
-"mI" = (
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	mouse_opacity = 0;
-	dir = 10
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/city/outskirtsfactory)
 "mK" = (
 /obj/structure/rack,
 /obj/item/toy/plush/big_bad_wolf,
@@ -1829,7 +1811,6 @@
 "nh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sigsystem/connector{
-	delay_time = 90;
 	dir = 1;
 	happens_once = 1
 	},
@@ -2091,7 +2072,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "pv" = (
@@ -2285,10 +2265,6 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/city/outskirtsfactory)
-"qW" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/facility,
 /area/city/outskirtsfactory)
 "qY" = (
 /obj/structure/table/wood/fancy/royalblack,
@@ -2769,7 +2745,7 @@
 /turf/open/floor/facility/dark,
 /area/department_main/manager)
 "uO" = (
-/obj/machinery/light/small/red{
+/obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/pod/dark,
@@ -2891,7 +2867,7 @@
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "vL" = (
-/obj/machinery/light/red,
+/obj/machinery/light,
 /turf/open/floor/pod/light,
 /area/city/outskirtsfactory)
 "vM" = (
@@ -3313,7 +3289,7 @@
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "yx" = (
-/obj/machinery/light/red{
+/obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3382,18 +3358,6 @@
 	},
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
-"yT" = (
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	mouse_opacity = 0;
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/mineral/plastitanium,
-/area/city/outskirtsfactory)
 "yX" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-11";
@@ -3417,19 +3381,6 @@
 	pixel_y = 19
 	},
 /turf/open/floor/pod/dark,
-/area/city/outskirtsfactory)
-"zr" = (
-/obj/machinery/door/poddoor/shutters/indestructible{
-	lockpickable = 0;
-	resistance_flags = 64;
-	id = "furnaceaccess"
-	},
-/obj/structure/sigsystem/activator,
-/obj/structure/sigsystem/connector{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "zv" = (
 /obj/structure/chair/comfy/black{
@@ -3541,7 +3492,6 @@
 /area/city/outskirtsfactory)
 "Aa" = (
 /obj/structure/sigsystem/connector{
-	delay_time = 90;
 	dir = 1;
 	happens_once = 1
 	},
@@ -3745,18 +3695,8 @@
 /turf/open/floor/carpet/green,
 /area/facility_hallway/manager)
 "Bv" = (
-/obj/machinery/conveyor/auto{
-	dir = 1;
-	resistance_flags = 64;
-	tamperproof = 1
-	},
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	mouse_opacity = 0;
-	dir = 8
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/ordeal/green_bot,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "BD" = (
@@ -4002,10 +3942,6 @@
 	},
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
-"DR" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/mineral/plastitanium,
-/area/city/outskirtsfactory)
 "DU" = (
 /obj/effect/turf_decal/siding/red/corner{
 	dir = 4
@@ -4107,7 +4043,7 @@
 	},
 /obj/structure/sigsystem/connector{
 	dir = 1;
-	delay_time = 200
+	delay_time = 150
 	},
 /turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
@@ -4186,7 +4122,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/facility_hallway/manager)
 "Fm" = (
-/obj/machinery/light/red{
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/pod/light,
@@ -4420,7 +4356,7 @@
 	name = "wing-grade railing";
 	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
 	mouse_opacity = 0;
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
@@ -4468,10 +4404,6 @@
 /obj/structure/sigsystem/tower/button{
 	pixel_x = 28;
 	signal_code = 09
-	},
-/obj/structure/sigsystem/tower{
-	signal_code = 09;
-	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
@@ -4539,12 +4471,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
-"HC" = (
-/obj/structure/sigsystem/tower{
-	signal_code = 92
-	},
-/turf/open/floor/mineral/gold,
-/area/city/outskirtsfactory)
 "HD" = (
 /obj/effect/turf_decal/siding/red,
 /obj/structure/sigsystem/connector/split{
@@ -4560,7 +4486,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "HI" = (
-/obj/machinery/light/red{
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/pod/light,
@@ -4903,14 +4829,17 @@
 /turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
 "KD" = (
-/obj/machinery/door/poddoor/shutters/indestructible{
-	lockpickable = 0;
+/obj/machinery/conveyor/auto{
+	dir = 4;
 	resistance_flags = 64;
-	id = "furnaceaccess"
+	tamperproof = 1
 	},
-/obj/structure/sigsystem/activator,
-/obj/structure/sigsystem/connector{
-	dir = 8
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
@@ -5113,7 +5042,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/facility_hallway/manager)
 "MC" = (
-/obj/machinery/light/red{
+/obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5348,17 +5277,6 @@
 /obj/effect/turf_decal,
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
-"OV" = (
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	mouse_opacity = 0;
-	dir = 4
-	},
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/mineral/plastitanium,
-/area/city/outskirtsfactory)
 "OZ" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Arcade"
@@ -5411,13 +5329,6 @@
 	},
 /turf/open/floor/pod/light,
 /area/city/outskirtsfactory)
-"PA" = (
-/obj/effect/turf_decal/siding/thinplating/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/facility,
-/area/city/outskirtsfactory)
 "PK" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -5441,7 +5352,7 @@
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "PR" = (
-/obj/machinery/light/red{
+/obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5807,7 +5718,7 @@
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
 "SQ" = (
-/obj/machinery/light/small/red{
+/obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/pod/light,
@@ -5902,14 +5813,6 @@
 	resistance_flags = 64
 	},
 /turf/open/floor/plating/asteroid/basalt,
-/area/city/outskirtsfactory)
-"TY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/caution{
-	pixel_y = 7;
-	pixel_x = -3
-	},
-/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "TZ" = (
 /obj/effect/turf_decal/siding/wood{
@@ -6283,12 +6186,6 @@
 /obj/item/food/bread/plain,
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
-"Xq" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/city/outskirtsfactory)
 "Xs" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 9
@@ -6386,18 +6283,14 @@
 /turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
 "XX" = (
-/obj/machinery/conveyor/auto{
-	dir = 4;
-	resistance_flags = 64;
-	tamperproof = 1
-	},
 /obj/structure/railing{
 	resistance_flags = 115;
 	name = "wing-grade railing";
 	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
 	mouse_opacity = 0;
-	dir = 8
+	dir = 4
 	},
+/obj/item/tresmetal,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "XZ" = (
@@ -13430,19 +13323,19 @@ Ve
 rm
 co
 rm
-gv
+oq
 Ve
 ar
 oq
 GY
 pq
 vF
-fL
-mI
-sr
-sr
-sr
-sr
+jI
+vF
+vF
+vF
+vF
+vF
 dF
 dF
 dF
@@ -13687,19 +13580,19 @@ oq
 rB
 oq
 oQ
-KD
+oq
 oq
 oq
 Ve
 tb
 Ve
-DR
+oq
 Ve
-Xq
-XX
-Bv
-Bv
-Bv
+oq
+co
+Ja
+Ja
+Ja
 gQ
 VE
 xE
@@ -13944,13 +13837,13 @@ wQ
 oq
 oq
 Ve
-zr
 oq
-Ve
+oq
+Bv
 Ve
 tb
 oq
-TY
+Ve
 pJ
 Ve
 co
@@ -13959,7 +13852,7 @@ Ve
 oq
 dF
 dF
-iU
+JQ
 dF
 dF
 dF
@@ -14198,20 +14091,20 @@ XO
 XO
 dF
 kZ
-DR
+oq
 Ve
 Ve
-KD
-jI
+oq
+Ve
 Hr
 Ve
-GY
+gv
 mT
-yT
-OV
+sq
 mT
-co
 mT
+KD
+XX
 mT
 sq
 dF
@@ -21101,8 +20994,8 @@ XO
 dF
 jl
 Vx
-HC
-cW
+Vx
+Lp
 gL
 Nm
 Hl
@@ -22189,7 +22082,7 @@ XO
 dF
 MW
 gh
-PA
+gh
 pc
 gh
 gh
@@ -22449,7 +22342,7 @@ DV
 DV
 Iv
 DV
-qW
+DV
 UW
 dF
 vp
@@ -22961,7 +22854,7 @@ dF
 bW
 Iv
 DV
-qW
+DV
 DV
 DV
 Ot

--- a/_maps/map_files/generic/Manager.dmm
+++ b/_maps/map_files/generic/Manager.dmm
@@ -748,6 +748,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/department_main/manager)
+"fL" = (
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
+	dir = 8
+	},
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirtsfactory)
 "fU" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -866,10 +877,11 @@
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "gL" = (
-/obj/machinery/door/poddoor/shutters/indestructible{
-	lockpickable = 0
+/obj/machinery/door/keycard{
+	puzzle_id = 32;
+	desc = "A high security vault door. This door only opens when a keycard is swiped. It looks virtually indestructable.";
+	name = "vault door"
 	},
-/obj/structure/sigsystem/activator,
 /turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
 "gP" = (
@@ -1637,11 +1649,6 @@
 /obj/structure/sigsystem/activator,
 /turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
-"mt" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light,
-/turf/open/floor/mineral/plastitanium,
-/area/city/outskirtsfactory)
 "mu" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -1684,11 +1691,14 @@
 /turf/open/floor/carpet/green,
 /area/facility_hallway/manager)
 "mI" = (
-/obj/structure/sigsystem/tower/button{
-	signal_code = 92;
-	signal_range = 3
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
+	dir = 10
 	},
-/turf/closed/indestructible/syndicate,
+/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "mK" = (
 /obj/structure/rack,
@@ -1898,17 +1908,6 @@
 /obj/structure/sigsystem/connector{
 	dir = 8
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/city/outskirtsfactory)
-"oa" = (
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	mouse_opacity = 0;
-	dir = 4
-	},
-/obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "ob" = (
@@ -2665,19 +2664,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/facility_hallway/manager)
-"tr" = (
-/obj/machinery/door/poddoor/shutters/indestructible{
-	lockpickable = 0;
-	resistance_flags = 64;
-	id = "furnaceaccess"
-	},
-/obj/structure/sigsystem/activator,
-/obj/structure/sigsystem/connector{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/mineral/plastitanium,
-/area/city/outskirtsfactory)
 "tD" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/sigsystem/tower/button{
@@ -3433,9 +3419,16 @@
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "zr" = (
-/obj/structure/railing/corner{
+/obj/machinery/door/poddoor/shutters/indestructible{
+	lockpickable = 0;
+	resistance_flags = 64;
+	id = "furnaceaccess"
+	},
+/obj/structure/sigsystem/activator,
+/obj/structure/sigsystem/connector{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "zv" = (
@@ -4561,6 +4554,11 @@
 /obj/machinery/light/small/red,
 /turf/open/floor/circuit/red,
 /area/city/outskirtsfactory)
+"HH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light,
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirtsfactory)
 "HI" = (
 /obj/machinery/light/red{
 	dir = 4
@@ -5356,8 +5354,9 @@
 	name = "wing-grade railing";
 	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
 	mouse_opacity = 0;
-	dir = 10
+	dir = 4
 	},
+/obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "OZ" = (
@@ -6285,14 +6284,9 @@
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
 "Xq" = (
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	mouse_opacity = 0;
+/obj/structure/railing/corner{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "Xs" = (
@@ -13178,7 +13172,7 @@ dF
 Uq
 Ve
 co
-mt
+HH
 dF
 dF
 dF
@@ -13443,8 +13437,8 @@ oq
 GY
 pq
 vF
-Xq
-OV
+fL
+mI
 sr
 sr
 sr
@@ -13701,7 +13695,7 @@ tb
 Ve
 DR
 Ve
-zr
+Xq
 XX
 Bv
 Bv
@@ -13950,7 +13944,7 @@ wQ
 oq
 oq
 Ve
-tr
+zr
 oq
 Ve
 Ve
@@ -14214,7 +14208,7 @@ Ve
 GY
 mT
 yT
-oa
+OV
 mT
 co
 mT
@@ -21366,7 +21360,7 @@ Gh
 Vx
 Vx
 zA
-mI
+dF
 Nm
 oq
 Nm

--- a/_maps/map_files/generic/Manager.dmm
+++ b/_maps/map_files/generic/Manager.dmm
@@ -855,7 +855,7 @@
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
 "gG" = (
-/obj/machinery/light/small/red{
+/obj/machinery/light/small{
 	dir = 1
 	},
 /obj/structure/sigsystem/tower{
@@ -1250,14 +1250,18 @@
 /turf/closed/indestructible/syndicate,
 /area/city/outskirtsfactory)
 "jI" = (
+/obj/machinery/conveyor/auto{
+	dir = 4;
+	resistance_flags = 64;
+	tamperproof = 1
+	},
 /obj/structure/railing{
 	resistance_flags = 115;
 	name = "wing-grade railing";
 	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
 	mouse_opacity = 0;
-	dir = 8
+	dir = 4
 	},
-/mob/living/simple_animal/hostile/ordeal/green_bot_big,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "jL" = (
@@ -1300,7 +1304,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "kb" = (
-/obj/machinery/light/small/red,
+/obj/machinery/light/small,
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "kd" = (
@@ -2305,7 +2309,7 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 1
 	},
-/obj/machinery/light/small/red{
+/obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/circuit/red,
@@ -2459,7 +2463,7 @@
 /area/city/outskirtsfactory)
 "sl" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/pod/dark,
@@ -2707,7 +2711,7 @@
 /turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
 "ue" = (
-/obj/machinery/light/red,
+/obj/machinery/light,
 /turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
 "ug" = (
@@ -2962,7 +2966,7 @@
 /area/facility_hallway/manager)
 "wp" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small/red,
+/obj/machinery/light/small,
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "wq" = (
@@ -3695,8 +3699,14 @@
 /turf/open/floor/carpet/green,
 /area/facility_hallway/manager)
 "Bv" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/ordeal/green_bot,
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
+	dir = 4
+	},
+/obj/item/tresmetal,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "BD" = (
@@ -4477,7 +4487,7 @@
 	dir = 1;
 	happens_once = 1
 	},
-/obj/machinery/light/small/red,
+/obj/machinery/light/small,
 /turf/open/floor/circuit/red,
 /area/city/outskirtsfactory)
 "HH" = (
@@ -4684,7 +4694,7 @@
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "Jf" = (
-/obj/machinery/light/small/red{
+/obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -4829,18 +4839,14 @@
 /turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
 "KD" = (
-/obj/machinery/conveyor/auto{
-	dir = 4;
-	resistance_flags = 64;
-	tamperproof = 1
-	},
 /obj/structure/railing{
 	resistance_flags = 115;
 	name = "wing-grade railing";
 	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
 	mouse_opacity = 0;
-	dir = 4
+	dir = 8
 	},
+/mob/living/simple_animal/hostile/ordeal/green_bot_big,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "KM" = (
@@ -5821,7 +5827,7 @@
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
 "Ua" = (
-/obj/machinery/light/red{
+/obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes{
@@ -6283,14 +6289,8 @@
 /turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
 "XX" = (
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	mouse_opacity = 0;
-	dir = 4
-	},
-/obj/item/tresmetal,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/ordeal/green_bot,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "XZ" = (
@@ -6367,7 +6367,7 @@
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
 "YD" = (
-/obj/machinery/light/red{
+/obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -13330,7 +13330,7 @@ oq
 GY
 pq
 vF
-jI
+KD
 vF
 vF
 vF
@@ -13839,7 +13839,7 @@ oq
 Ve
 oq
 oq
-Bv
+XX
 Ve
 tb
 oq
@@ -13852,7 +13852,7 @@ Ve
 oq
 dF
 dF
-JQ
+iU
 dF
 dF
 dF
@@ -14103,8 +14103,8 @@ mT
 sq
 mT
 mT
-KD
-XX
+jI
+Bv
 mT
 sq
 dF

--- a/_maps/map_files/generic/Manager.dmm
+++ b/_maps/map_files/generic/Manager.dmm
@@ -1,6 +1,8 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ac" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	bulb_colour = "#FF3232"
+	},
 /obj/structure/chair/plastic{
 	dir = 8
 	},
@@ -70,7 +72,9 @@
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "an" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	bulb_colour = "#FF3232"
+	},
 /obj/effect/turf_decal/siding/brown,
 /turf/open/floor/carpet/orange,
 /area/facility_hallway/manager)
@@ -93,7 +97,9 @@
 /turf/closed/indestructible/syndicate,
 /area/city/outskirtsfactory)
 "ay" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	bulb_colour = "#FF3232"
+	},
 /obj/structure/chair/plastic{
 	dir = 4
 	},
@@ -194,7 +200,9 @@
 /turf/open/floor/carpet/cyan,
 /area/department_main/manager)
 "bG" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	bulb_colour = "#FF3232"
+	},
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
 "bH" = (
@@ -380,7 +388,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 8
+	dir = 8;
+	bulb_colour = "#FF3232"
 	},
 /obj/structure/closet/crate,
 /obj/item/tresmetal,
@@ -703,7 +712,8 @@
 "fr" = (
 /obj/structure/table/glass,
 /obj/machinery/light{
-	dir = 4
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
@@ -825,11 +835,6 @@
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "gv" = (
-/obj/machinery/conveyor/auto{
-	dir = 8;
-	resistance_flags = 64;
-	tamperproof = 1
-	},
 /obj/structure/railing{
 	resistance_flags = 115;
 	name = "wing-grade railing";
@@ -837,6 +842,7 @@
 	mouse_opacity = 0;
 	dir = 4
 	},
+/obj/item/tresmetal,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "gx" = (
@@ -856,7 +862,8 @@
 /area/facility_hallway/manager)
 "gG" = (
 /obj/machinery/light/small{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /obj/structure/sigsystem/tower{
 	dir = 8;
@@ -929,7 +936,9 @@
 	dir = 1;
 	light_color = "#333333"
 	},
-/obj/machinery/light,
+/obj/machinery/light{
+	bulb_colour = "#FF3232"
+	},
 /obj/structure/table/reinforced,
 /obj/item/food/bread/banana,
 /obj/item/food/bread/banana,
@@ -1132,7 +1141,9 @@
 	pixel_x = -5;
 	pixel_y = 5
 	},
-/obj/machinery/light,
+/obj/machinery/light{
+	bulb_colour = "#FF3232"
+	},
 /turf/open/floor/carpet/green,
 /area/facility_hallway/manager)
 "iK" = (
@@ -1174,7 +1185,8 @@
 /area/city/outskirtsfactory)
 "jg" = (
 /obj/machinery/light{
-	dir = 8
+	dir = 8;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/pod/light,
 /area/city/outskirtsfactory)
@@ -1250,18 +1262,14 @@
 /turf/closed/indestructible/syndicate,
 /area/city/outskirtsfactory)
 "jI" = (
-/obj/machinery/conveyor/auto{
-	dir = 4;
-	resistance_flags = 64;
-	tamperproof = 1
-	},
 /obj/structure/railing{
 	resistance_flags = 115;
 	name = "wing-grade railing";
 	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
 	mouse_opacity = 0;
-	dir = 4
+	dir = 8
 	},
+/mob/living/simple_animal/hostile/ordeal/green_bot_big,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "jL" = (
@@ -1304,7 +1312,9 @@
 /turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "kb" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small{
+	bulb_colour = "#FF3232"
+	},
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "kd" = (
@@ -1489,7 +1499,8 @@
 /area/city/outskirtsfactory)
 "lw" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /obj/machinery/roulette,
 /turf/open/floor/plasteel/dark,
@@ -1705,7 +1716,8 @@
 /area/facility_hallway/manager)
 "mM" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /obj/machinery/newscaster/security_unit{
 	pixel_y = 32
@@ -1840,7 +1852,9 @@
 /turf/open/floor/facility/dark,
 /area/department_main/manager)
 "no" = (
-/obj/machinery/light/small/red,
+/obj/machinery/light/small{
+	bulb_colour = "#FF3232"
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/city/outskirtsfactory)
 "np" = (
@@ -2024,7 +2038,9 @@
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
 "oZ" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	bulb_colour = "#FF3232"
+	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 7
 	},
@@ -2035,7 +2051,8 @@
 /area/facility_hallway/manager)
 "pb" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /obj/machinery/computer/shuttle/mining{
 	dir = 1;
@@ -2062,7 +2079,8 @@
 /area/facility_hallway/manager)
 "pp" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
@@ -2201,8 +2219,9 @@
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
 "qx" = (
-/obj/machinery/light/small/red{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /obj/effect/turf_decal/siding/green{
 	dir = 4
@@ -2210,8 +2229,9 @@
 /turf/open/floor/pod/light,
 /area/city/outskirtsfactory)
 "qy" = (
-/obj/machinery/light/small/red{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 8;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/city/outskirtsfactory)
@@ -2221,7 +2241,8 @@
 /area/city/outskirtsfactory)
 "qC" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -2265,8 +2286,9 @@
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "qU" = (
-/obj/machinery/light/red{
-	dir = 4
+/obj/machinery/light{
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
@@ -2291,7 +2313,9 @@
 /turf/open/floor/carpet/orange,
 /area/facility_hallway/manager)
 "rd" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	bulb_colour = "#FF3232"
+	},
 /turf/open/floor/plasteel,
 /area/department_main/manager)
 "rg" = (
@@ -2310,7 +2334,8 @@
 	dir = 1
 	},
 /obj/machinery/light/small{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/circuit/red,
 /area/city/outskirtsfactory)
@@ -2411,8 +2436,9 @@
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
 "rL" = (
-/obj/machinery/light/small/red{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /obj/structure/sigsystem/connector{
 	dir = 1
@@ -2443,7 +2469,8 @@
 /area/city/outskirtsfactory)
 "sg" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
@@ -2464,7 +2491,8 @@
 "sl" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
@@ -2509,7 +2537,8 @@
 	},
 /obj/item/bedsheet,
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -2559,7 +2588,8 @@
 /obj/structure/bed/pod,
 /obj/item/bedsheet/black,
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -2624,7 +2654,8 @@
 /area/city/outskirtsfactory)
 "tn" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /obj/machinery/newscaster/security_unit{
 	pixel_x = 32
@@ -2711,7 +2742,9 @@
 /turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
 "ue" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	bulb_colour = "#FF3232"
+	},
 /turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
 "ug" = (
@@ -2750,7 +2783,8 @@
 /area/department_main/manager)
 "uO" = (
 /obj/machinery/light/small{
-	dir = 4
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
@@ -2815,7 +2849,8 @@
 /area/department_main/manager)
 "vz" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/plasteel,
 /area/department_main/manager)
@@ -2871,7 +2906,9 @@
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "vL" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	bulb_colour = "#FF3232"
+	},
 /turf/open/floor/pod/light,
 /area/city/outskirtsfactory)
 "vM" = (
@@ -2966,7 +3003,9 @@
 /area/facility_hallway/manager)
 "wp" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small,
+/obj/machinery/light/small{
+	bulb_colour = "#FF3232"
+	},
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "wq" = (
@@ -2975,7 +3014,8 @@
 /area/city/outskirtsfactory)
 "ws" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -3087,7 +3127,8 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/carpet/red,
 /area/facility_hallway/manager)
@@ -3102,7 +3143,9 @@
 /area/department_main/manager)
 "xq" = (
 /obj/machinery/vending/lobotomyuniform,
-/obj/machinery/light,
+/obj/machinery/light{
+	bulb_colour = "#FF3232"
+	},
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
 "xs" = (
@@ -3243,8 +3286,9 @@
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
 "yl" = (
-/obj/machinery/light/small/red{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 8;
+	bulb_colour = "#FF3232"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/siding/green{
@@ -3294,7 +3338,8 @@
 /area/city/outskirtsfactory)
 "yx" = (
 /obj/machinery/light{
-	dir = 8
+	dir = 8;
+	bulb_colour = "#FF3232"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
@@ -3324,7 +3369,9 @@
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
 "yH" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	bulb_colour = "#FF3232"
+	},
 /turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
 "yM" = (
@@ -3416,7 +3463,8 @@
 /area/department_main/manager)
 "zE" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /obj/effect/turf_decal/siding/brown{
 	dir = 1
@@ -3519,7 +3567,8 @@
 /area/facility_hallway/manager)
 "Ag" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
@@ -3699,14 +3748,18 @@
 /turf/open/floor/carpet/green,
 /area/facility_hallway/manager)
 "Bv" = (
+/obj/machinery/conveyor/auto{
+	dir = 8;
+	resistance_flags = 64;
+	tamperproof = 1
+	},
 /obj/structure/railing{
 	resistance_flags = 115;
 	name = "wing-grade railing";
 	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
 	mouse_opacity = 0;
-	dir = 4
+	dir = 8
 	},
-/obj/item/tresmetal,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "BD" = (
@@ -3784,7 +3837,8 @@
 "Cr" = (
 /obj/structure/closet/cabinet,
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/wood,
 /area/department_main/manager)
@@ -3885,7 +3939,8 @@
 "Dd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/red{
-	dir = 4
+	dir = 4;
+	nightshift_allowed = 1
 	},
 /mob/living/simple_animal/hostile/ordeal/grungeon_shielder,
 /turf/open/floor/facility/dark,
@@ -3997,8 +4052,9 @@
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
 "Ek" = (
-/obj/machinery/light/small/red{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/city/outskirtsfactory)
@@ -4026,8 +4082,9 @@
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
 "Et" = (
-/obj/machinery/light/red{
-	dir = 1
+/obj/machinery/light{
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/city/outskirtsfactory)
@@ -4114,7 +4171,9 @@
 /area/city/outskirtsfactory)
 "Fg" = (
 /obj/structure/table,
-/obj/machinery/light,
+/obj/machinery/light{
+	bulb_colour = "#FF3232"
+	},
 /obj/item/toy/plush/bongbong,
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
@@ -4133,7 +4192,8 @@
 /area/facility_hallway/manager)
 "Fm" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/pod/light,
 /area/city/outskirtsfactory)
@@ -4142,7 +4202,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /obj/structure/table/reinforced,
 /obj/item/weldingtool/largetank{
@@ -4366,7 +4427,7 @@
 	name = "wing-grade railing";
 	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
 	mouse_opacity = 0;
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
@@ -4465,7 +4526,8 @@
 	light_color = "#333333"
 	},
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -4477,7 +4539,8 @@
 "HA" = (
 /obj/machinery/vending/lobotomyuniform,
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
@@ -4487,7 +4550,9 @@
 	dir = 1;
 	happens_once = 1
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small{
+	bulb_colour = "#FF3232"
+	},
 /turf/open/floor/circuit/red,
 /area/city/outskirtsfactory)
 "HH" = (
@@ -4497,7 +4562,8 @@
 /area/city/outskirtsfactory)
 "HI" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/pod/light,
 /area/city/outskirtsfactory)
@@ -4676,7 +4742,9 @@
 /obj/structure/table/wood,
 /obj/item/clothing/suit/apron/chef,
 /obj/item/clothing/head/chefhat,
-/obj/machinery/light,
+/obj/machinery/light{
+	bulb_colour = "#FF3232"
+	},
 /turf/open/floor/wood,
 /area/department_main/manager)
 "Jc" = (
@@ -4703,7 +4771,8 @@
 /obj/item/bedsheet/dorms,
 /obj/structure/bed,
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/wood,
 /area/department_main/manager)
@@ -4816,7 +4885,8 @@
 /area/city/outskirtsfactory)
 "Kl" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/carpet/red,
 /area/facility_hallway/manager)
@@ -4839,27 +4909,33 @@
 /turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
 "KD" = (
+/obj/machinery/conveyor/auto{
+	dir = 4;
+	resistance_flags = 64;
+	tamperproof = 1
+	},
 /obj/structure/railing{
 	resistance_flags = 115;
 	name = "wing-grade railing";
 	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
 	mouse_opacity = 0;
-	dir = 8
+	dir = 4
 	},
-/mob/living/simple_animal/hostile/ordeal/green_bot_big,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "KM" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "KR" = (
-/obj/machinery/light/small/red{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/siding/green{
@@ -4889,7 +4965,8 @@
 /area/facility_hallway/manager)
 "Li" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /obj/structure/lootcrate/tres,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4897,8 +4974,9 @@
 /area/city/outskirtsfactory)
 "Lj" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
-/obj/machinery/light/small/red{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
@@ -4937,7 +5015,9 @@
 /turf/open/floor/carpet/royalblue,
 /area/facility_hallway/manager)
 "LB" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	bulb_colour = "#FF3232"
+	},
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -32
 	},
@@ -4950,7 +5030,9 @@
 /turf/open/floor/carpet/royalblack,
 /area/facility_hallway/manager)
 "LF" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	bulb_colour = "#FF3232"
+	},
 /obj/machinery/vending/snack/green,
 /turf/open/floor/plasteel,
 /area/department_main/manager)
@@ -4976,7 +5058,9 @@
 /obj/structure/chair/wood{
 	dir = 4
 	},
-/obj/machinery/light,
+/obj/machinery/light{
+	bulb_colour = "#FF3232"
+	},
 /turf/open/floor/wood,
 /area/department_main/manager)
 "LR" = (
@@ -5049,7 +5133,8 @@
 /area/facility_hallway/manager)
 "MC" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
@@ -5084,7 +5169,8 @@
 /obj/machinery/shower,
 /obj/item/soap/deluxe,
 /obj/machinery/light{
-	dir = 4
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/noslip,
 /area/facility_hallway/manager)
@@ -5164,7 +5250,8 @@
 /area/city/outskirtsfactory)
 "Nx" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
@@ -5215,8 +5302,9 @@
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
 "NV" = (
-/obj/machinery/light/small/red{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 8;
+	bulb_colour = "#FF3232"
 	},
 /obj/effect/turf_decal/siding/green{
 	dir = 8
@@ -5352,14 +5440,16 @@
 /turf/open/floor/wood,
 /area/department_main/manager)
 "PP" = (
-/obj/machinery/light/small/red{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 8;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "PR" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
@@ -5378,7 +5468,8 @@
 /obj/item/storage/fancy/candle_box,
 /obj/item/lighter,
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/wood,
 /area/department_main/manager)
@@ -5415,7 +5506,9 @@
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "Qq" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	bulb_colour = "#FF3232"
+	},
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/champagne,
 /turf/open/floor/wood,
@@ -5526,8 +5619,9 @@
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
 "QW" = (
-/obj/machinery/light/red{
-	dir = 8
+/obj/machinery/light{
+	dir = 8;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
@@ -5545,10 +5639,14 @@
 /turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
 "Rm" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	bulb_colour = "#FF3232"
+	},
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv,
-/obj/machinery/light,
+/obj/machinery/light{
+	bulb_colour = "#FF3232"
+	},
 /turf/open/floor/wood,
 /area/department_main/manager)
 "Rn" = (
@@ -5667,7 +5765,8 @@
 /area/department_main/manager)
 "SA" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /obj/structure/chair/sofa/corp,
 /turf/open/floor/facility/dark,
@@ -5682,7 +5781,8 @@
 "SH" = (
 /obj/machinery/griddle,
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/wood,
 /area/department_main/manager)
@@ -5725,7 +5825,8 @@
 /area/facility_hallway/manager)
 "SQ" = (
 /obj/machinery/light/small{
-	dir = 8
+	dir = 8;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/pod/light,
 /area/city/outskirtsfactory)
@@ -5828,7 +5929,8 @@
 /area/facility_hallway/manager)
 "Ua" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -6143,8 +6245,9 @@
 /turf/open/floor/carpet/cyan,
 /area/department_main/manager)
 "Xg" = (
-/obj/machinery/light/small/red{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 8;
+	bulb_colour = "#FF3232"
 	},
 /obj/structure/sigsystem/connector{
 	dir = 1
@@ -6170,7 +6273,9 @@
 /obj/machinery/computer/crew{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light{
+	bulb_colour = "#FF3232"
+	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 7
 	},
@@ -6264,7 +6369,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -6368,7 +6474,8 @@
 /area/facility_hallway/manager)
 "YD" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/facility/dark,
@@ -6478,8 +6585,9 @@
 /turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "Zh" = (
-/obj/machinery/light/red{
-	dir = 1
+/obj/machinery/light{
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
@@ -6539,7 +6647,8 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4
+	dir = 4;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/facility_hallway/manager)
@@ -6573,7 +6682,8 @@
 /area/facility_hallway/manager)
 "ZV" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	bulb_colour = "#FF3232"
 	},
 /turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
@@ -13327,10 +13437,10 @@ oq
 Ve
 ar
 oq
-GY
+Bv
 pq
 vF
-KD
+jI
 vF
 vF
 vF
@@ -14098,13 +14208,13 @@ oq
 Ve
 Hr
 Ve
-gv
+GY
 mT
 sq
 mT
 mT
-jI
-Bv
+KD
+gv
 mT
 sq
 dF

--- a/_maps/map_files/generic/Manager.dmm
+++ b/_maps/map_files/generic/Manager.dmm
@@ -1269,7 +1269,7 @@
 	mouse_opacity = 0;
 	dir = 8
 	},
-/mob/living/simple_animal/hostile/ordeal/green_bot_big,
+/mob/living/simple_animal/hostile/ordeal/green_bot,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "jL" = (

--- a/_maps/map_files/generic/Manager.dmm
+++ b/_maps/map_files/generic/Manager.dmm
@@ -1637,6 +1637,11 @@
 /obj/structure/sigsystem/activator,
 /turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
+"mt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light,
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirtsfactory)
 "mu" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -1893,6 +1898,17 @@
 /obj/structure/sigsystem/connector{
 	dir = 8
 	},
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirtsfactory)
+"oa" = (
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
+	dir = 4
+	},
+/obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "ob" = (
@@ -2649,6 +2665,19 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/facility_hallway/manager)
+"tr" = (
+/obj/machinery/door/poddoor/shutters/indestructible{
+	lockpickable = 0;
+	resistance_flags = 64;
+	id = "furnaceaccess"
+	},
+/obj/structure/sigsystem/activator,
+/obj/structure/sigsystem/connector{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirtsfactory)
 "tD" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/sigsystem/tower/button{
@@ -3404,14 +3433,9 @@
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "zr" = (
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	mouse_opacity = 0;
-	dir = 4
+/obj/structure/railing/corner{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "zv" = (
@@ -4173,19 +4197,6 @@
 	dir = 1
 	},
 /turf/open/floor/pod/light,
-/area/city/outskirtsfactory)
-"Ft" = (
-/obj/machinery/door/poddoor/shutters/indestructible{
-	lockpickable = 0;
-	resistance_flags = 64;
-	id = "furnaceaccess"
-	},
-/obj/structure/sigsystem/activator,
-/obj/structure/sigsystem/connector{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "Fx" = (
 /obj/effect/turf_decal/siding/thinplating/light{
@@ -5340,12 +5351,13 @@
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "OV" = (
-/obj/structure/destructible/cult/forge{
-	resistance_flags = 64;
-	desc = "A forge used in crafting various parts.";
-	name = "forge"
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
+	dir = 10
 	},
-/obj/machinery/light,
 /turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "OZ" = (
@@ -5683,16 +5695,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/facility_hallway/manager)
-"RO" = (
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	mouse_opacity = 0;
-	dir = 10
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/city/outskirtsfactory)
 "RP" = (
 /obj/effect/turf_decal/siding/red/corner{
 	dir = 1
@@ -6213,12 +6215,6 @@
 "WN" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/plating/asteroid/basalt,
-/area/city/outskirtsfactory)
-"WQ" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "WS" = (
 /obj/effect/turf_decal/siding/blue{
@@ -13182,7 +13178,7 @@ dF
 Uq
 Ve
 co
-Ve
+mt
 dF
 dF
 dF
@@ -13439,7 +13435,7 @@ dF
 Ve
 rm
 co
-OV
+rm
 gv
 Ve
 ar
@@ -13448,7 +13444,7 @@ GY
 pq
 vF
 Xq
-RO
+OV
 sr
 sr
 sr
@@ -13705,7 +13701,7 @@ tb
 Ve
 DR
 Ve
-WQ
+zr
 XX
 Bv
 Bv
@@ -13954,7 +13950,7 @@ wQ
 oq
 oq
 Ve
-Ft
+tr
 oq
 Ve
 Ve
@@ -14218,7 +14214,7 @@ Ve
 GY
 mT
 yT
-zr
+oa
 mT
 co
 mT

--- a/_maps/map_files/generic/Manager.dmm
+++ b/_maps/map_files/generic/Manager.dmm
@@ -19088,7 +19088,7 @@ dF
 Jr
 dF
 xA
-sk
+lB
 lB
 Qn
 lB

--- a/_maps/map_files/generic/Manager.dmm
+++ b/_maps/map_files/generic/Manager.dmm
@@ -3404,11 +3404,15 @@
 /turf/open/floor/pod/dark,
 /area/city/outskirtsfactory)
 "zr" = (
-/obj/structure/sigsystem/connector{
-	dir = 4;
-	delay_time = 30
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
+	dir = 4
 	},
-/turf/open/floor/pod/dark,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "zv" = (
 /obj/structure/chair/comfy/black{
@@ -4169,6 +4173,19 @@
 	dir = 1
 	},
 /turf/open/floor/pod/light,
+/area/city/outskirtsfactory)
+"Ft" = (
+/obj/machinery/door/poddoor/shutters/indestructible{
+	lockpickable = 0;
+	resistance_flags = 64;
+	id = "furnaceaccess"
+	},
+/obj/structure/sigsystem/activator,
+/obj/structure/sigsystem/connector{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "Fx" = (
 /obj/effect/turf_decal/siding/thinplating/light{
@@ -5227,6 +5244,12 @@
 	dir = 4
 	},
 /obj/structure/table/glass,
+/obj/machinery/button/door/indestructible{
+	id = "disc_blast";
+	name = "External Elevator Opening";
+	req_access_txt = "20";
+	pixel_y = 7
+	},
 /turf/open/floor/carpet/cyan,
 /area/department_main/manager)
 "NH" = (
@@ -5660,6 +5683,16 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/facility_hallway/manager)
+"RO" = (
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
+	dir = 10
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirtsfactory)
 "RP" = (
 /obj/effect/turf_decal/siding/red/corner{
 	dir = 1
@@ -6112,7 +6145,7 @@
 /area/facility_hallway/manager)
 "Wc" = (
 /obj/structure/sigsystem/connector{
-	delay_time = 100;
+	delay_time = 30;
 	dir = 4
 	},
 /turf/closed/indestructible/syndicate,
@@ -6180,6 +6213,12 @@
 "WN" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/plating/asteroid/basalt,
+/area/city/outskirtsfactory)
+"WQ" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/city/outskirtsfactory)
 "WS" = (
 /obj/effect/turf_decal/siding/blue{
@@ -6250,17 +6289,16 @@
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
 "Xq" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 5
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
+	mouse_opacity = 0;
+	dir = 8
 	},
-/obj/machinery/button/door/indestructible{
-	id = "disc_blast";
-	name = "External Elevator Opening";
-	pixel_y = -25;
-	req_access_txt = "20"
-	},
-/turf/open/floor/carpet/cyan,
-/area/department_main/manager)
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirtsfactory)
 "Xs" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 9
@@ -13146,8 +13184,8 @@ Ve
 co
 Ve
 dF
-XO
-XO
+dF
+dF
 dF
 aP
 sr
@@ -13402,15 +13440,15 @@ Ve
 rm
 co
 OV
-dF
-dF
-dF
-dF
-aP
-sr
-sr
-sr
-sr
+gv
+Ve
+ar
+oq
+GY
+pq
+vF
+Xq
+RO
 sr
 sr
 sr
@@ -13659,15 +13697,15 @@ oq
 rB
 oq
 oQ
-gv
-Ve
-ar
+KD
 oq
-GY
-pq
-vF
-pq
-vF
+oq
+Ve
+tb
+Ve
+DR
+Ve
+WQ
 XX
 Bv
 Bv
@@ -13916,7 +13954,7 @@ wQ
 oq
 oq
 Ve
-KD
+Ft
 oq
 Ve
 Ve
@@ -14180,7 +14218,7 @@ Ve
 GY
 mT
 yT
-mT
+zr
 mT
 co
 mT
@@ -14195,7 +14233,7 @@ dF
 JV
 RI
 lB
-zr
+cU
 lB
 Fi
 cs
@@ -18167,7 +18205,7 @@ wy
 AV
 Qf
 PN
-Xq
+Sy
 NF
 Ao
 Gy

--- a/_maps/map_files/generic/Manager.dmm
+++ b/_maps/map_files/generic/Manager.dmm
@@ -4086,7 +4086,7 @@
 	},
 /obj/structure/sigsystem/connector{
 	dir = 1;
-	delay_time = 250
+	delay_time = 200
 	},
 /turf/open/floor/facility/dark,
 /area/city/outskirtsfactory)
@@ -4847,7 +4847,7 @@
 /area/city/outskirtsfactory)
 "Kk" = (
 /obj/structure/sigsystem/announcer{
-	message_range = 5;
+	message_range = 7;
 	message = "Unauthorized access detected. Door opening delayed."
 	},
 /turf/closed/indestructible/syndicate,
@@ -5870,6 +5870,7 @@
 /turf/open/floor/plating/asteroid/basalt,
 /area/city/outskirtsfactory)
 "TY" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/item/caution{
 	pixel_y = 7;
 	pixel_x = -3
@@ -13661,7 +13662,7 @@ oQ
 gv
 Ve
 ar
-TY
+oq
 GY
 pq
 vF
@@ -13921,7 +13922,7 @@ Ve
 Ve
 tb
 oq
-Ve
+TY
 pJ
 Ve
 co

--- a/code/game/objects/items/puzzle_pieces.dm
+++ b/code/game/objects/items/puzzle_pieces.dm
@@ -45,7 +45,7 @@
 	/// Make sure that the key has the same puzzle_id as the keycard door!
 	var/puzzle_id = null
 	/// Message that occurs when the door is opened
-	var/open_message = "The door beeps, and slides opens."
+	var/open_message = "The door beeps, and slides open."
 
 //Standard Expressions to make keycard doors basically un-cheeseable
 /obj/machinery/door/keycard/Bumped(atom/movable/AM)


### PR DESCRIPTION
# About The Pull Request

Tweaks several aspects of the Outskirts Factory, intended to address issues with the level design and enemies. Again.

Full list of changes:
## **ENEMIES:**
### Aegis of Answers:

Health: 600 (from 500)

## **LEVEL DESIGN:**
### Cargo Bay:
Decreased the timer for opening the way to the Foundry to 3 seconds (from 10) and removed the timer on the Aegis's room opening.

### Foundry:
Removed the sections where you can get pushed into lava. Enemies populate the hall to compensate for this.

### Main Room:
Removed the timer for the Aegis's rooms opening.

### Ambush Room:
Survival timer decreased to 15 seconds (from 25)

### Boss Arena/Vault:
The Denial of Concept now drops a keycard which is used to open the vault door, rather than the vault door being opened via a button on the wall next to it.

<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

# Why It's Good For The Game
The old level design is dogshit, as per usual with things I make, and the new enemies aren't quite as much of a threat as they probably should be. Also, you could steal the stuff from the vault without killing the boss first, which is super stinky. The changes here should ensure all these problems are mitigated or fixed outright, but knowing my work, it probably won't.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here


<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
tweak: Tweaked the level design of the Outskirts Factory to be more player-friendly
balance: slightly buffed the Aegis of Answers
:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
