### PR TITLE
rosespanner bug fix and buff?!?!?!

### DIFF
--- a/ModularLobotomy/ego_weapons/melee/city/rosespanner.dm
+++ b/ModularLobotomy/ego_weapons/melee/city/rosespanner.dm
@@ -33,12 +33,10 @@
 	charged = TRUE
 	qdel(I)
 
-/obj/item/ego_weapon/city/rosespanner/HandleCharge(added_charge, mob/target)
+/obj/item/ego_weapon/city/rosespanner/HandleCharge(added_charge, mob/target) // Came here for a bugfix, accidentally buffed it by letting the overcharge bypass charge consumption
 	. = ..()
-	if(!.)
-		return FALSE
 
-	if(charge_amount == charge_cap)
+	if(charge_amount >= charge_cap)
 		overcharged = TRUE
 		currently_charging = TRUE
 


### PR DESCRIPTION
## About The Pull Request

<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! --> fixed a bug inside of the weapon's handlecharge, it had a check that was always true, making it return early. also it now can infinitely do it's 'charged attack' as long as you don't mind killing yourself in the process.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --> Bug Fix + buff to one of the least used inputs (will honestly not change the fact that it'll still be the least used)

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [x] This PR compiles
* [x] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [x] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
fix: rosespanner/HandleCharge() to actually detect that the weapon is 'overcharged'
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
