### PR TITLE
Makes city DayNight cycle only effect station Z levels (needs review for issues)

### DIFF
--- a/code/controllers/subsystem/city_events.dm
+++ b/code/controllers/subsystem/city_events.dm
@@ -240,6 +240,10 @@ SUBSYSTEM_DEF(cityevents)
 //Daynight stuff
 /datum/controller/subsystem/cityevents/proc/Daynight()
 	for(var/obj/effect/light_emitter/L in lights)
+		var/turf/T = get_turf(L)
+		if(T)
+			if(!is_station_level(T.z))
+				continue
 		L.set_light(25, globalillumination)
 
 	if(globalillumination <= -0.2)	//Go back up


### PR DESCRIPTION
## About The Pull Request
I made a small if statement in the city_events, in my local test it allowed the city to be night while the testing range was bright.

## Why It's Good For The Game
Fixes a issue with the refraction railway being pitch black... if this works correctly.

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [x] This PR compiles
* [x] This PR runs fine in a local test
* [x] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
fix: testing range being effected by CoL daynight cycle
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
