### PR TITLE
Makes E.G.O. purchase console UI more lightweight

### DIFF
--- a/ModularLobotomy/lc13_obj/lc13_computers/abnormality_ego.dm
+++ b/ModularLobotomy/lc13_obj/lc13_computers/abnormality_ego.dm
@@ -348,7 +348,7 @@
 
 			ego_list |= list(datum_data)
 
-		// Actual Abnormality data. Portrait not included here, it's in static data and linked to the abno via its reference in the UI.
+		// Actual Abnormality data.
 		var/list/abno_data = list(
 			"name" = AD.name,
 			"desc" = AD.desc,
@@ -366,13 +366,16 @@
 /obj/machinery/computer/ego_purchase/ui_static_data(mob/user)
 	var/list/data = list()
 	data["all_tags"] = list()
+
+	// Abnormality portraits commented out due to performance concerns.
+	/*
 	data["abnormality_portraits"] = list()
 
 	for(var/datum/abnormality/AD in SSlobotomy_corp.all_abnormality_datums)
 		var/list/abno_data = list(REF(AD) = GetPortraitOrPreview(AD))
 
 		data["abnormality_portraits"] += abno_data
-
+	*/
 
 	// Get all the EGO tags defined in EGO_TAGS_DESCRIPTION_LIST and send an object consisting of their name and description, also tag_checked so we can easily turn their filtering on and off in the frontend
 	for(var/tag in EGO_TAGS_DESCRIPTION_LIST)

--- a/tgui/packages/tgui/interfaces/EgoPurchaseConsole.js
+++ b/tgui/packages/tgui/interfaces/EgoPurchaseConsole.js
@@ -13,7 +13,7 @@ grouping the E.G.O. by Abnormality and the Abnormalities by Threat Class.
 
 export const EgoPurchaseConsole = (props, context) => {
   const { act, data } = useBackend(context);
-  const { abnormalities, abnormality_portraits,
+  const { abnormalities,
     all_tags, log, user_price_multiplier, selected_level } = data;
 
   /* ------------ React Hooks ------------*/
@@ -547,17 +547,6 @@ export const EgoPurchaseConsole = (props, context) => {
         <Collapsible title={datum.name + " - " + datum.boxes + " PE"} color={ActiveFilters() && PassesFilters(datum) ? "green" : "default"} key={datum.name} open={collapsiblesStateList[datum.name]}
           onClick={() => UpdateCollapsibleStatesList(datum.name)}>
           <Flex direction="column" align="center">
-            <FlexItem
-              as="img"
-              m={2}
-              src={`data:image/jpeg;base64,
-                ${abnormality_portraits[datum.reference]}`}
-              height="64px"
-              width="64px"
-              style={{
-                '-ms-interpolation-mode': 'nearest-neighbor',
-              }} />
-
             <FlexItem>
               {datum.boxes} PE
             </FlexItem>


### PR DESCRIPTION
## About The Pull Request
Basically people complain (and I've experienced) about several seconds of delay when trying to open the E.G.O. purchase console.
Looking into it, it seems that the abnormality portraits being turned into Base64 is pretty expensive in terms of size, as they are significantly larger than armour/weapon icons, so perhaps those assets being beamed over to the players is taking too long.

While I can test this on local to make sure it works, I can't really simulate latency and bandwidth as easily, so I will need to see how it feels on the live server.

If this isn't enough to make the UI passably agile, then I will have to take more drastic measures like only sending the active tab's data on demand, which I don't want to do since it makes some things like search highlighting a lot harder.

I'm going to try and investigate to see if it's possible to do lazy loading for the icons in general, too.
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Smoother interface, an interface which is used very often in facility mode.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
tweak: E.G.O. purchase console no longer displays Abnormality portraits, in the interest of performance.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
