### PR TITLE
Adds 10 new COL rooms

### DIFF
--- a/ModularLobotomy/backstreets/random_rooms/large/south.dm
+++ b/ModularLobotomy/backstreets/random_rooms/large/south.dm
@@ -49,6 +49,17 @@
 	mappath = "_maps/RandomRooms/backstreets/large_south/lab_lsa.dmm"
 	stock = 1
 
+/datum/map_template/random_room/backstreets/large_south/lab_lsb
+	name = "Lab - Large South B"
+	room_id = "lab_lsb"
+	mappath = "_maps/RandomRooms/backstreets/large_south/lab_lsb.dmm"
+	stock = 1
+
+/datum/map_template/random_room/backstreets/large_south/lab_lsc
+	name = "Lab - Large South C"
+	room_id = "lab_lsc"
+	mappath = "_maps/RandomRooms/backstreets/large_south/lab_lsc.dmm"
+
 /datum/map_template/random_room/backstreets/large_south/shotgun_exam
 	name = "ShotgunExam - Large South"
 	room_id = "shotgun_exam"

--- a/ModularLobotomy/backstreets/random_rooms/medium/east.dm
+++ b/ModularLobotomy/backstreets/random_rooms/medium/east.dm
@@ -77,3 +77,8 @@
 	room_id = "workshop_me"
 	mappath = "_maps/RandomRooms/backstreets/medium_east/workshop_me.dmm"
 	stock = 1 // Only one, but it's common
+
+/datum/map_template/random_room/backstreets/medium_east/boluslab_mea
+	name = "Bolus Lab - Medium East A"
+	room_id = "boluslab_mea"
+	mappath = "_maps/RandomRooms/backstreets/medium_east/boluslab_mea.dmm"

--- a/ModularLobotomy/backstreets/random_rooms/medium/south.dm
+++ b/ModularLobotomy/backstreets/random_rooms/medium/south.dm
@@ -65,3 +65,18 @@
 	name = "Extra Appartment - Medium South A"
 	room_id = "apartmentmsa"
 	mappath = "_maps/RandomRooms/backstreets/medium_south/apartmentmsa.dmm"
+
+/datum/map_template/random_room/backstreets/medium_south/citrine_msa
+	name = "Citrine - Medium South A"
+	room_id = "citrinemsa"
+	mappath = "_maps/RandomRooms/backstreets/medium_south/citrine_msa.dmm"
+
+/datum/map_template/random_room/backstreets/medium_south/citrine_msb
+	name = "Citrine - Medium South B"
+	room_id = "citrinemsb"
+	mappath = "_maps/RandomRooms/backstreets/medium_south/citrine_msb.dmm"
+
+/datum/map_template/random_room/backstreets/medium_south/medstroage_msa
+	name = "Medical Storage - Medium South A"
+	room_id = "medstorage_msa"
+	mappath = "_maps/RandomRooms/backstreets/medium_south/medstorage_msa.dmm"

--- a/ModularLobotomy/backstreets/random_rooms/small/east.dm
+++ b/ModularLobotomy/backstreets/random_rooms/small/east.dm
@@ -78,3 +78,13 @@
     room_id = "ukulele"
     mappath = "_maps/RandomRooms/backstreets/small_east/ukulele.dmm"
     weight = 2
+
+/datum/map_template/random_room/backstreets/small_east/boluslab_sea
+    name = "Bolus Lab - Small East A"
+    room_id = "boluslab_sea"
+    mappath = "_maps/RandomRooms/backstreets/small_east/boluslab_sea.dmm"
+
+/datum/map_template/random_room/backstreets/small_east/citrine_sea
+    name = "Citrine - Small East A"
+    room_id = "citrine_sea"
+    mappath = "_maps/RandomRooms/backstreets/small_east/citrine_sea.dmm"

--- a/ModularLobotomy/backstreets/random_rooms/small/south.dm
+++ b/ModularLobotomy/backstreets/random_rooms/small/south.dm
@@ -72,3 +72,8 @@
 	name = "Candlelit Dinner - Small South A"
 	room_id = "candlelit_dinner"
 	mappath = "_maps/RandomRooms/backstreets/small_south/candlelit_dinner.dmm"
+
+/datum/map_template/random_room/backstreets/small_east/boluslab_ssa
+    name = "Bolus Lab - Small South A"
+    room_id = "boluslab_ssa"
+    mappath = "_maps/RandomRooms/backstreets/small_east/boluslab_ssa.dmm"

--- a/ModularLobotomy/backstreets/random_rooms/small/west.dm
+++ b/ModularLobotomy/backstreets/random_rooms/small/west.dm
@@ -67,3 +67,8 @@
 	name = "Runaway Birds - Small West"
 	room_id = "runaway_bird"
 	mappath = "_maps/RandomRooms/backstreets/small_west/runaway_bird.dmm"
+
+/datum/map_template/random_room/backstreets/small_east/boluslab_swa
+    name = "Bolus Lab - Small West A"
+    room_id = "boluslab_swa"
+    mappath = "_maps/RandomRooms/backstreets/small_east/boluslab_swa.dmm"

--- a/_maps/RandomRooms/backstreets/large_south/lab_lsb.dmm
+++ b/_maps/RandomRooms/backstreets/large_south/lab_lsb.dmm
@@ -1,0 +1,558 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"bd" = (
+/turf/closed/indestructible/reinforced,
+/area/city/backstreets_room)
+"cd" = (
+/obj/item/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"cE" = (
+/obj/machinery/smartfridge/chemistry,
+/turf/closed/indestructible/reinforced,
+/area/city/backstreets_room)
+"dB" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	color = "#bf48b1";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/white,
+/area/city/backstreets_room)
+"ix" = (
+/obj/machinery/door/window{
+	dir = 8
+	},
+/obj/machinery/door/window/brigdoor{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
+"jh" = (
+/obj/structure/table/glass,
+/obj/item/assembly/igniter/condenser{
+	pixel_x = 9;
+	pixel_y = -3
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 9;
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/city/backstreets_room)
+"jW" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/bucket/melting,
+/obj/machinery/camera{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "hidden security camera";
+	short_range = 13;
+	view_range = 13
+	},
+/obj/machinery/reagentgrinder{
+	desc = "Used to grind things up into raw materials and liquids.";
+	pixel_y = 14;
+	pixel_x = 2
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/white,
+/area/city/backstreets_room)
+"kq" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"kD" = (
+/obj/structure/window/shuttle{
+	name = "window"
+	},
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/city/backstreets_room)
+"kI" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#5269e9";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/white,
+/area/city/backstreets_room)
+"kK" = (
+/obj/structure/filingcabinet,
+/obj/structure/filingcabinet{
+	pixel_x = -9
+	},
+/obj/structure/filingcabinet{
+	pixel_x = 10
+	},
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"nj" = (
+/turf/closed/indestructible/rock,
+/area/city/backstreets_room)
+"oj" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"qo" = (
+/obj/structure/table/glass,
+/obj/item/kirbyplants/random{
+	pixel_y = 10
+	},
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"rP" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"rS" = (
+/obj/effect/turf_decal/tile{
+	color = "#ffb964";
+	alpha = 150;
+	dir = 4
+	},
+/obj/effect/turf_decal/tile{
+	color = "#FF8C00";
+	alpha = 150;
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/white,
+/area/city/backstreets_room)
+"sM" = (
+/obj/effect/turf_decal/tile{
+	color = "#FF8C00";
+	alpha = 150;
+	dir = 1
+	},
+/obj/effect/turf_decal/tile{
+	color = "#ffb964";
+	alpha = 150;
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/city/backstreets_room)
+"ti" = (
+/obj/structure/table/glass,
+/obj/item/clipboard,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"tm" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#5269e9"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#5269e9";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/city/backstreets_room)
+"tN" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "pharmacy";
+	req_one_access_txt = "5"
+	},
+/turf/open/floor/plasteel/white,
+/area/city/backstreets_room)
+"uv" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"vG" = (
+/obj/effect/turf_decal/tile{
+	color = "#FF8C00";
+	alpha = 150
+	},
+/obj/effect/turf_decal/tile{
+	color = "#ffb964";
+	alpha = 150;
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/city/backstreets_room)
+"xd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/indestructible/reinforced,
+/area/city/backstreets_room)
+"xo" = (
+/obj/structure/table/glass,
+/obj/item/scalpel,
+/obj/item/hemostat,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"yk" = (
+/obj/effect/turf_decal/tile{
+	color = "#FF8C00";
+	alpha = 150
+	},
+/obj/effect/turf_decal/tile{
+	color = "#ffb964";
+	alpha = 150;
+	dir = 4
+	},
+/obj/effect/turf_decal/tile{
+	color = "#ffb964";
+	alpha = 150;
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/city/backstreets_room)
+"zu" = (
+/obj/effect/turf_decal/tile{
+	color = "#ffb964";
+	alpha = 150;
+	dir = 4
+	},
+/obj/effect/turf_decal/tile{
+	color = "#FF8C00";
+	alpha = 150;
+	dir = 1
+	},
+/obj/effect/turf_decal/tile{
+	color = "#ffb964";
+	alpha = 150;
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/city/backstreets_room)
+"Cs" = (
+/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 19
+	},
+/obj/item/storage/bag/chemistry,
+/obj/structure/closet/crate/medical{
+	name = "equipments crate"
+	},
+/obj/item/clothing/suit/armor/ego_gear/limbus_labs/chem,
+/obj/item/clothing/head/beret/tegu/chem,
+/turf/open/floor/noslip,
+/area/city/backstreets_room)
+"De" = (
+/obj/structure/bed/roller,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"DH" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#5269e9"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/city/backstreets_room)
+"Fp" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"GI" = (
+/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 19
+	},
+/obj/machinery/chem_master,
+/turf/open/floor/noslip,
+/area/city/backstreets_room)
+"Ho" = (
+/obj/effect/turf_decal/tile/purple{
+	color = "#bf48b1";
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/city/backstreets_room)
+"HF" = (
+/obj/structure/bed/pod,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"HR" = (
+/obj/effect/turf_decal/tile{
+	color = "#FF8C00";
+	alpha = 150
+	},
+/obj/effect/turf_decal/tile{
+	color = "#ffb964";
+	alpha = 150;
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/white,
+/area/city/backstreets_room)
+"JD" = (
+/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/machinery/chem_dispenser/lc13{
+	recharge_amount = 0
+	},
+/turf/open/floor/noslip,
+/area/city/backstreets_room)
+"Kp" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/syringes{
+	pixel_x = -9
+	},
+/obj/item/storage/box/beakers,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/white,
+/area/city/backstreets_room)
+"Kq" = (
+/obj/structure/table/glass,
+/obj/item/folder/white{
+	desc = "Looks to be remnants of the old G-Corp.";
+	name = "Outdated G-Corp Folder"
+	},
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"La" = (
+/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/machinery/chem_heater,
+/turf/open/floor/noslip,
+/area/city/backstreets_room)
+"Oo" = (
+/obj/machinery/door/airlock/freezer{
+	name = "airlock"
+	},
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"PK" = (
+/obj/item/reagent_containers/blood,
+/obj/machinery/iv_drip,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"QB" = (
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"QF" = (
+/obj/structure/table/glass,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"RD" = (
+/obj/structure/bed/pod,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"Ts" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	color = "#bf48b1";
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/white,
+/area/city/backstreets_room)
+"WZ" = (
+/obj/machinery/modular_computer/console{
+	desc = "A corporate computer for private communications between persons of interest. This one appears to have its memory reset, however.";
+	name = "communications console"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"Yr" = (
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/white,
+/area/city/backstreets_room)
+
+(1,1,1) = {"
+bd
+bd
+bd
+bd
+bd
+bd
+bd
+bd
+"}
+(2,1,1) = {"
+kD
+De
+De
+kK
+kK
+qo
+Kq
+bd
+"}
+(3,1,1) = {"
+Oo
+QB
+QB
+QB
+Fp
+QF
+QB
+bd
+"}
+(4,1,1) = {"
+kD
+Fp
+QB
+Fp
+Fp
+ti
+kq
+bd
+"}
+(5,1,1) = {"
+kD
+QB
+Fp
+Fp
+QB
+WZ
+Fp
+bd
+"}
+(6,1,1) = {"
+kD
+uv
+rP
+Fp
+QB
+QB
+Fp
+bd
+"}
+(7,1,1) = {"
+bd
+bd
+bd
+Oo
+bd
+bd
+bd
+bd
+"}
+(8,1,1) = {"
+bd
+HF
+QB
+Fp
+xo
+RD
+QF
+bd
+"}
+(9,1,1) = {"
+bd
+PK
+QB
+QB
+Fp
+Fp
+Fp
+xd
+"}
+(10,1,1) = {"
+bd
+cd
+Fp
+Fp
+QB
+QB
+oj
+bd
+"}
+(11,1,1) = {"
+bd
+bd
+tN
+cE
+cE
+ix
+bd
+bd
+"}
+(12,1,1) = {"
+bd
+GI
+zu
+sM
+kI
+tm
+bd
+nj
+"}
+(13,1,1) = {"
+bd
+JD
+rS
+Kp
+jW
+DH
+bd
+nj
+"}
+(14,1,1) = {"
+bd
+La
+Ho
+Yr
+jh
+HR
+bd
+nj
+"}
+(15,1,1) = {"
+bd
+Cs
+Ts
+dB
+vG
+yk
+bd
+nj
+"}
+(16,1,1) = {"
+bd
+bd
+bd
+bd
+bd
+bd
+bd
+nj
+"}

--- a/_maps/RandomRooms/backstreets/large_south/lab_lsc.dmm
+++ b/_maps/RandomRooms/backstreets/large_south/lab_lsc.dmm
@@ -1,0 +1,338 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"bd" = (
+/turf/closed/indestructible/reinforced,
+/area/city/backstreets_room)
+"cd" = (
+/obj/structure/table/glass,
+/obj/item/essence/wood,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"cE" = (
+/obj/structure/table/glass,
+/obj/item/essence/earth,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"ix" = (
+/obj/structure/table/glass,
+/obj/item/essence/fire,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"kD" = (
+/obj/structure/window/shuttle{
+	name = "window"
+	},
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/city/backstreets_room)
+"kI" = (
+/obj/structure/chair/office/light,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"kK" = (
+/obj/structure/filingcabinet,
+/obj/structure/filingcabinet{
+	pixel_x = -9
+	},
+/obj/structure/filingcabinet{
+	pixel_x = 10
+	},
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"nj" = (
+/obj/structure/table/glass,
+/obj/item/flashlight/lamp,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"qo" = (
+/obj/structure/table/glass,
+/obj/item/kirbyplants/random{
+	pixel_y = 10
+	},
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"sM" = (
+/obj/machinery/door/airlock/freezer{
+	name = "storage"
+	},
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"ti" = (
+/obj/structure/table/glass,
+/obj/item/bolus/simple,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"vG" = (
+/obj/structure/table/glass,
+/obj/item/bolus/flower,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"xd" = (
+/obj/machinery/modular_computer/console{
+	desc = "A corporate computer for private communications between persons of interest. This one appears to have its memory reset, however.";
+	name = "communications console"
+	},
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"yk" = (
+/obj/structure/table/glass,
+/obj/item/essence/water,
+/obj/item/essence/water,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"zu" = (
+/obj/structure/closet/crate/medical{
+	name = "equipments crate"
+	},
+/obj/item/storage/box/hcorpmetal,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"Cs" = (
+/obj/structure/closet/crate/medical{
+	name = "equipments crate"
+	},
+/obj/item/bolus/armor,
+/obj/item/storage/box/hcorpwood,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"De" = (
+/obj/structure/table/glass,
+/obj/item/essence/water,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"Fp" = (
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"Ho" = (
+/obj/structure/closet/crate/medical{
+	name = "equipments crate"
+	},
+/obj/item/bolus/charred,
+/obj/item/storage/box/hcorpwater,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"HF" = (
+/obj/structure/table/glass,
+/obj/item/clipboard,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"HR" = (
+/obj/structure/closet/crate/medical{
+	name = "equipments crate"
+	},
+/obj/item/storage/box/hcorpfire,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"JD" = (
+/obj/structure/closet/crate/medical{
+	name = "equipments crate"
+	},
+/obj/item/storage/box/hcorpearth,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"Kq" = (
+/turf/closed/indestructible/rock,
+/area/city/backstreets_room)
+"La" = (
+/obj/structure/closet/crate/medical{
+	name = "equipments crate"
+	},
+/obj/item/bolus/clay,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"Oo" = (
+/obj/machinery/door/airlock/freezer{
+	name = "airlock"
+	},
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"PK" = (
+/obj/structure/table/glass,
+/obj/item/bolus/mossy,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"QF" = (
+/obj/structure/table/glass,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"RD" = (
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"Ts" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"WZ" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"Yr" = (
+/mob/living/simple_animal/hostile/bloodfiend_mook,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+
+(1,1,1) = {"
+bd
+bd
+bd
+bd
+bd
+bd
+Kq
+Kq
+"}
+(2,1,1) = {"
+kD
+Fp
+kK
+qo
+yk
+bd
+Kq
+Kq
+"}
+(3,1,1) = {"
+Oo
+Fp
+Fp
+ti
+Fp
+bd
+Kq
+Kq
+"}
+(4,1,1) = {"
+kD
+Fp
+Fp
+HF
+WZ
+bd
+Kq
+Kq
+"}
+(5,1,1) = {"
+kD
+Fp
+Fp
+xd
+Fp
+bd
+Kq
+Kq
+"}
+(6,1,1) = {"
+kD
+Fp
+Fp
+Fp
+Fp
+bd
+Kq
+Kq
+"}
+(7,1,1) = {"
+bd
+bd
+bd
+Oo
+bd
+bd
+bd
+bd
+"}
+(8,1,1) = {"
+bd
+PK
+RD
+Fp
+nj
+RD
+vG
+bd
+"}
+(9,1,1) = {"
+bd
+QF
+Fp
+Fp
+Fp
+kI
+QF
+bd
+"}
+(10,1,1) = {"
+bd
+cd
+WZ
+Fp
+Fp
+Ts
+QF
+bd
+"}
+(11,1,1) = {"
+bd
+De
+QF
+Fp
+cE
+ix
+cE
+bd
+"}
+(12,1,1) = {"
+bd
+bd
+bd
+sM
+bd
+bd
+bd
+bd
+"}
+(13,1,1) = {"
+bd
+JD
+Fp
+Fp
+Fp
+Yr
+HR
+bd
+"}
+(14,1,1) = {"
+bd
+La
+Fp
+Yr
+Fp
+Fp
+Ho
+bd
+"}
+(15,1,1) = {"
+bd
+Cs
+Fp
+Fp
+Fp
+Yr
+zu
+bd
+"}
+(16,1,1) = {"
+bd
+bd
+bd
+bd
+bd
+bd
+bd
+bd
+"}

--- a/_maps/RandomRooms/backstreets/medium_east/boluslab_mea.dmm
+++ b/_maps/RandomRooms/backstreets/medium_east/boluslab_mea.dmm
@@ -1,0 +1,203 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"f" = (
+/turf/closed/indestructible/rock,
+/area/city/backstreets_room)
+"g" = (
+/obj/structure/closet/crate{
+	anchorable = 0;
+	anchored = 1
+	},
+/obj/item/essence/wood,
+/obj/item/essence/wood,
+/obj/item/essence/wood,
+/obj/item/essence/wood,
+/obj/item/essence/water,
+/obj/item/essence/water,
+/obj/item/essence/water,
+/obj/item/essence/water,
+/obj/item/essence/metal,
+/obj/item/essence/metal,
+/obj/item/essence/metal,
+/obj/item/essence/metal,
+/obj/item/essence/fire,
+/obj/item/essence/fire,
+/obj/item/essence/fire,
+/obj/item/essence/fire,
+/obj/item/essence/earth,
+/obj/item/bolus/odd,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/shuttle,
+/area/city/backstreets_room)
+"i" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plasteel/shuttle,
+/area/city/backstreets_room)
+"p" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/city/backstreets_room)
+"u" = (
+/obj/machinery/door/airlock/freezer{
+	name = "airlock"
+	},
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"v" = (
+/obj/effect/turf_decal/siding{
+	dir = 10
+	},
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"x" = (
+/turf/closed/indestructible/reinforced,
+/area/city/backstreets_room)
+"y" = (
+/obj/structure/chair/office/light,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"A" = (
+/obj/structure/table/glass,
+/obj/item/bolus/pale,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"E" = (
+/obj/structure/fluff/broken_flooring{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/shuttle,
+/area/city/backstreets_room)
+"G" = (
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"H" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/shuttle,
+/area/city/backstreets_room)
+"M" = (
+/obj/effect/turf_decal/siding{
+	dir = 9
+	},
+/obj/machinery/computer/secure_data/laptop{
+	desc = "An interestingly high-tech laptop, wonder who owned this.";
+	name = "high-tech laptop"
+	},
+/obj/structure/table/glass,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"O" = (
+/obj/structure/table/glass,
+/obj/item/essence/fire,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"P" = (
+/obj/structure/mineral_door/wood,
+/turf/open/floor/plasteel/shuttle,
+/area/city/backstreets_room)
+"S" = (
+/obj/structure/table/glass,
+/obj/item/essence/earth,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"V" = (
+/obj/effect/turf_decal/siding{
+	dir = 6
+	},
+/obj/structure/table/glass,
+/obj/item/essence/wood,
+/obj/item/essence/wood,
+/obj/item/essence/wood,
+/obj/item/essence/wood,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"X" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"Y" = (
+/obj/effect/turf_decal/siding{
+	dir = 5
+	},
+/obj/structure/table/glass,
+/obj/item/bolus/poison,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+
+(1,1,1) = {"
+f
+x
+x
+x
+x
+u
+x
+x
+x
+f
+"}
+(2,1,1) = {"
+f
+x
+X
+X
+G
+G
+G
+G
+x
+f
+"}
+(3,1,1) = {"
+x
+x
+i
+x
+P
+x
+x
+P
+x
+x
+"}
+(4,1,1) = {"
+x
+p
+E
+x
+M
+v
+x
+y
+S
+x
+"}
+(5,1,1) = {"
+x
+g
+H
+x
+Y
+V
+x
+A
+O
+x
+"}
+(6,1,1) = {"
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+"}

--- a/_maps/RandomRooms/backstreets/medium_south/citrine_msa.dmm
+++ b/_maps/RandomRooms/backstreets/medium_south/citrine_msa.dmm
@@ -1,0 +1,136 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"c" = (
+/turf/open/floor/plating/rust,
+/area/city/backstreets_room)
+"f" = (
+/obj/item/stack/spacecash/c10,
+/turf/open/floor/material,
+/area/city/backstreets_room)
+"k" = (
+/mob/living/simple_animal/hostile/ordeal/citrine/archer,
+/turf/open/floor/plating/rust,
+/area/city/backstreets_room)
+"q" = (
+/obj/structure/frame/machine,
+/turf/open/floor/material,
+/area/city/backstreets_room)
+"r" = (
+/turf/open/floor/material{
+	icon_state = "damaged2"
+	},
+/area/city/backstreets_room)
+"t" = (
+/obj/item/stack/spacecash/c10,
+/turf/open/floor/plating/rust,
+/area/city/backstreets_room)
+"x" = (
+/turf/open/floor/material,
+/area/city/backstreets_room)
+"P" = (
+/obj/item/stack/spacecash/c10,
+/mob/living/simple_animal/hostile/ordeal/citrine/archer,
+/turf/open/floor/plating/rust,
+/area/city/backstreets_room)
+"Q" = (
+/turf/closed/indestructible/reinforced,
+/area/city/backstreets_room)
+"S" = (
+/mob/living/simple_animal/hostile/ordeal/citrine/archer,
+/turf/open/floor/material,
+/area/city/backstreets_room)
+"W" = (
+/turf/open/floor/material{
+	icon_state = "damaged3"
+	},
+/area/city/backstreets_room)
+"X" = (
+/obj/item/mecha_parts/mecha_equipment/repair_droid,
+/turf/open/floor/material{
+	icon_state = "damaged1"
+	},
+/area/city/backstreets_room)
+"Z" = (
+/obj/structure/mecha_wreckage/reticence,
+/turf/open/floor/plating/rust,
+/area/city/backstreets_room)
+
+(1,1,1) = {"
+Q
+Q
+Q
+Q
+Q
+Q
+"}
+(2,1,1) = {"
+c
+c
+W
+c
+x
+Q
+"}
+(3,1,1) = {"
+t
+c
+q
+X
+f
+Q
+"}
+(4,1,1) = {"
+c
+c
+c
+k
+x
+Q
+"}
+(5,1,1) = {"
+c
+t
+S
+Z
+S
+Q
+"}
+(6,1,1) = {"
+c
+c
+c
+P
+c
+Q
+"}
+(7,1,1) = {"
+c
+c
+c
+c
+f
+Q
+"}
+(8,1,1) = {"
+c
+c
+c
+r
+x
+Q
+"}
+(9,1,1) = {"
+c
+c
+x
+x
+x
+Q
+"}
+(10,1,1) = {"
+Q
+Q
+Q
+Q
+Q
+Q
+"}

--- a/_maps/RandomRooms/backstreets/medium_south/citrine_msb.dmm
+++ b/_maps/RandomRooms/backstreets/medium_south/citrine_msb.dmm
@@ -1,0 +1,141 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"c" = (
+/turf/open/floor/plating/rust,
+/area/city/backstreets_room)
+"f" = (
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/floor/plating/rust,
+/area/city/backstreets_room)
+"k" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/rust,
+/area/city/backstreets_room)
+"q" = (
+/obj/structure/lootcrate/money,
+/turf/open/floor/plating/rust,
+/area/city/backstreets_room)
+"r" = (
+/mob/living/simple_animal/hostile/ordeal/citrine/knight,
+/turf/open/floor/material{
+	icon_state = "damaged1"
+	},
+/area/city/backstreets_room)
+"t" = (
+/obj/effect/landmark/cratespawn/corpo,
+/turf/open/floor/plating/rust,
+/area/city/backstreets_room)
+"x" = (
+/obj/item/clothing/head/helmet/skull,
+/turf/open/floor/plating/rust,
+/area/city/backstreets_room)
+"P" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating/rust,
+/area/city/backstreets_room)
+"Q" = (
+/turf/closed/indestructible/reinforced,
+/area/city/backstreets_room)
+"S" = (
+/obj/structure/lootcrate/money,
+/turf/open/floor/material{
+	icon_state = "damaged3"
+	},
+/area/city/backstreets_room)
+"W" = (
+/turf/open/floor/material{
+	icon_state = "damaged3"
+	},
+/area/city/backstreets_room)
+"X" = (
+/turf/open/floor/material{
+	icon_state = "damaged1"
+	},
+/area/city/backstreets_room)
+"Z" = (
+/obj/effect/landmark/cratespawn/corpo,
+/turf/open/floor/material{
+	icon_state = "damaged3"
+	},
+/area/city/backstreets_room)
+
+(1,1,1) = {"
+Q
+Q
+Q
+Q
+Q
+Q
+"}
+(2,1,1) = {"
+Q
+P
+W
+f
+x
+Q
+"}
+(3,1,1) = {"
+c
+c
+c
+X
+f
+Q
+"}
+(4,1,1) = {"
+Q
+f
+k
+c
+W
+Q
+"}
+(5,1,1) = {"
+Q
+Q
+Q
+c
+Q
+Q
+"}
+(6,1,1) = {"
+Q
+t
+c
+c
+t
+Q
+"}
+(7,1,1) = {"
+Q
+q
+c
+c
+c
+Q
+"}
+(8,1,1) = {"
+Q
+Z
+c
+r
+c
+Q
+"}
+(9,1,1) = {"
+Q
+c
+X
+c
+S
+Q
+"}
+(10,1,1) = {"
+Q
+Q
+Q
+Q
+Q
+Q
+"}

--- a/_maps/RandomRooms/backstreets/medium_south/medstorage_msa.dmm
+++ b/_maps/RandomRooms/backstreets/medium_south/medstorage_msa.dmm
@@ -1,0 +1,205 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/table/glass,
+/obj/item/flashlight/lamp,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"g" = (
+/mob/living/simple_animal/hostile/ordeal/bigbird_eye{
+	dir = 8
+	},
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"h" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/table/glass,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"o" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/indestructible/reinforced,
+/area/city/backstreets_room)
+"u" = (
+/obj/machinery/door/airlock/freezer{
+	name = "storage"
+	},
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"w" = (
+/obj/machinery/door/airlock/wood,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"y" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack,
+/obj/item/reagent_containers/hypospray/medipen/antitoxin,
+/obj/item/reagent_containers/hypospray/medipen/antitoxin,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"z" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack,
+/obj/item/reagent_containers/hypospray/medipen/l_health,
+/obj/item/reagent_containers/hypospray/medipen/l_health,
+/obj/item/reagent_containers/hypospray/medipen/l_health,
+/obj/item/reagent_containers/hypospray/medipen/l_health,
+/obj/item/reagent_containers/hypospray/medipen/l_health,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"A" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack,
+/obj/item/reagent_containers/hypospray/medipen/l_burn,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"B" = (
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"C" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/hypospray/medipen/l_sanity,
+/obj/item/reagent_containers/hypospray/medipen/l_sanity,
+/obj/item/reagent_containers/hypospray/medipen/l_sanity,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"E" = (
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"H" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"K" = (
+/obj/structure/table/glass,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"L" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"M" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2{
+	layer = 5
+	},
+/obj/structure/rack,
+/obj/item/reagent_containers/hypospray/medipen/l_burn,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"N" = (
+/mob/living/simple_animal/hostile/ordeal/bigbird_eye{
+	dir = 4
+	},
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"Q" = (
+/turf/closed/indestructible/reinforced,
+/area/city/backstreets_room)
+"V" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"W" = (
+/mob/living/simple_animal/hostile/ordeal/bigbird_eye{
+	dir = 1
+	},
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"X" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack,
+/obj/item/reagent_containers/hypospray/medipen/k_simple,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"Y" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+
+(1,1,1) = {"
+Q
+Q
+Q
+Q
+Q
+Q
+"}
+(2,1,1) = {"
+Q
+a
+B
+K
+h
+Q
+"}
+(3,1,1) = {"
+Q
+E
+Y
+L
+g
+Q
+"}
+(4,1,1) = {"
+w
+g
+V
+L
+L
+Q
+"}
+(5,1,1) = {"
+Q
+L
+L
+E
+L
+Q
+"}
+(6,1,1) = {"
+Q
+L
+W
+H
+N
+o
+"}
+(7,1,1) = {"
+Q
+Q
+u
+Q
+Q
+o
+"}
+(8,1,1) = {"
+Q
+y
+E
+H
+C
+Q
+"}
+(9,1,1) = {"
+Q
+M
+X
+A
+z
+Q
+"}
+(10,1,1) = {"
+Q
+Q
+Q
+Q
+Q
+Q
+"}

--- a/_maps/RandomRooms/backstreets/small_east/boluslab_sea.dmm
+++ b/_maps/RandomRooms/backstreets/small_east/boluslab_sea.dmm
@@ -1,0 +1,140 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/closed/indestructible/reinforced,
+/area/city/backstreets_room)
+"e" = (
+/obj/structure/table/wood,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/bolus/pale,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"g" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"j" = (
+/mob/living/simple_animal/hostile/ordeal/sin_wrath/noon,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"k" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced,
+/obj/item/bolus/charred,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"v" = (
+/obj/structure/table/wood,
+/obj/item/bolus/mossy,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"w" = (
+/obj/structure/table/wood,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/bolus/clay,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"x" = (
+/obj/structure/table/wood,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/bolus/poison,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"y" = (
+/obj/structure/table/wood,
+/obj/item/bolus/rust,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"F" = (
+/obj/structure/table/wood,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/bolus/flower,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"J" = (
+/obj/structure/table/wood,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/bolus/soaked,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"K" = (
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"N" = (
+/obj/structure/table/wood,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/bolus/armor,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"Q" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"X" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+
+(1,1,1) = {"
+a
+a
+a
+a
+a
+X
+a
+"}
+(2,1,1) = {"
+a
+v
+w
+F
+N
+g
+a
+"}
+(3,1,1) = {"
+a
+k
+j
+g
+g
+K
+a
+"}
+(4,1,1) = {"
+a
+y
+J
+e
+x
+Q
+a
+"}
+(5,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+"}

--- a/_maps/RandomRooms/backstreets/small_east/citrine_sea.dmm
+++ b/_maps/RandomRooms/backstreets/small_east/citrine_sea.dmm
@@ -1,0 +1,86 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/closed/indestructible/reinforced,
+/area/city/backstreets_room)
+"m" = (
+/mob/living/simple_animal/hostile/ordeal/citrine/knight,
+/turf/open/floor/bronze,
+/area/city/backstreets_room)
+"v" = (
+/turf/open/floor/bronze,
+/area/city/backstreets_room)
+"w" = (
+/obj/structure/fluff/clockwork/alloy_shards/medium_gearbit,
+/turf/open/floor/bronze,
+/area/city/backstreets_room)
+"x" = (
+/obj/structure/fluff/clockwork/alloy_shards,
+/turf/open/floor/bronze,
+/area/city/backstreets_room)
+"J" = (
+/obj/structure/fluff/clockwork/clockgolem_remains,
+/turf/open/floor/bronze,
+/area/city/backstreets_room)
+"N" = (
+/obj/structure/fluff/clockwork/blind_eye,
+/turf/open/floor/bronze,
+/area/city/backstreets_room)
+"S" = (
+/obj/structure/fluff/clockwork/alloy_shards/medium,
+/obj/structure/fluff/clockwork/fallen_armor,
+/turf/open/floor/bronze,
+/area/city/backstreets_room)
+"T" = (
+/obj/structure/fluff/clockwork/alloy_shards/large,
+/turf/open/floor/bronze,
+/area/city/backstreets_room)
+"X" = (
+/obj/item/nullrod/spear,
+/turf/open/floor/bronze,
+/area/city/backstreets_room)
+
+(1,1,1) = {"
+a
+v
+v
+v
+v
+v
+a
+"}
+(2,1,1) = {"
+a
+J
+v
+w
+X
+v
+a
+"}
+(3,1,1) = {"
+a
+v
+x
+m
+v
+N
+a
+"}
+(4,1,1) = {"
+a
+S
+v
+v
+v
+T
+a
+"}
+(5,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+"}

--- a/_maps/RandomRooms/backstreets/small_south/boluslab_ssa.dmm
+++ b/_maps/RandomRooms/backstreets/small_south/boluslab_ssa.dmm
@@ -1,0 +1,112 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/table/glass,
+/obj/item/essence/metal,
+/obj/item/essence/metal,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"o" = (
+/obj/item/clipboard,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"t" = (
+/obj/structure/table/glass,
+/obj/item/bolus/simple,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"x" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"M" = (
+/obj/structure/table/glass,
+/obj/item/flashlight/lamp,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"N" = (
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"P" = (
+/obj/machinery/door/airlock/wood,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"R" = (
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"S" = (
+/obj/structure/chair/office/light,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"U" = (
+/turf/closed/indestructible/reinforced,
+/area/city/backstreets_room)
+"X" = (
+/obj/structure/table/glass,
+/obj/item/essence/fire,
+/obj/item/essence/fire,
+/obj/item/essence/fire,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"Y" = (
+/obj/structure/closet/crate{
+	anchorable = 0;
+	anchored = 1
+	},
+/obj/item/bolus/rust,
+/obj/item/storage/box/hcorpmetal,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+
+(1,1,1) = {"
+U
+U
+U
+U
+U
+"}
+(2,1,1) = {"
+U
+M
+N
+t
+U
+"}
+(3,1,1) = {"
+U
+R
+S
+X
+U
+"}
+(4,1,1) = {"
+P
+R
+x
+a
+U
+"}
+(5,1,1) = {"
+U
+R
+R
+R
+U
+"}
+(6,1,1) = {"
+U
+Y
+o
+R
+U
+"}
+(7,1,1) = {"
+U
+U
+U
+U
+U
+"}

--- a/_maps/RandomRooms/backstreets/small_west/boluslab_swa.dmm
+++ b/_maps/RandomRooms/backstreets/small_west/boluslab_swa.dmm
@@ -1,0 +1,134 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/closed/indestructible/reinforced,
+/area/city/backstreets_room)
+"n" = (
+/obj/structure/table/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/bolus/simple,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"p" = (
+/obj/structure/closet/crate{
+	anchorable = 0;
+	anchored = 1
+	},
+/obj/item/storage/box/hcorpwood,
+/obj/item/essence/wood,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"v" = (
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"w" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate{
+	anchorable = 0;
+	anchored = 1
+	},
+/obj/item/storage/box/hcorpearth,
+/obj/item/essence/earth,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"x" = (
+/obj/structure/closet/crate{
+	anchorable = 0;
+	anchored = 1
+	},
+/obj/item/storage/box/hcorpfire,
+/obj/item/essence/fire,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"E" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate{
+	anchorable = 0;
+	anchored = 1
+	},
+/obj/item/storage/box/hcorpwater,
+/obj/item/essence/water,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"J" = (
+/obj/structure/closet/crate{
+	anchorable = 0;
+	anchored = 1
+	},
+/obj/item/storage/box/hcorpmetal,
+/obj/item/essence/metal,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"K" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"N" = (
+/obj/structure/table/glass,
+/obj/item/flashlight/lamp,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"O" = (
+/obj/structure/chair/office/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"P" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ordeal/sin_gloom/noon,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+"X" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/holofloor/white,
+/area/city/backstreets_room)
+
+(1,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+"}
+(2,1,1) = {"
+a
+x
+w
+X
+N
+v
+a
+"}
+(3,1,1) = {"
+a
+J
+X
+P
+O
+n
+a
+"}
+(4,1,1) = {"
+a
+E
+p
+X
+X
+X
+a
+"}
+(5,1,1) = {"
+a
+a
+a
+a
+a
+K
+a
+"}


### PR DESCRIPTION
## About The Pull Request
10 New Citrine, Bolus and more themed COL rooms!
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More COL Rooms is always awesome. I do enjoy seeing the map variety created from it!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Did you test this PR?

* [ ] This PR compiles
* [ ] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
add: Added 10 new COL maps
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
