### PR TITLE
Nosferatu bloodpack diet

### DIFF
--- a/code/game/machinery/computer/extraction_cargo.dm
+++ b/code/game/machinery/computer/extraction_cargo.dm
@@ -66,6 +66,7 @@
 		new /datum/data/extraction_cargo("Orange Tree Flamer",			/obj/item/ego_weapon/ranged/flammenwerfer,							500, CAT_MEDICAL) = 1,
 		new /datum/data/extraction_cargo("Prosthetic Limb Crate ",		/obj/structure/closet/crate/freezer/surplus_limbs,					500, CAT_MEDICAL) = 1,
 		new /datum/data/extraction_cargo("Assorted Medi-Pen Kit ",		/obj/item/storage/firstaid/revival,									500, CAT_MEDICAL) = 1,
+		new /datum/data/extraction_cargo("Blood Pack (O-) ",				/obj/item/reagent_containers/blood/o_minus,							50, CAT_MEDICAL)  = 1,
 
 		//Resources - Raw PE, ETC. Abnochem stuff goes here too. This is one use items to further LC13 systems
 		new /datum/data/extraction_cargo("Blue Filter ",				/obj/item/stack/refiner_filter/blue,								5, CAT_RESOURCE) = 1,

--- a/code/game/machinery/computer/extraction_cargo.dm
+++ b/code/game/machinery/computer/extraction_cargo.dm
@@ -66,7 +66,7 @@
 		new /datum/data/extraction_cargo("Orange Tree Flamer",			/obj/item/ego_weapon/ranged/flammenwerfer,							500, CAT_MEDICAL) = 1,
 		new /datum/data/extraction_cargo("Prosthetic Limb Crate ",		/obj/structure/closet/crate/freezer/surplus_limbs,					500, CAT_MEDICAL) = 1,
 		new /datum/data/extraction_cargo("Assorted Medi-Pen Kit ",		/obj/item/storage/firstaid/revival,									500, CAT_MEDICAL) = 1,
-		new /datum/data/extraction_cargo("Blood Pack (O-) ",				/obj/item/reagent_containers/blood/o_minus,							50, CAT_MEDICAL)  = 1,
+		new /datum/data/extraction_cargo("Blood Pack (O-) ",			/obj/item/reagent_containers/blood/o_minus,							50, CAT_MEDICAL)  = 1,
 
 		//Resources - Raw PE, ETC. Abnochem stuff goes here too. This is one use items to further LC13 systems
 		new /datum/data/extraction_cargo("Blue Filter ",				/obj/item/stack/refiner_filter/blue,								5, CAT_RESOURCE) = 1,

--- a/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
@@ -60,6 +60,8 @@
 	var/last_drawn = null
 	var/last_drawn_check = 0
 	var/failed = FALSE
+	/// Bloodpacks offered to Nosferatu must have at least this volume of blood in them to be accepted.
+	var/bloodpack_min_volume = 120
 
 	// Breach stuff
 	var/bloodlust = 4
@@ -220,6 +222,7 @@
 			user.adjustBruteLoss(999)
 			AdjustThirst(user.blood_volume) // gain up to 2000 blood by draining this poor sod dry
 			user.Drain()
+	failed = FALSE
 
 /mob/living/simple_animal/hostile/abnormality/nosferatu/examine(mob/user)
 	. = ..()
@@ -234,6 +237,42 @@
 			if(3)
 				shown_value = span_nicegreen("Looks like it's had enough for now.")
 		. += shown_value
+
+/// You can feed a bloodpack to Nosferatu to reset its 'same-feeder-instakill' mechanic.
+/mob/living/simple_animal/hostile/abnormality/nosferatu/attackby(obj/O, mob/user, params)
+	// Throughout we avoid returning ..() for all the bloodpack behaviour since this proc is also used for abnochem. We only call ..() when we're sure we're not dealing with a bloodpack
+	if(IsContained() && istype(O, /obj/item/reagent_containers/blood))
+		var/obj/item/reagent_containers/blood/pack = O
+		var/datum/reagents/the_chems = pack.reagents
+		if(!the_chems)
+			return
+
+		var/datum/reagent/blood_datum = the_chems.has_reagent(/datum/reagent/blood, null)
+		var/how_much_blood = (blood_datum ? blood_datum.volume : 0)
+		if(!(how_much_blood >= bloodpack_min_volume))
+			to_chat(user, span_warning("There isn't enough blood in this pack ([how_much_blood]u offered / [bloodpack_min_volume]u required)! Nosferatu is likelier to go for your neck if you offer it..."))
+			return
+
+		// If Nosferatu is at Qlip 1 or 2, and you have >= 150u of blood, you feed it all the blood.
+		if(datum_reference.qliphoth_meter < 3)
+			AdjustThirst(how_much_blood * 0.5) // It just isn't the same.
+			// Resets this damn mechanic
+			last_drawn = null
+			last_drawn_check = 0
+
+			// Say goodbye to the blood
+			the_chems.remove_reagent(/datum/reagent/blood, 9999)
+
+			// Feedback
+			playsound(get_turf(src), 'sound/abnormalities/nosferatu/bloodcollect.ogg', 35, FALSE)
+			visible_message(span_warning("[src] accepts the offering of blood and drains it in an instant."))
+			to_chat(user, span_nicegreen("It won't be sated by this, but at least the taste of live blood has been washed away. [src] should be safe to work with once again."))
+			return
+		else
+			to_chat(user, span_warning("Nosferatu is well-fed, and won't accept subpar blood like this. Wait for it to get thirstier before offering a bloodpack."))
+			return
+	. = ..()
+
 
 // Breach
 /mob/living/simple_animal/hostile/abnormality/nosferatu/BreachEffect(mob/living/carbon/human/user, breach_type)

--- a/code/modules/paperwork/records/info/waw.dm
+++ b/code/modules/paperwork/records/info/waw.dm
@@ -343,6 +343,7 @@
 		"When the work result was Bad, the employee was forcibly drained of a moderate amount of blood.",
 		"When repression work was succesfully performed, the level of thirst increased but blood was not drawn.",
 		"If the same employee was drained of blood 3 times in a row, they were forcibly drained of a lethal amount of blood.",
+		"Feeding a bloodpack to Nosferatu seems to \"wash away\" the taste of the previous employee, restarting the counter for a lethal draining of blood.",
 		"When given far too much blood, the abnormality breached containment in a frenzy.",
 		"While Nosferatu is escaping, it will show sensitive reactions to blood. Suppression becomes difficult if blood is readily accessible to this abnormality.")
 	abno_breach_damage_type = "Red/Black"
@@ -617,7 +618,7 @@
 		"Attachment" = "Very Low",
 		"Repression" = "Low | Low | Low | Common | Common"
 	)
-	
+
 //400 Roses
 /obj/item/paper/fluff/info/waw/four_hundred_roses
 	abno_type = /mob/living/simple_animal/hostile/abnormality/roses_waw

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -29,7 +29,7 @@
 	if(labelled)
 		return
 
-	name = "blood_pack[blood_type ? " - [blood_type]" : ""]"
+	name = "blood pack[blood_type ? " - [blood_type]" : ""]"
 
 /obj/item/reagent_containers/blood/random
 	icon_state = "random_bloodpack"


### PR DESCRIPTION
## About The Pull Request
1. Fixes a bug wherein failing a Nosferatu work would mark all future workers, regardless of worktype or success, for being fed on.
2. You can now **feed Nosferatu blood packs** with at least 120u of blood in them, this doesn't really give it much blood but it does **reset the 'lethal drain' work mechanic**. So, you can let Nosferatu feed on you twice, then feed it a bloodpack, and feed on you twice again, and it won't kill you.
3. You can now **buy blood packs at Cargo for 50 PE**, specifically O- blood type. However you can actually use **any** blood type for Nosferatu and you can fill up empty blood packs if need be.
4. Blood packs no longer have an underscore in their name
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the abno less of a criminal in solo runs.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
tweak: You can now buy blood packs (O-) at the Corporate Trade Console for 50 PE.
fix: Nosferatu failed works no longer cause future works to all result in a drain regardless of other factors.
add: You can now feed a blood pack with at least 120u of blood to Nosferatu, in exchange for resetting the lethal drain mechanic. Half of that blood will also go towards its bloodfeast component.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
