### PR TITLE
[WCC] L2-A Buff

### DIFF
--- a/code/modules/jobs/job_types/wcorp/wcorprecon.dm
+++ b/code/modules/jobs/job_types/wcorp/wcorprecon.dm
@@ -40,7 +40,7 @@ GLOBAL_LIST_INIT(l2asquads, list("Axe", "Buckler", "Cleaver"))
 	name = "W-Corp L2 Type A Lieutenant"
 	jobtype = /datum/job/wcorpl2support
 
-	ears = /obj/item/radio/headset/agent_lieutenant
+	ears = /obj/item/radio/headset/wcorp_lieutenant
 	glasses = /obj/item/clothing/glasses/sunglasses
 	uniform = /obj/item/clothing/under/suit/lobotomy/wsenior
 	belt = /obj/item/ego_weapon/city/wcorp/cleanup
@@ -57,6 +57,7 @@ GLOBAL_LIST_INIT(l2asquads, list("Axe", "Buckler", "Cleaver"))
 		/obj/item/binoculars,
 		/obj/item/announcementmaker/wcorp,
 		/obj/item/commandprojector,
+		/obj/item/roller,
 	)
 
 
@@ -73,7 +74,7 @@ GLOBAL_LIST_INIT(l2asquads, list("Axe", "Buckler", "Cleaver"))
 	new /obj/item/grenade/r_corp/black(src)
 	new /obj/item/grenade/r_corp/black(src)
 
-//having all the squads was SO weird.
+//having all the channels with no one on it was SO weird.
 /obj/item/radio/headset/wcorp_lieutenant
 	name = "\proper the lieutenant's headset"
 	desc = "A headset used by agents in wcorp who support the squads."

--- a/code/modules/jobs/job_types/wcorp/wcorprecon.dm
+++ b/code/modules/jobs/job_types/wcorp/wcorprecon.dm
@@ -49,11 +49,39 @@ GLOBAL_LIST_INIT(l2asquads, list("Axe", "Buckler", "Cleaver"))
 	implants = list(/obj/item/organ/cyberimp/eyes/hud/security)
 	head = /obj/item/clothing/head/ego_hat/wcorp
 	suit = /obj/item/clothing/suit/armor/ego_gear/wcorp/noreq
-	l_pocket = /obj/item/commandprojector
-	r_pocket = /obj/item/storage/packet
+	l_pocket = /obj/item/storage/rcorp_grenade/wcorp
+	r_pocket = /obj/item/storage/First_aid_l2
 
 	backpack_contents = list(
 		/obj/item/storage/box/pcorp,
 		/obj/item/binoculars,
 		/obj/item/announcementmaker/wcorp,
+		/obj/item/commandprojector,
 	)
+
+
+//L2-LT stuff
+
+/obj/item/storage/rcorp_grenade/wcorp
+	name = "W-Corp Grenade pouch"
+	desc = "Put onto your pocket to hold up to 5 grenades. Filled with Black Fragility Grenades"
+
+/obj/item/storage/rcorp_grenade/wcorp/PopulateContents()
+	new /obj/item/grenade/r_corp/black(src)
+	new /obj/item/grenade/r_corp/black(src)
+	new /obj/item/grenade/r_corp/black(src)
+	new /obj/item/grenade/r_corp/black(src)
+	new /obj/item/grenade/r_corp/black(src)
+
+//having all the squads was SO weird.
+/obj/item/radio/headset/wcorp_lieutenant
+	name = "\proper the lieutenant's headset"
+	desc = "A headset used by agents in wcorp who support the squads."
+	icon_state = "com_headset"
+	keyslot = new /obj/item/encryptionkey/wcorp_lieutenant
+
+/obj/item/encryptionkey/wcorp_lieutenant
+	name = "\proper the agent captain's encryption key"
+	icon_state = "cap_cypherkey"
+	channels = list(RADIO_CHANNEL_SAFETY = 1, RADIO_CHANNEL_WELFARE = 1, RADIO_CHANNEL_DISCIPLINE = 1)
+


### PR DESCRIPTION
## About The Pull Request
L2-LT gets a buff!

Here's what they get:
- A pouch full of grenades
- Better healing equipment
- Better headsets
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
L2-A/L2-LT is supposed to be a support role, and before, all they could do is communicate with a VERY small amount of healing.
I'm increasing their support capacity to just be better.

### Did you test this PR?

* [x] This PR compiles
* [ ] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
balance: W-Corp L2-A Agents get significantly better equipment.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
