### PR TITLE
NCorp Temperience Discount (the competitors are cutthroat)

### DIFF
--- a/ModularLobotomy/representative/research/ncorp.dm
+++ b/ModularLobotomy/representative/research/ncorp.dm
@@ -84,10 +84,10 @@
 	required_research = /datum/data/lc13research/nbuff1
 
 /datum/data/lc13research/ntemp1/ResearchEffect(obj/structure/representative_console/requester)
-	ItemUnlock(requester.order_list, "Fading Fortitude Ampule",	/obj/item/attribute_temporary/fortitudesmall, 500)
-	ItemUnlock(requester.order_list, "Fading Temperance Ampule",	/obj/item/attribute_temporary/temperancesmall, 500)
-	ItemUnlock(requester.order_list, "Fading Prudence Ampule",	/obj/item/attribute_temporary/prudencesmall, 500)
-	ItemUnlock(requester.order_list, "Fading Justice Ampule",	/obj/item/attribute_temporary/justicesmall, 500)
+	ItemUnlock(requester.order_list, "Fading Fortitude Ampule",	/obj/item/attribute_temporary/fortitudesmall, 250)
+	ItemUnlock(requester.order_list, "Fading Temperance Ampule",	/obj/item/attribute_temporary/temperancesmall, 250)
+	ItemUnlock(requester.order_list, "Fading Prudence Ampule",	/obj/item/attribute_temporary/prudencesmall, 250)
+	ItemUnlock(requester.order_list, "Fading Justice Ampule",	/obj/item/attribute_temporary/justicesmall, 250)
 	..()
 
 /datum/data/lc13research/ntemp2
@@ -98,7 +98,7 @@
 	required_research = /datum/data/lc13research/ntemp1
 
 /datum/data/lc13research/ntemp2/ResearchEffect(obj/structure/representative_console/requester)
-	ItemUnlock(requester.order_list, "Fading Attribute Ampule",	/obj/item/attribute_temporary/stattemporary, 1000)
+	ItemUnlock(requester.order_list, "Fading Attribute Ampule",	/obj/item/attribute_temporary/stattemporary, 500)
 	..()
 
 /datum/data/lc13research/ntemp3
@@ -109,10 +109,10 @@
 	required_research = /datum/data/lc13research/ntemp2
 
 /datum/data/lc13research/ntemp3/ResearchEffect(obj/structure/representative_console/requester)
-	ItemUnlock(requester.order_list, "Focused Fading Fortitude Ampule",	/obj/item/attribute_temporary/fortitudebig, 1500)
-	ItemUnlock(requester.order_list, "Focused Fading Temperance Ampule",	/obj/item/attribute_temporary/temperancebig, 1500)
-	ItemUnlock(requester.order_list, "Focused Fading Prudence Ampule",	/obj/item/attribute_temporary/prudencebig, 1500)
-	ItemUnlock(requester.order_list, "Focused Fading Justice Ampule",	/obj/item/attribute_temporary/justicebig, 1500)
+	ItemUnlock(requester.order_list, "Focused Fading Fortitude Ampule",	/obj/item/attribute_temporary/fortitudebig, 750)
+	ItemUnlock(requester.order_list, "Focused Fading Temperance Ampule",	/obj/item/attribute_temporary/temperancebig, 750)
+	ItemUnlock(requester.order_list, "Focused Fading Prudence Ampule",	/obj/item/attribute_temporary/prudencebig, 750)
+	ItemUnlock(requester.order_list, "Focused Fading Justice Ampule",	/obj/item/attribute_temporary/justicebig, 7500)
 	..()
 
 


### PR DESCRIPTION
## About The Pull Request
Halves the ahn price of all temporary attribute ampules until the scripture update.

## Why It's Good For The Game
N-Corp lacks endgame benefit once a agent has maxed out and the addition of new features which consume ahn has caused the price of temporary ampules to become too exorbitant in comparison. Underperforming reps are bad so this is a temporary buff until I finish coding scriptures.

### Put your cool images here
<img width="423" height="280" alt="image" src="https://github.com/user-attachments/assets/d1da2d96-925c-4858-a3f1-e735225998d2" />

_The shutterstock sounded funnier in my head_

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
balance: NCorp rep temp ampule price cut in half
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
