### PR TITLE
Makes Midnight Crimson Spawned Noons and Dusks not reproduce on death.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/crimson.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/crimson.dm
@@ -131,6 +131,7 @@
 	damage_coeff = list(RED_DAMAGE = 0.6, WHITE_DAMAGE = 1.2, BLACK_DAMAGE = 1.2, PALE_DAMAGE = 1.5)
 	blood_volume = BLOOD_VOLUME_NORMAL
 	ordeal_remove_ondeath = FALSE
+	var/spawn_clowns = TRUE
 	var/clown_derivitive = /mob/living/simple_animal/hostile/ordeal/crimson_clown
 
 	/// How many mobs we spawn on death
@@ -144,7 +145,7 @@
 		if(faction_check_mob(victim))
 			to_chat(src, span_warning("Attacking your fellow jesters simply isn't in your nature, no matter how funny it is."))
 			return FALSE
-	. = ..()
+	return ..()
 
 /mob/living/simple_animal/hostile/ordeal/crimson_noon/gib()
 	//Please dont spam the animation sir
@@ -167,7 +168,8 @@
 	if(QDELETED(src))
 		return
 	visible_message(span_danger("[src] suddenly explodes!"))
-	ReleaseTheClowns()
+	if(spawn_clowns)
+		ReleaseTheClowns()
 	if(ordeal_reference)
 		ordeal_reference.OnMobDeath(src)
 		ordeal_reference = null
@@ -530,6 +532,7 @@
 	health = 650
 	mob_spawn_amount = 1
 	clown_derivitive = /mob/living/simple_animal/hostile/ordeal/crimson_clown/spawned
+	spawn_clowns = FALSE
 	var/time_to_explode
 
 /mob/living/simple_animal/hostile/ordeal/crimson_noon/spawned/Initialize()
@@ -542,6 +545,7 @@
 	if(!.)
 		return
 	if(world.time >= time_to_explode)
+		spawn_clowns = TRUE
 		gib()
 
 // Dusk
@@ -550,6 +554,7 @@
 	maxHealth = 500
 	health = 500
 	clown_derivitive = /mob/living/simple_animal/hostile/ordeal/crimson_noon/spawned
+	spawn_clowns = FALSE
 	var/time_to_explode
 
 /mob/living/simple_animal/hostile/ordeal/crimson_noon/crimson_dusk/spawned/Initialize()
@@ -562,4 +567,5 @@
 	if(!.)
 		return
 	if(world.time >= time_to_explode)
+		spawn_clowns = TRUE
 		gib()


### PR DESCRIPTION
## About The Pull Request
Crimson Midnight spawns are supposed to only reproduce if they die by their own hands. This hsould fix that.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
fix: Cimson Midnight Reproduction
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
