### PR TITLE
Stops suiciding as ordeals and teamkilling as Crimson ordeals

### DIFF
--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -219,7 +219,7 @@
 		if(SSmaptype.maptype in SSmaptype.lc_maps)
 			var/list/ongoing_ordeals = SSlobotomy_corp.current_ordeals
 			if(length(ongoing_ordeals) > 0)
-				for(var/datum/ordeal/ord in ongoing_ordeals)
+				for(var/datum/ordeal/ord as anything in ongoing_ordeals)
 					if(src in ord.ordeal_mobs)
 						ghostize(FALSE)
 						toggle_ai(AI_ON)

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -217,13 +217,11 @@
 	if(confirm == "Yes")
 		// On Facility mode, stop people from suiciding if they possess a mob that's part of an Ordeal, during an Ordeal. Just ghost them.
 		if(SSmaptype.maptype in SSmaptype.lc_maps)
-			var/list/ongoing_ordeals = SSlobotomy_corp.current_ordeals
-			if(length(ongoing_ordeals) > 0)
-				for(var/datum/ordeal/ord as anything in ongoing_ordeals)
-					if(src in ord.ordeal_mobs)
-						ghostize(FALSE)
-						toggle_ai(AI_ON)
-						return FALSE
+			for(var/datum/ordeal/ord as anything in SSlobotomy_corp.current_ordeals)
+				if(src in ord.ordeal_mobs)
+					ghostize(FALSE)
+					toggle_ai(AI_ON)
+					return FALSE
 		set_suicide(TRUE)
 		visible_message("<span class='danger'>[src] begins to fall down. It looks like [p_theyve()] lost the will to live.</span>", \
 						"<span class='userdanger'>[src] begins to fall down. It looks like [p_theyve()] lost the will to live.</span>")

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -231,6 +231,14 @@
 	log_message("(job: [src.job ? "[src.job]" : "None"]) committed suicide", LOG_ATTACK)
 
 /mob/living/proc/canSuicide()
+	// On Facility mode, stop people from suiciding if they possess a mob that's part of an Ordeal, during an Ordeal.
+	if(SSmaptype.maptype in SSmaptype.lc_maps)
+		var/list/ongoing_ordeals = SSlobotomy_corp.current_ordeals
+		if(length(ongoing_ordeals) > 0)
+			for(var/datum/ordeal/ord in ongoing_ordeals)
+				if(src in ord.ordeal_mobs)
+					to_chat(src, span_warning("No. Stand and fight.")) // You would just get automatically banned if you try to do this as a Crimson ordeal if I had my way
+					return FALSE
 	var/area/A = get_area(src)
 	if(A.area_flags & BLOCK_SUICIDE)
 		to_chat(src, "<span class='warning'>You can't commit suicide here! You can ghost if you'd like.</span>")

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -215,6 +215,15 @@
 	if(!canSuicide())
 		return
 	if(confirm == "Yes")
+		// On Facility mode, stop people from suiciding if they possess a mob that's part of an Ordeal, during an Ordeal. Just ghost them.
+		if(SSmaptype.maptype in SSmaptype.lc_maps)
+			var/list/ongoing_ordeals = SSlobotomy_corp.current_ordeals
+			if(length(ongoing_ordeals) > 0)
+				for(var/datum/ordeal/ord in ongoing_ordeals)
+					if(src in ord.ordeal_mobs)
+						ghostize(FALSE)
+						toggle_ai(AI_ON)
+						return FALSE
 		set_suicide(TRUE)
 		visible_message("<span class='danger'>[src] begins to fall down. It looks like [p_theyve()] lost the will to live.</span>", \
 						"<span class='userdanger'>[src] begins to fall down. It looks like [p_theyve()] lost the will to live.</span>")
@@ -231,14 +240,6 @@
 	log_message("(job: [src.job ? "[src.job]" : "None"]) committed suicide", LOG_ATTACK)
 
 /mob/living/proc/canSuicide()
-	// On Facility mode, stop people from suiciding if they possess a mob that's part of an Ordeal, during an Ordeal.
-	if(SSmaptype.maptype in SSmaptype.lc_maps)
-		var/list/ongoing_ordeals = SSlobotomy_corp.current_ordeals
-		if(length(ongoing_ordeals) > 0)
-			for(var/datum/ordeal/ord in ongoing_ordeals)
-				if(src in ord.ordeal_mobs)
-					to_chat(src, span_warning("No. Stand and fight.")) // You would just get automatically banned if you try to do this as a Crimson ordeal if I had my way
-					return FALSE
 	var/area/A = get_area(src)
 	if(A.area_flags & BLOCK_SUICIDE)
 		to_chat(src, "<span class='warning'>You can't commit suicide here! You can ghost if you'd like.</span>")

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/crimson.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/crimson.dm
@@ -137,6 +137,15 @@
 	var/mob_spawn_amount = 3
 	var/being_gibbed = FALSE
 
+/// Forbidden from attacking other Crimson Ordeals (or itself)
+/mob/living/simple_animal/hostile/ordeal/crimson_noon/AttackingTarget(atom/attacked_target)
+	if(ismob(attacked_target))
+		var/mob/victim = attacked_target
+		if(faction_check_mob(victim))
+			to_chat(src, span_warning("Attacking your fellow jesters simply isn't in your nature, no matter how funny it is."))
+			return FALSE
+	. = ..()
+
 /mob/living/simple_animal/hostile/ordeal/crimson_noon/gib()
 	//Please dont spam the animation sir
 	if(being_gibbed)


### PR DESCRIPTION
## About The Pull Request
Some particularly annoying people suicide as Crimson ordeals during playables, this PR disables suiciding on Facility mode for mobs which are part of an ongoing ordeal, and prevents Crimson ordeals from attacking themselves or eachother.
The attempt to suicide will instead ghost you and re enable the mob's AI.
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Shuts down a very annoying exploit during a rare station trait
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
tweak: Mobs in an active Ordeal's mob list cannot suicide in Facility mode.
tweak: Crimson Ordeals can no longer attack eachother or themselves.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
