### PR TITLE
Moves Abnormality Blitz from Station Traits to Gamespeed Vote

### DIFF
--- a/ModularLobotomy/representative/research/lcorp.dm
+++ b/ModularLobotomy/representative/research/lcorp.dm
@@ -126,7 +126,7 @@ GLOBAL_LIST_EMPTY(lcorp_upgrades)
 /datum/data/lc13research/clerkbuff/ResearchEffect(obj/structure/representative_console/requester)
 	for(var/mob/living/carbon/human/H in GLOB.player_list)
 		if(H?.mind?.assigned_role in GLOB.service_positions)
-			if(SSmaptype.chosen_trait == FACILITY_TRAIT_ABNO_BLITZ)
+			if(SSlobotomy_corp.BlitzActive())
 				H.set_attribute_limit(60)
 				H.adjust_all_attribute_levels(60)
 				return

--- a/code/__DEFINES/facility_traits.dm
+++ b/code/__DEFINES/facility_traits.dm
@@ -3,7 +3,6 @@
 #define FACILITY_TRAIT_MOBA_AGENTS "MOBA Agents"
 #define FACILITY_TRAIT_CRITICAL_HITS "Critical Hits"
 #define FACILITY_TRAIT_DEPARTMENTAL_BUFFS "Department Agents"
-#define FACILITY_TRAIT_ABNO_BLITZ "Abno Blitz"
 #define FACILITY_TRAIT_WORKING_CLERKS "Working Clerks"
 #define FACILITY_TRAIT_PLAYABLES "Playable Abnormalities"
 #define FACILITY_TRAIT_CALLBACK "Callback"

--- a/code/controllers/subsystem/abnormality_queue.dm
+++ b/code/controllers/subsystem/abnormality_queue.dm
@@ -57,9 +57,6 @@ SUBSYSTEM_DEF(abnormality_queue)
 		flags |= SS_NO_FIRE
 		return ..() // Sleepy time
 
-	if(SSmaptype.chosen_trait == FACILITY_TRAIT_ABNO_BLITZ)
-		next_abno_spawn_time/=2
-
 	RegisterSignal(SSdcs, COMSIG_GLOB_ORDEAL_END, PROC_REF(OnOrdealEnd))
 	next_abno_spawn_time -= min(2, rooms_start * 0.05) MINUTES // 20 rooms will decrease wait time by 1 Minute
 	return ..()
@@ -98,7 +95,7 @@ SUBSYSTEM_DEF(abnormality_queue)
 		return
 
 	//For the blitz gamemode, only pick Waw and Aleph enemies. There should only be 80+ agents here
-	if(SSmaptype.chosen_trait == FACILITY_TRAIT_ABNO_BLITZ)
+	if(SSlobotomy_corp.BlitzActive())
 		if(spawned_abnos >= rooms_start * 0.5)
 			available_levels = list(WAW_LEVEL, ALEPH_LEVEL)
 		else

--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -164,15 +164,12 @@ SUBSYSTEM_DEF(lobotomy_corp)
 		if(O.AbleToRun())
 			all_ordeals[O.level] += O
 
-	if(SSmaptype.chosen_trait == FACILITY_TRAIT_ABNO_BLITZ)
-		next_ordeal_level = 3
-		ordeal_timelock = list(0, 0, 30 MINUTES, 50 MINUTES, 0, 0, 0, 0, 0)
 	RollOrdeal()
 	return TRUE
 
 // Called when any normal midnight ends
 /datum/controller/subsystem/lobotomy_corp/proc/PickPotentialSuppressions(announce = FALSE, extra_core = FALSE)
-	if(SSmaptype.chosen_trait == FACILITY_TRAIT_ABNO_BLITZ)
+	if(SSlobotomy_corp.BlitzActive())
 		priority_announce("This shift is a 'Blitz' Shift. Cores have been disabled.", \
 						"Core Suppression", sound = 'sound/machines/dun_don_alert.ogg')
 		return
@@ -326,7 +323,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 			A.current.OnQliphothEvent()
 	var/ran_ordeal = FALSE
 	if(qliphoth_state + 1 >= next_ordeal_time) // If ordeal is supposed to happen on the meltdown after that one
-		if(SSmaptype.chosen_trait != FACILITY_TRAIT_ABNO_BLITZ)
+		if(SSlobotomy_corp.BlitzActive())
 			if(istype(next_ordeal) && ordeal_timelock[next_ordeal.level] > ROUNDTIME) // And it's on timelock
 				next_ordeal_time += 1 // So it does not appear on the ordeal monitors until timelock is off
 	if(qliphoth_state >= next_ordeal_time)
@@ -494,31 +491,14 @@ SUBSYSTEM_DEF(lobotomy_corp)
 /// Proc called to adjust the gamespeed, hastens abnormality arrival time, sets new timelocks and recalculates next ordeal time.
 /datum/controller/subsystem/lobotomy_corp/proc/AdjustGamespeed(datum/gamespeed_setting/new_gamespeed)
 	if(!new_gamespeed) // If this somehow gets called with a null argument...
+		warning("GAMESPEED: Tried to adjust gamespeed with a null gamespeed setting.")
 		return FALSE
 	if(gamespeed.speed_coefficient <= 0 || new_gamespeed.speed_coefficient <= 0) // Checking we don't get something that would really mess things up like negative or 0 value
+		warning("GAMESPEED: Tried to adjust gamespeed from, or to a gamespeed setting with a negative speed coefficient.")
 		return FALSE
 
-	// Timelocks: we need to do these before setting the gamespeed so we can undo potential changes to the original timelock values
-	// As in, original Dawn timelock is 12000. If the speed gets changed by 1.25x, it will go down to 9600. We want to change it back to 12000 before applying
-	// any new speed.
-	var/list/new_timelocks = list()
-	for(var/current_timelock in ordeal_timelock)
-		var/modified_timelock = ((current_timelock) * (gamespeed.speed_coefficient)) * (1 / new_gamespeed.speed_coefficient)
-		new_timelocks.Add(modified_timelock)
+	new_gamespeed.ApplyChanges()
 
-	ordeal_timelock = new_timelocks
-
-	// Also set next abno spawn time back to whatever it was.
-	SSabnormality_queue.next_abno_spawn_time *= gamespeed.speed_coefficient
-
-	// Now we can set the gamespeed. We don't need the old one anymore.
-	gamespeed = new_gamespeed
-
-	// Ordeal time
-	SetNextOrdealTime(TRUE)
-
-	// Abno arrival speed
-	SSabnormality_queue.next_abno_spawn_time *= (1 / gamespeed.speed_coefficient)
 
 /// Proc that checks to see if there's a Manager in the round. If there isn't, allows any crewmember to start a Core Suppression.
 // Important: This is called by ticker.dm with a timer set on roundstart
@@ -536,3 +516,6 @@ SUBSYSTEM_DEF(lobotomy_corp)
 						This means any of our employees may begin a Suppression. The restrictions will remain lifted until a Manager for this shift awakens. Our employees are encouraged to Face the Fear, and Build the Future.",\
 						"Core Selection Override", 'sound/machines/dun_don_alert.ogg')
 	return TRUE
+
+/datum/controller/subsystem/lobotomy_corp/proc/BlitzActive()
+	return istype(gamespeed, /datum/gamespeed_setting/abno_blitz)

--- a/code/controllers/subsystem/maptype.dm
+++ b/code/controllers/subsystem/maptype.dm
@@ -22,13 +22,12 @@ SUBSYSTEM_DEF(maptype)
 
 	//LC13 Gamemode Traits
 	var/list/lc_trait = list(
-						//Actual traits						
+						//Actual traits
 						FACILITY_TRAIT_MOBA_AGENTS = 10, 		//Agents pick a MOBA class
 						FACILITY_TRAIT_CRITICAL_HITS = 10,		//EGO can Critical hit.
 						FACILITY_TRAIT_DEPARTMENTAL_BUFFS = 10,	//Departmental Agent Buffs
 						FACILITY_TRAIT_XP_MOD = 7,				//XP works differently on HP/SP
 						FACILITY_TRAIT_DARK_SOULS = 5,			//You get estus flasks and rolling
-						FACILITY_TRAIT_ABNO_BLITZ = 3,			//The game is significantly Faster, starts after noon.
 						FACILITY_TRAIT_NO_EGO = 3,				//No EGO, works like our events with double the outputs and refineries
 						FACILITY_TRAIT_PROSTHETICS = 3,			//There's a new prosthetics vendor!
 

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -103,20 +103,6 @@ SUBSYSTEM_DEF(vote)
 					if(choices[default.player_facing_name] >= greatest_votes)
 						greatest_votes = choices[default.player_facing_name]
 
-
-			// Non voters will automatically count as votes for default gamespeed.
-			else if(mode == "gamespeed")
-				var/datum/gamespeed_setting/default
-				for(var/datum/gamespeed_setting/g_speed in SSlobotomy_corp.available_gamespeeds)
-					if(g_speed.player_facing_name == "Default Speed (1x)")
-						default = g_speed
-						break
-				if(default)
-					choices[default.player_facing_name] += length(non_voters)
-					if(choices[default.player_facing_name] >= greatest_votes)
-						greatest_votes = choices[default.player_facing_name]
-
-
 	. = list()
 	if(greatest_votes)
 		for(var/option in choices)
@@ -199,9 +185,7 @@ SUBSYSTEM_DEF(vote)
 					if((. == setting.player_facing_name) && (SSlobotomy_corp.gamespeed.player_facing_name != .))
 						// Adjust the gamespeed to the new one and announce it.
 						SSlobotomy_corp.AdjustGamespeed(setting)
-						priority_announce("Personnel must be advised: As a result of changes in internal Enkephalin filtering procedures, Ordeal events for this shift will occur within fewer meltdowns than is the norm. \
-						To compensate for this, Extraction has agreed to speed up Abnormality delivery accordingly.",\
-						"Ordeal Frequency Notice", 'sound/machines/dun_don_alert.ogg')
+
 	if(restart)
 		var/active_admins = FALSE
 		for(var/client/C in GLOB.admins + GLOB.deadmins)

--- a/code/datums/gamespeed.dm
+++ b/code/datums/gamespeed.dm
@@ -15,6 +15,8 @@
 	var/meltdowns_per_ordeal_adjustment = alist(1 = 0, 2 = 0, 3 = 0, 4 = 0)
 	/// Can this setting be voted for?
 	var/available_setting = TRUE
+	var/applied_announcement = "Personnel must be advised: Enkephalin filtering procedures have been shifted back to standard protocols. Ordeal events and Abnormality meltdowns will return to standard frequency."
+	var/applied_sfx = 'sound/machines/dun_don_alert.ogg'
 
 /datum/gamespeed_setting/fast
 	player_facing_name = "Fast Speed (1.25x)"
@@ -22,6 +24,8 @@
 	speed_coefficient = 1.25
 	minimum_ordeal_gap = alist(1 = 3, 2 = 4, 3 = 4, 4 = 6)
 	meltdowns_per_ordeal_adjustment = alist(1 = 0, 2 = -1, 3 = -1, 4 = -2)
+	applied_announcement = "Personnel must be advised: As a result of changes in internal Enkephalin filtering procedures, Ordeal events for this shift will occur within fewer meltdowns than is the norm. \
+	To compensate for this, Extraction has agreed to speed up Abnormality delivery accordingly."
 
 /// For testing
 /datum/gamespeed_setting/ultrafast
@@ -30,3 +34,88 @@
 	speed_coefficient = 2
 	minimum_ordeal_gap = alist(1 = 2, 2 = 3, 3 = 3, 4 = 4)
 	meltdowns_per_ordeal_adjustment = alist(1 = 0, 2 = -2, 3 = -3, 4 = -4)
+	applied_announcement = "Personnel must be advised: Experimental Enkephalin filtering procedures have been enabled, optimizing for speed. \
+	As a side effect, the resulting accumulation of impurities will result in significantly faster Ordeal events. Abnormalities will be delivered with twice as much speed so you may prepare E.G.O. to face them. This will be rough. Good luck."
+// ------------- PROCS -------------
+/datum/gamespeed_setting/proc/ApplyChanges()
+	// Timelocks: we need to do these before setting the gamespeed so we can undo potential changes to the original timelock values
+	// As in, original Dawn timelock is 12000. If the speed gets changed by 1.25x, it will go down to 9600. We want to change it back to 12000 before applying
+	// any new speed.
+	HandleTimelocks()
+
+	// Also set next abno spawn time back to whatever it was, then to the correctly modified time.
+	HandleAbnoSpawnTime()
+
+	// Now we can set the gamespeed. We don't need the old one anymore.
+	SSlobotomy_corp.gamespeed = src
+
+	// Ordeal time
+	HandleOrdeals()
+
+	priority_announce(applied_announcement, "Ordeal Frequency Notice", applied_sfx)
+
+/datum/gamespeed_setting/proc/HandleTimelocks()
+	var/list/new_timelocks = list()
+	for(var/current_timelock in SSlobotomy_corp.ordeal_timelock)
+		var/modified_timelock = ((current_timelock) * (SSlobotomy_corp.gamespeed.speed_coefficient)) * (1 / src.speed_coefficient)
+		new_timelocks.Add(modified_timelock)
+
+	SSlobotomy_corp.ordeal_timelock = new_timelocks
+
+/datum/gamespeed_setting/proc/HandleAbnoSpawnTime()
+	SSabnormality_queue.next_abno_spawn_time *= SSlobotomy_corp.gamespeed.speed_coefficient
+	SSabnormality_queue.next_abno_spawn_time *= (1 / src.speed_coefficient)
+
+/datum/gamespeed_setting/proc/HandleOrdeals()
+	SSlobotomy_corp.SetNextOrdealTime(TRUE)
+
+// ------------- ABNO BLITZ -------------
+/// This one has a bunch of snowflake behaviour, it's not a true game speed setting. It's an adaptation of a former station trait called Abno Blitz.
+/// In essence, it skips Dawn and Noon, ups everyone's stats, speeds up Abno arrivals, and forces only WAW+ abnormalities.
+/datum/gamespeed_setting/abno_blitz
+	player_facing_name = "ABNO BLITZ"
+	available_setting = TRUE
+	speed_coefficient = 2
+	applied_announcement = "Personnel must be advised: Due to a disaster in another branch, this Facility has been requisitioned to hold their most dangerous Abnormalities while repairs are performed, as well as the more volatile specimens already shipped by the Logistics division. \n\n\
+	Enhancement bullets have been applied to all personnel. You will be receiving one single ZAYIN - all other Abnormalities will be WAW or ALEPH threat class. Prepare for a Dusk Ordeal.\n\n\
+	The Extraction and Architecture Departments wish you the best of luck. Face the Fear, Build the Future."
+	applied_sfx = 'sound/effects/suppression.ogg'
+	var/list/job_minimum_stats = list(/datum/job/agent = 80, /datum/job/suppression = 80, /datum/job/command = 60, /datum/job/assistant = 40)
+
+/datum/gamespeed_setting/abno_blitz/HandleTimelocks()
+	SSlobotomy_corp.ordeal_timelock = list(0, 0, 30 MINUTES, 50 MINUTES, 0, 0, 0, 0, 0)
+
+/datum/gamespeed_setting/abno_blitz/HandleOrdeals()
+	SSlobotomy_corp.next_ordeal_level = 3
+	SSlobotomy_corp.RollOrdeal()
+
+/datum/gamespeed_setting/abno_blitz/ApplyChanges()
+	. = ..()
+	HandleExistingHumanStatBuffs()
+
+/datum/gamespeed_setting/abno_blitz/proc/HandleExistingHumanStatBuffs()
+	for(var/mob/living/carbon/human/person_that_already_exists in GLOB.player_list)
+		if(person_that_already_exists.stat >= DEAD)
+			continue
+		if(!(person_that_already_exists.mind))
+			continue
+
+		// Get their job and compare the job's minimum Blitz stats to what they already have.
+		var/datum/job/wageslave_specialization = SSjob.name_occupations[person_that_already_exists.mind.assigned_role]
+		for(var/evaluating_job_datum_match in job_minimum_stats)
+			if(!istype(wageslave_specialization, evaluating_job_datum_match))
+				continue
+
+			// Raise all their attribute limits and levels as appropiate.
+			var/minimum_stat_level = job_minimum_stats[evaluating_job_datum_match]
+			for(var/attr in person_that_already_exists.attributes)
+				var/datum/attribute/current_attr_datum = person_that_already_exists.attributes[attr]
+				var/current_attr_limit = current_attr_datum.level_limit
+				if(current_attr_limit < minimum_stat_level)
+					person_that_already_exists.adjust_attribute_limit(minimum_stat_level-current_attr_limit) // weird: this affects all attributes. thankfully the conditional should stop us from stacking this
+				var/current_attr_level = get_raw_level(person_that_already_exists, attr)
+				if(current_attr_level < minimum_stat_level)
+					person_that_already_exists.adjust_attribute_level(attr, minimum_stat_level-current_attr_level)
+			break
+
+

--- a/code/modules/jobs/job_types/agent.dm
+++ b/code/modules/jobs/job_types/agent.dm
@@ -123,7 +123,7 @@
 	if(GLOB.lobotomy_damages)//Enkephalin Rush baby!
 		facility_full_percentage = 100 * (GLOB.lobotomy_repairs / GLOB.lobotomy_damages)
 
-	if(SSmaptype.chosen_trait == FACILITY_TRAIT_ABNO_BLITZ)	//blitz needs you with higher stats
+	if(SSlobotomy_corp.BlitzActive())	//blitz needs you with higher stats as a latejoiner
 		set_attribute *= 4
 
 	else

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -50,17 +50,16 @@ GLOBAL_LIST_EMPTY(spawned_clerks)
 	else	//Don't buff them if they can work jesus
 		outfit_owner.set_attribute_limit(130)
 
-	switch(SSmaptype.chosen_trait)
-		if(FACILITY_TRAIT_ABNO_BLITZ)
-			outfit_owner.set_attribute_limit(40)
-			outfit_owner.adjust_all_attribute_levels(40)
-		if(FACILITY_TRAIT_DARK_SOULS)
-			outfit_owner.equip_to_slot_or_del(new /obj/item/estus(outfit_owner), ITEM_SLOT_HANDS, TRUE)
+	if(SSlobotomy_corp.BlitzActive())
+		outfit_owner.set_attribute_limit(40)
+		outfit_owner.adjust_all_attribute_levels(40)
 
+	if(SSmaptype.chosen_trait == FACILITY_TRAIT_DARK_SOULS)
+		outfit_owner.equip_to_slot_or_del(new /obj/item/estus(outfit_owner), ITEM_SLOT_HANDS, TRUE)
 
 	for(var/upgradecheck in GLOB.lcorp_upgrades)
 		if(upgradecheck == "Clerk Buff")
-			if(SSmaptype.chosen_trait == FACILITY_TRAIT_ABNO_BLITZ)
+			if(SSlobotomy_corp.BlitzActive())
 				outfit_owner.set_attribute_limit(60)
 				outfit_owner.adjust_all_attribute_levels(60)
 				return

--- a/code/modules/jobs/job_types/command.dm
+++ b/code/modules/jobs/job_types/command.dm
@@ -54,11 +54,11 @@
 	ADD_TRAIT(outfit_owner, TRAIT_ATTRIBUTES_VISION, JOB_TRAIT)
 	outfit_owner.grant_language(/datum/language/bong, TRUE, FALSE, LANGUAGE_MIND) //So they can understand the bong-bong but not speak it
 
-	switch(SSmaptype.chosen_trait)
-		if(FACILITY_TRAIT_ABNO_BLITZ)
-			outfit_owner.adjust_all_attribute_levels(40)
-		if(FACILITY_TRAIT_DARK_SOULS)
-			outfit_owner.equip_to_slot_or_del(new /obj/item/estus(outfit_owner), ITEM_SLOT_HANDS, TRUE)
+	if(SSlobotomy_corp.BlitzActive())
+		outfit_owner.adjust_all_attribute_levels(40)
+
+	if(SSmaptype.chosen_trait == FACILITY_TRAIT_DARK_SOULS)
+		outfit_owner.equip_to_slot_or_del(new /obj/item/estus(outfit_owner), ITEM_SLOT_HANDS, TRUE)
 
 /datum/outfit/job/command/extraction
 	name = "Extraction Officer"

--- a/code/modules/jobs/job_types/suppression.dm
+++ b/code/modules/jobs/job_types/suppression.dm
@@ -40,7 +40,7 @@
 	// how full the facility is, from 0 abnormalities out of 24 cells being 0% and 24/24 cells being 100%
 
 
-	if(SSmaptype.chosen_trait == FACILITY_TRAIT_ABNO_BLITZ)	//Need more stats during abno blitz.
+	if(SSlobotomy_corp.BlitzActive())	//Need more stats during abno blitz.
 		set_attribute *= 4
 		set_attribute += GetFacilityUpgradeValue(UPGRADE_AGENT_STATS)
 

--- a/code/modules/ordeals/_ordeal.dm
+++ b/code/modules/ordeals/_ordeal.dm
@@ -61,7 +61,7 @@
 	SSlobotomy_corp.completed_challenges += akward_record_formatting
 	SSlobotomy_corp.completed_challenges[akward_record_formatting] = level
 
-	if(SSmaptype.chosen_trait != FACILITY_TRAIT_ABNO_BLITZ)
+	if(!SSlobotomy_corp.BlitzActive())
 		SSlobotomy_corp.ordeal_stats += 5
 	for(var/mob/living/carbon/human/person as anything in SSabnormality_queue.active_suppression_agents)
 		if(!istype(person) || QDELETED(person)) // gibbed or cryo'd, we no longer care about them


### PR DESCRIPTION
## About The Pull Request
1. Refactors Gamespeed to be a bit more modular and over-rideable and whatnot
2. Blitz is removed as a Trait and instead becomes a votable Game Speed at the start of rounds.
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People don't always want to play Blitz and it's a bit too drastic of a gameplay change to JUST be a trait.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
refactor: Game Speed Settings now have an ApplyChange proc and a few others which handle their changes to the different LobCorp/Abno subsystems instead of doing it in SSlobotomy_corp.
tweak: Abno Blitz removed from Station Traits and made into a Game Speed, should work exactly the same as before.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
