### PR TITLE
Making Comb harmless with Mermaid Realization

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
@@ -333,9 +333,11 @@
 
 /obj/item/clothing/head/unrequited_crown/process()
 	if((love_cooldown < world.time) && loved && mermaid.workingflag != TRUE)
-		mermaid.datum_reference.qliphoth_change(-1)
-		new /obj/effect/temp_visual/heart(get_turf(loved))
-		to_chat(loved, span_warning("You feel as though you're forgetting someone..."))
+		var/obj/item/clothing/suit/armor/ego_gear/realization/forever/Z = loved.get_item_by_slot(ITEM_SLOT_OCLOTHING)
+		if(!istype(Z))
+			mermaid.datum_reference.qliphoth_change(-1)
+			new /obj/effect/temp_visual/heart(get_turf(loved))
+			to_chat(loved, span_warning("You feel as though you're forgetting someone..."))
 		love_cooldown = world.time + love_cooldown_time
 
 /obj/item/clothing/head/unrequited_crown/Destroy()


### PR DESCRIPTION
Added some lines in pisc_mermaid.dm to try and make it so that the comb is free for Together Forever realization users. 

## About The Pull Request

<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Makes the comb not breach mermaid when wearing the realization. However there's a slight issue, being that activating the special hat removes the comb but doesn't breach mermaid, but taking the comb off the ground afterward seems to breach her like usual. Maybe it needs to be fixed later?

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Now, wearing Together Forever allows you to wear the comb without needing to babysit Mermaid, making her the biggest fan! It makes the armour have a niche outside of being a big white armour. Reminder that petting the mermaid is still deadly though!

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
code: added some lines in pisc_mermaid.dm
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
