### PR TITLE
Citrine Adjustment

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/citrine/noon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/citrine/noon.dm
@@ -30,7 +30,7 @@
 	casingtype = /obj/item/ammo_casing/caseless/citrine_noon
 	projectilesound = 'sound/effects/sparks4.ogg'
 
-	faith_per_lifetick = 2
+	faith_per_lifetick = 2.4
 	faith_line = "He is risen! Our prayers were answered!"
 	var/can_say
 	var/can_fire = TRUE
@@ -328,7 +328,7 @@
 	SLEEP_CHECK_DEATH(30)
 	if(ordeal_reference)
 		var/datum/ordeal/simplespawn/citrine/C = ordeal_reference
-		C.current_faith += 5	//Get 5 Faith for praying.
+		C.current_faith += 10	//Get 10 Faith for praying.
 	can_act = TRUE
 
 

--- a/code/modules/ordeals/citrine_ordeals.dm
+++ b/code/modules/ordeals/citrine_ordeals.dm
@@ -36,7 +36,7 @@
 	spawn_amount = 3
 	spawn_type = list(
 		/mob/living/simple_animal/hostile/ordeal/citrine/knight,
-		/mob/living/simple_animal/hostile/ordeal/citrine/archer,
+		/mob/living/simple_animal/hostile/ordeal/citrine/archer/noon,
 		/mob/living/simple_animal/hostile/ordeal/citrine/priest,
 		)
 


### PR DESCRIPTION
## About The Pull Request
Makes the Citrine Archer Noons actually exist.
Changes some faith gain stuff.
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mostly a bugfix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [ ] This PR compiles
* [ ] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
fix: Citrine noon uses the correct mobs
balance: Citrine Priests and Knights create more faith
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
