### PR TITLE
G-Corp warbeast deletes on death

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/steel/warbeast.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/steel/warbeast.dm
@@ -33,6 +33,12 @@
 	. = ..()
 	ADD_TRAIT(src, TRAIT_STRONG_GRABBER, "initialize")
 
+/mob/living/simple_animal/hostile/ordeal/steel_dawn/steel_midnight/death(gibbed)
+	density = FALSE
+	animate(src, alpha = 0, time = 10 SECONDS)
+	QDEL_IN(src, 10 SECONDS)
+	return ..()
+
 /mob/living/simple_animal/hostile/ordeal/steel_dawn/steel_midnight/handle_automated_action()
 	. = ..()
 	if(stat == DEAD)


### PR DESCRIPTION
## About The Pull Request
Does what it says on the tin.
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
sometimes we get weird sprite shit, I want to avoid that.
A shitty fix.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


### Did you test this PR?

* [ ] This PR compiles
* [ ] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
tweak: G-Corp Warbeast deletes on death.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
