### PR TITLE
Fixes some Crew Manifest weirdness

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -213,10 +213,11 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 
 // This function can not be undone; do not call this unless you are sure
 /obj/machinery/cryopod/proc/despawn_occupant()
-	var/mob/living/mob_occupant = occupant
+	var/mob/living/carbon/mob_occupant = occupant
 	var/list/crew_member = list()
 
 	crew_member["name"] = mob_occupant.real_name
+	crew_member["fingerprint"] = md5(mob_occupant.dna.uni_identity) // This is their fingerprint, as it will appear in the datacore. We want it so we can remove the correct record from there.
 
 	var/list/these_roles_arent_actually_in_the_round = list(
 		"Test Range Agent", // Test Range
@@ -256,17 +257,24 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		crew_member["job"] = "N/A"
 
 	// Delete them from datacore.
+	var/record_id
 	var/announce_rank = null
-	for(var/datum/data/record/medical_record as anything in GLOB.data_core.medical)
-		if(medical_record.fields["name"] == mob_occupant.real_name)
-			qdel(medical_record)
-	for(var/datum/data/record/security_record as anything in GLOB.data_core.security)
-		if(security_record.fields["name"] == mob_occupant.real_name)
-			qdel(security_record)
-	for(var/datum/data/record/general_record as anything in GLOB.data_core.general)
-		if(general_record.fields["name"] == mob_occupant.real_name)
-			announce_rank = general_record.fields["rank"]
-			qdel(general_record)
+
+	// We find the correct person's records via fingerprints.
+	// Why? Because people can share names, and more importantly, people can enter cryo, ghost, respawn, rejoin, and when their original body gets despawned, if we used names or ranks, now we can't reliably ensure the correct record is eliminated.
+	// There are only 2 situations where this method can fail, AFAIK: 1. Your DNA changes in some way - very rare, has to be stuff like Wabbajack. 2. Extremely unlikely scenario of 2 people having the same DNA.
+	var/datum/data/record/genrecord = find_record("fingerprint", crew_member["fingerprint"], GLOB.data_core.general)
+	if(genrecord)
+		record_id = genrecord.fields["id"] // An ID is shared across the same's person records in general, security and medical.
+		announce_rank = genrecord.fields["rank"]
+		qdel(genrecord)
+	if(record_id)
+		var/datum/data/record/secrecord = find_record("id", record_id, GLOB.data_core.security)
+		var/datum/data/record/medrecord = find_record("id", record_id, GLOB.data_core.medical)
+		if(secrecord)
+			qdel(secrecord)
+		if(medrecord)
+			qdel(medrecord)
 
 	control_computer?.frozen_crew += list(crew_member)
 
@@ -291,7 +299,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 	name = initial(name)
 
 /obj/machinery/cryopod/MouseDrop_T(mob/living/target, mob/user)
-	if(!istype(target) || !can_interact(user) || !target.Adjacent(user) || !ismob(target) || isanimal(target) || !istype(user.loc, /turf) || target.buckled)
+	if(!istype(target) || !can_interact(user) || !target.Adjacent(user) || !iscarbon(target) || !istype(user.loc, /turf) || target.buckled)
 		return
 
 	if(occupant)
@@ -326,7 +334,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		if(antag)
 			tgalert(target, "You're \a [antag.name]! [AHELP_FIRST_MESSAGE]")
 
-	if(!istype(target) || !can_interact(user) || !target.Adjacent(user) || !ismob(target) || isanimal(target) || !istype(user.loc, /turf) || target.buckled)
+	if(!istype(target) || !can_interact(user) || !target.Adjacent(user) || !iscarbon(target) || !istype(user.loc, /turf) || target.buckled)
 		return
 		// rerun the checks in case of shenanigans
 

--- a/code/modules/jobs/job_types/trusted_players/association/roaming.dm
+++ b/code/modules/jobs/job_types/trusted_players/association/roaming.dm
@@ -137,6 +137,7 @@
 	// Claw kills you for tax evasion or something. There's no immersion-friendly way to do this unless you want me to script, like, a train ride coming for you and taking you elsewhere?
 	if(chosen_asso == "uh_oh")
 		if(!already_used)
+			// Do the visual
 			var/turf/origin = get_turf(probably_a_fixer)
 			var/list/all_turfs = origin.reachableAdjacentTurfs()
 			for(var/turf/T in all_turfs)
@@ -145,9 +146,29 @@
 				new /obj/effect/temp_visual/dir_setting/claw_appears(T)
 				break
 			new /obj/effect/temp_visual/justitia_effect(origin)
+
+			// Remove this goofball from the datacore, so they don't clog up the crew manifest and whatnot.
+			var/datum/data/record/genrecord = find_record("fingerprint", md5(probably_a_fixer.dna.uni_identity), GLOB.data_core.general) // Why fingerprint? In the extremely rare case two people share a name. Theoretically their fingerprint can also be duped but let's get real
+			var/record_id
+			if(genrecord && genrecord.fields["rank"] == "Roaming Association Fixer") // let's just make sure
+				record_id = genrecord.fields["id"] // The same person's records will share an ID across the different datacore lists! We can use it to find the other 2 records reliably.
+				qdel(genrecord)
+			// If we got a record_id that means we successfully found and deleted a general record, do the same for sec and medical.
+			if(record_id)
+				var/datum/data/record/secrecord = find_record("id", record_id, GLOB.data_core.security)
+				var/datum/data/record/medrecord = find_record("id", record_id, GLOB.data_core.medical)
+				if(secrecord)
+					qdel(secrecord)
+				if(medrecord)
+					qdel(medrecord)
+
+			// Open up a job slot
 			roamer_job_reference.current_positions -= 1
+
+			// GOODBYE
 			qdel(probably_a_fixer)
 			qdel(src)
+
 		return FALSE
 
 	var/armor
@@ -268,6 +289,11 @@
 
 		if(found_id && found_pda)
 			break
+
+	// Update their crew manifest entry too
+	var/datum/data/record/our_persons_record = find_record("fingerprint", md5(probably_a_fixer.dna.uni_identity), GLOB.data_core.general)
+	if(our_persons_record && our_persons_record.fields["rank"] == "Roaming Association Fixer") // let's just make sure
+		our_persons_record.fields["rank"] = what_did_they_choose
 
 	to_chat(probably_a_fixer, span_nicegreen("Delivered equipment corresponding to a [what_did_they_choose]. Make us proud."))
 	playsound(src, 'sound/machines/terminal_success.ogg', 50, FALSE)


### PR DESCRIPTION
## About The Pull Request
1. Roaming Associate Fixers now update their job title in the crew manifest when selecting a loadout
2. Roaming Associate Fixers are now deleted off the datacore when they take the "return to lobby" option from the uplink
3. Cryopods will now find the correct record to delete by searching fingerprints. That is, md5(occupant.dna.uni_identity).

The third one needs some further explanation. Basically, the old system for cryopods used the occupant's real_name to search for **all** records bearing that name, and deleted them. This had a couple of issues, for instance, the fact that two people can share the same name, and you could observe this resulting in a bug when you cryo and immediately respawn, since once the original body was cryo'd it'd nuke ALL the records of the characters with its name.

There isn't really a great way to find the corresponding record without a ton of checks, like pulling every single record, comparing name and rank and etc; but records **DO** store a Fingerprint which is an md5 hash of the person's DNA.uni_identity. This is, as you might expect, unique, even if you spawn as the same character twice the DNA will be different. It'd have to be astronomically unlikely for two people to share the same DNA.

This method is a bit vulnerable to DNA-changing shenanigans; magic mirrors or wabbajacks, for instance, will change your uni_identity. But they're unattainable in standard gameplay so it should be fine.

<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More accurate manifest
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
tweak: Roaming Association Fixers are now taken off the Crew Manifest when dying after refusing their loadout choices.
tweak: Roaming Association Fixers' ranks are updated in the Crew Manifest when selecting a loadout.
tweak: Cryopods will use Fingerprints to search for the correct data records to delete, instead of the person's name. This will avoid unintentional deletion of records.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
