### PR TITLE
Ports TGStation click catcher fix and view helpers

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -729,19 +729,28 @@ GLOBAL_LIST_INIT(WALLITEMS_INVERSE, typecacheof(list(
 		else
 			return "white"
 
-/proc/params2turf(scr_loc, turf/origin, client/C)
-	if(!scr_loc)
+// PORTED FROM TGSTATION: PR #64147
+// Note: In that PR, this proc is in code/__HELPERS/turfs.dm. We don't have that dm file here, so it's going where its predecessor was (params_to_turf/params2turf)
+///Returns a turf based on text inputs, original turf and viewing client
+/proc/parse_caught_click_modifiers(list/modifiers, turf/origin, client/viewing_client)
+	if(!modifiers)
 		return null
-	var/tX = splittext(scr_loc, ",")
-	var/tY = splittext(tX[2], ":")
-	var/tZ = origin.z
-	tY = tY[1]
-	tX = splittext(tX[1], ":")
-	tX = tX[1]
-	var/list/actual_view = getviewsize(C ? C.view : world.view)
-	tX = clamp(origin.x + text2num(tX) - round(actual_view[1] / 2) - 1, 1, world.maxx)
-	tY = clamp(origin.y + text2num(tY) - round(actual_view[2] / 2) - 1, 1, world.maxy)
-	return locate(tX, tY, tZ)
+
+	var/screen_loc = splittext(LAZYACCESS(modifiers, SCREEN_LOC), ",")
+	var/list/actual_view = getviewsize(viewing_client ? viewing_client.view : world.view)
+	var/click_turf_x = splittext(screen_loc[1], ":")
+	var/click_turf_y = splittext(screen_loc[2], ":")
+	var/click_turf_z = origin.z
+
+	var/click_turf_px = text2num(click_turf_x[2])
+	var/click_turf_py = text2num(click_turf_y[2])
+	click_turf_x = origin.x + text2num(click_turf_x[1]) - round(actual_view[1] / 2) - 1
+	click_turf_y = origin.y + text2num(click_turf_y[1]) - round(actual_view[2] / 2) - 1
+
+	var/turf/click_turf = locate(clamp(click_turf_x, 1, world.maxx), clamp(click_turf_y, 1, world.maxy), click_turf_z)
+	LAZYSET(modifiers, ICON_X, "[(click_turf_px - click_turf.pixel_x) + ((click_turf_x - click_turf.x) * world.icon_size)]")
+	LAZYSET(modifiers, ICON_Y, "[(click_turf_py - click_turf.pixel_y) + ((click_turf_y - click_turf.y) * world.icon_size)]")
+	return click_turf
 
 /proc/screen_loc2turf(text, turf/origin, client/C)
 	if(!text)

--- a/code/__HELPERS/view.dm
+++ b/code/__HELPERS/view.dm
@@ -6,12 +6,6 @@
 		var/list/viewrangelist = splittext(view,"x")
 		return list(text2num(viewrangelist[1]), text2num(viewrangelist[2]))
 
-/proc/in_view_range(mob/user, atom/A)
-	var/list/view_range = getviewsize(user.client.view)
-	var/turf/source = get_turf(user)
-	var/turf/target = get_turf(A)
-	return ISINRANGE(target.x, source.x - view_range[1], source.x + view_range[1]) && ISINRANGE(target.y, source.y - view_range[1], source.y + view_range[1])
-
 // PORTED FROM TGSTATION: PR #65180
 /// Takes a string or num view, and converts it to pixel width/height in a list(pixel_width, pixel_height)
 /proc/view_to_pixels(view)
@@ -21,3 +15,26 @@
 	view_info[1] *= 32
 	view_info[2] *= 32
 	return view_info
+
+// PORTED FROM TGSTATION: PR #82767
+/**
+* Frustrated with bugs in can_see(), this instead uses viewers for a much more effective approach.
+* ### Things to note:
+* - Src/source must be a mob. `viewers()` returns mobs.
+* - Adjacent objects are always considered visible.
+*/
+
+/// The default tile-distance between two atoms for one to consider the other as visible.
+// Note: This was originally 7 in the PR I ported it from, but our view is 17x15 (8 tiles horizontally and 7 tiles vertically). Setting to 8 to avoid weirdness.
+#define DEFAULT_SIGHT_DISTANCE 8
+
+/// Basic check to see if the src object can see the target object.
+#define CAN_I_SEE(target) ((src in viewers(DEFAULT_SIGHT_DISTANCE, target)) || in_range(target, src))
+
+
+/// Checks the visibility between two other objects.
+#define CAN_THEY_SEE(target, source) ((source in viewers(DEFAULT_SIGHT_DISTANCE, target)) || in_range(target, source))
+
+
+/// Further checks distance between source and target.
+#define CAN_SEE_RANGED(target, source, dist) ((source in viewers(dist, target)) || in_range(target, source))

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -508,10 +508,10 @@
 
 /atom/movable/screen/click_catcher/Click(location, control, params)
 	var/list/modifiers = params2list(params)
-	var/turf/T = params2turf(LAZYACCESS(modifiers, SCREEN_LOC), get_turf(usr.client ? usr.client.eye : usr), usr.client)
-	params += "&catcher=1"
-	if(T)
-		T.Click(location, control, params)
+	var/turf/click_turf = parse_caught_click_modifiers(modifiers, get_turf(usr.client ? usr.client.eye : usr), usr.client)
+	if (click_turf)
+		modifiers["catcher"] = TRUE
+		click_turf.Click(click_turf, control, list2params(modifiers))
 	. = 1
 
 /// MouseWheelOn

--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -100,17 +100,17 @@
 
 /datum/component/automatic_fire/proc/on_mouse_down(client/source, atom/_target, turf/location, control, params)
 	SIGNAL_HANDLER
-	var/list/L = params2list(params) //If they're shift+clicking, for example, let's not have them accidentally shoot.
+	var/list/modifiers = params2list(params) //If they're shift+clicking, for example, let's not have them accidentally shoot.
 
-	if (L[SHIFT_CLICK])
+	if(LAZYACCESS(modifiers, SHIFT_CLICK))
 		return
-	if (L[CTRL_CLICK])
+	if(LAZYACCESS(modifiers, CTRL_CLICK))
 		return
-	if (L[MIDDLE_CLICK])
+	if(LAZYACCESS(modifiers, MIDDLE_CLICK))
 		return
-	if (L[RIGHT_CLICK])
+	if(LAZYACCESS(modifiers, RIGHT_CLICK))
 		return
-	if (L[ALT_CLICK])
+	if(LAZYACCESS(modifiers, ALT_CLICK))
 		return
 	if(source.mob.in_throw_mode)
 		return
@@ -124,7 +124,8 @@
 	if(isnull(location)) //Clicking on a screen object.
 		if(_target.plane != CLICKCATCHER_PLANE) //The clickcatcher is a special case. We want the click to trigger then, under it.
 			return //If we click and drag on our worn backpack, for example, we want it to open instead.
-		_target = params2turf(L["screen-loc"], get_turf(source.eye), source)
+		_target = parse_caught_click_modifiers(modifiers, get_turf(source.eye), source)
+		params = list2params(modifiers)
 		if(!_target)
 			CRASH("Failed to get the turf under clickcatcher")
 
@@ -208,9 +209,10 @@
 
 /datum/component/automatic_fire/proc/on_mouse_drag(client/source, atom/src_object, atom/over_object, turf/src_location, turf/over_location, src_control, over_control, params)
 	SIGNAL_HANDLER
-	if(isnull(over_location) || istype(over_object, /atom/movable/screen)) //This happens when the mouse is over an inventory or screen object, or on entering deep darkness, for example.
+	if(isnull(over_location)) //This happens when the mouse is over an inventory or screen object, or on entering deep darkness, for example.
 		var/list/modifiers = params2list(params)
-		var/new_target = params2turf(modifiers["screen-loc"], get_turf(source.eye), source)
+		var/new_target = parse_caught_click_modifiers(modifiers, get_turf(source.eye), source)
+		params = list2params(modifiers)
 		mouse_parameters = params
 		if(!new_target)
 			if(QDELETED(target)) //No new target acquired, and old one was deleted, get us out of here.
@@ -237,7 +239,7 @@
 	if(get_dist(shooter, target) <= 0)
 		target = get_step(shooter, shooter.dir) //Shoot in the direction faced if the mouse is on the same tile as we are.
 		target_loc = target
-	else if(!in_view_range(shooter, target))
+	else if(!CAN_THEY_SEE(target, shooter))
 		stop_autofiring() //Elvis has left the building.
 		return FALSE
 	shooter.face_atom(target)

--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -87,7 +87,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, typecacheof(list(
 	if(client)
 		for(var/X in totalMembers)
 			var/obj/machinery/atmospherics/A = X //all elements in totalMembers are necessarily of this type.
-			if(in_view_range(client.mob, A))
+			if(CAN_THEY_SEE(A, client.mob))
 				if(!A.pipe_vision_img)
 					A.pipe_vision_img = image(A, A.loc, layer = ABOVE_HUD_LAYER, dir = A.dir)
 					A.pipe_vision_img.plane = ABOVE_HUD_PLANE


### PR DESCRIPTION
## About The Pull Request
# Skippable yapping (explanation)
So, when porting the TG projectile fix in #479, everything went pretty well, until it didn't. When aiming at obscured turfs, players' shots started going off into nowhere.

There wasn't actually anything wrong with the stuff I ported over, but our previous buggy behaviour was covering up an already existing bug, wherein wrong PIXEL_X and PIXEL_Y values were being obtained by Click(). 

My understanding of the issue is as follows:
1. When clicking on absolute darkness or obscured tiles, the click is first caught by the client's /atom/movable/screen/click_catcher, since it is the only opaque object that the player can see in that darkness. This click catcher has a significantly scaled 32x32 icon.
2. This click_catcher correctly passed on the clicked turf through some calculations made by params2turf(), but since IT was clicked, and not the turf, the modifiers of the click correspond to the click_catcher's parameters. This means that the PIXEL_X and PIXEL_Y values of the click are based on where in the click catcher's icon you clicked.
3. Since the click catcher's icon is super scaled, and PIXEL_X/Y are based off of the position in the icon where you clicked with scaling being factored in, the value that is actually given is SUPER off.

# Relevant stuff
The fixes made by **TGStation PR #64147** make it so that the screen catcher modifies the PIXEL_X/PIXEL_Y by pulling them out of the screen_loc param, and fixes the whole issue.

I also had to port some extra stuff from **TGStation PR #82767** to fix a runtime in autofire. Apparently it's also just a better, less buggy way to check if something is in view, so there.

As a result, people should be able to shoot at obscured tiles accurately again. **HOWEVER**: If they try to autofire into darkness/obscured tiles, they will not be able to. This is consistent with current behaviour on TG, but technically not with our prior one...
Old behaviour was that you'd be able to _start_ shooting at darkness, but wouldn't be able to change your aim in it until you moved your mouse to an actually visible turf. If this upsets too many people I can try and find a solution.
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution
[TGStation](https://github.com/tgstation/tgstation/) PRs [#82767](https://github.com/tgstation/tgstation/pull/82767) (view stuff) and [#64147](https://github.com/tgstation/tgstation/pull/64147) (click catcher/aiming stuff)
<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
fix: Aiming at obscured/dark tiles will no longer send your projectile in the completely wrong direction. Courtesy of TGStation PR #64147 .
code: in_view_range replaced with CAN_I_SEE, CAN_THEY_SEE, CAN_SEE_RANGED view helpers. In essence, viewers() is used to check for visibility now. Courtesy of TGStation PR #82767.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
