### PR TITLE
RCA Big and Will be Bad Wolf changes

### DIFF
--- a/ModularLobotomy/rcorp/rcorp_abnos/hardteam/hardcombat/big_wolf.dm
+++ b/ModularLobotomy/rcorp/rcorp_abnos/hardteam/hardcombat/big_wolf.dm
@@ -18,7 +18,7 @@
 	melee_damage_type = RED_DAMAGE
 	melee_damage_lower = 20
 	melee_damage_upper = 40
-	original_abno = /mob/living/simple_animal/hostile/rcorp_abno/hard/big_wolf
+	original_abno = /mob/living/simple_animal/hostile/abnormality/big_wolf
 
 	//For when the wolf becomes incorporal and flees.
 	var/last_reached_health = 75
@@ -124,6 +124,12 @@
 
 /mob/living/simple_animal/hostile/rcorp_abno/hard/big_wolf/Life()
 	. = ..()
+	if(fleeing_now != TRUE && hp_check_cooldown <= world.time)
+		var/our_hp = WOLF_HP_PERCENT
+		if(our_hp <= last_reached_health)
+			FleeNow()
+			last_reached_health = last_reached_health - 25
+		hp_check_cooldown = world.time + (10 SECONDS)
 	if(!client && can_act && howl_cooldown <= world.time && fleeing_now != TRUE)
 		Howl()
 

--- a/ModularLobotomy/rcorp/rcorp_abnos/hardteam/hardcombat/big_wolf.dm
+++ b/ModularLobotomy/rcorp/rcorp_abnos/hardteam/hardcombat/big_wolf.dm
@@ -133,7 +133,7 @@
 
 /mob/living/simple_animal/hostile/rcorp_abno/hard/big_wolf/Life()
 	. = ..()
-	if(fleeing_now != TRUE && hp_check_cooldown <= world.time)
+	if(fleeing_now != TRUE && hp_check_cooldown <= world.time && client)
 		var/our_hp = WOLF_HP_PERCENT
 		if(our_hp <= last_reached_health)
 			FleeNow()

--- a/ModularLobotomy/rcorp/rcorp_abnos/hardteam/hardcombat/big_wolf.dm
+++ b/ModularLobotomy/rcorp/rcorp_abnos/hardteam/hardcombat/big_wolf.dm
@@ -31,6 +31,8 @@
 	var/obj/effect/proc_holder/ability/aimed/rca_dash/big_wolf/ourdash
 	var/mob/living/simple_animal/hostile/rcorp_abno/hard/red_hood/rival
 	var/hit_rival = 0 //I LOVE FIGHTING MY LONGLIFE LIFELONG RIVAL
+	//Dont get stuck in a wall for the love of god
+	var/turf/starting_location
 
 	attack_action_types = list(
 		/datum/action/innate/rca_abnormality_attack/toggle/wolf_dash_toggle,
@@ -46,6 +48,13 @@
 		|Roaring Wolf|: When pressing your 'Howl' ability you will begin to inhale. \
 		After a 2 second delay you will howl, affecting all hostiles within a 20 tile range of yourself. \
 		The howl will deal 50 WHITE damage to those affected and will go through walls. <br>\
+		<br>\
+		|Into the Dark|: When losing over 25% of your HP you will start skulking in the shadows for 3 seconds. \
+		Your speed will be greatly boosted and you will phase through all obstacles. \
+		You may not phase through certain map borders and team partitions. \
+		If this state ends while within a wall you will return to your original position. \
+		While in this state you may not perform any attacks or abilities. \
+		This has a cooldown of 10 seconds and may be repeated when you lose the required amount of HP again. <br>\
 		<br>\
 		|Destined to be the Big Bad Wolf|: The Abnormality 'Little Red Riding Hooded Mercenary' is always harmed by your AoE attacks. \
 		When 'Little Red Riding Hooded Mercenary' is caught in your attack all others hit by this same attack will take double the damage from it. </b>"
@@ -166,19 +175,28 @@
 /mob/living/simple_animal/hostile/rcorp_abno/hard/big_wolf/proc/FleeNow()
 	icon_state = "big_wolf_flee"
 	playsound(get_turf(src), 'sound/abnormalities/big_wolf/Wolf_FogChange.ogg', 75, 1)
-	ADD_TRAIT(src, TRAIT_MOVE_PHASING, "fleeing")
+	visible_message(span_danger("[src] retreats into the shadows!"))
+	starting_location = get_turf(src)
+	incorporeal_move = TRUE
 	LoseTarget(FALSE)
 	retreat_distance = 20
 	TemporarySpeedChange(-2, 3 SECONDS)
 	fleeing_now = TRUE
+	density = FALSE
 	addtimer(CALLBACK(src, PROC_REF(StopFleeing)), 3 SECONDS)
 
 /mob/living/simple_animal/hostile/rcorp_abno/hard/big_wolf/proc/StopFleeing()
+	var/turf/current_turf = get_turf(src)
+	if(current_turf && current_turf.density && starting_location)
+		forceMove(starting_location)
+		to_chat(src, span_danger("You were trapped in a wall and have been returned to your starting location!"))
 	playsound(get_turf(src), 'sound/magic/ethereal_exit.ogg', 75, 1)
+	visible_message(span_danger("[src] emerges from the shadows!"))
 	retreat_distance = null
 	fleeing_now = FALSE
 	color = initial(color)
-	REMOVE_TRAIT(src, TRAIT_MOVE_PHASING, "fleeing")
+	incorporeal_move = FALSE
+	density = TRUE
 	icon_state = icon_living
 
 //Combat Skills


### PR DESCRIPTION
## About The Pull Request
Wolf now uses RCA phasing, this means that mapping border restrictions stop him, this also captures wolfs position incase he gets stuck in a wall, this also fixes his lack of sprite
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Wolf needs sprites, I dont want wolf stuck in  a wall, I dont want wolf phasing through team partitions
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution
Phase code taken from
https://github.com/Lobotomy-Corporation-13/lc13/pull/226
<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
add: added fleeing to wolf tutorial description
add: made fleeing also apply to the player and not just the wolf AI
tweak: tweaked wolf flee code so itll use Enders RCA phasing system
fix: fixed original abno using the wrong path for wolf which made him lose his sprite
/:cl:
<!--

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
