### PR TITLE
LCL Minor Update: Bug Fixes

### DIFF
--- a/ModularLobotomy/ego_weapons/melee/city/udjat_limbus.dm
+++ b/ModularLobotomy/ego_weapons/melee/city/udjat_limbus.dm
@@ -69,8 +69,8 @@
 		balloon_alert(user, "Stun activated.")
 
 
-//Ever important weapon, the mask.
-/obj/item/clothing/head/udjat
+//Ever important weapon, the mask. On the mask slot, so it does not fight a helmet for the head.
+/obj/item/clothing/mask/udjat
 	name = "\improper Udjat mask"
 	desc = "A mask worn by The Udjat, a mysterious Grade 1 Fixer office."
 	icon_state = "udjat"

--- a/ModularLobotomy/limbus_labs/lce_areas.dm
+++ b/ModularLobotomy/limbus_labs/lce_areas.dm
@@ -25,6 +25,7 @@
 	icon_state = "lce_light_block"
 	area_flags = BLOBS_ALLOWED | UNIQUE_AREA | CULT_PERMITTED
 	sound_environment = SOUND_AREA_TUNNEL_ENCLOSED
+	var/specimen_cell = FALSE
 
 /area/lce/containment/light
 	name = "Light Containment"
@@ -33,18 +34,22 @@
 /area/lce/containment/light/one
 	name = "Light Containment Unit 1"
 	icon_state = "lce_light_1"
+	specimen_cell = TRUE
 
 /area/lce/containment/light/two
 	name = "Light Containment Unit 2"
 	icon_state = "lce_light_2"
+	specimen_cell = TRUE
 
 /area/lce/containment/light/three
 	name = "Light Containment Unit 3"
 	icon_state = "lce_light_3"
+	specimen_cell = TRUE
 
 /area/lce/containment/light/four
 	name = "Light Containment Unit 4"
 	icon_state = "lce_light_4"
+	specimen_cell = TRUE
 
 // One booth per column, serving the unit above and the unit below through separate poddoor banks.
 /area/lce/containment/light/control_west
@@ -68,10 +73,12 @@
 /area/lce/containment/heavy/one
 	name = "Heavy Containment Unit 1"
 	icon_state = "lce_heavy_1"
+	specimen_cell = TRUE
 
 /area/lce/containment/heavy/two
 	name = "Heavy Containment Unit 2"
 	icon_state = "lce_heavy_2"
+	specimen_cell = TRUE
 
 /area/lce/containment/heavy/control_one
 	name = "Heavy Containment Control 1"

--- a/ModularLobotomy/limbus_labs/lce_lasso.dm
+++ b/ModularLobotomy/limbus_labs/lce_lasso.dm
@@ -39,6 +39,10 @@
 	var/tension_per_tile = 6
 	var/tension_blocked = 14
 	var/tension_decay = 9
+	///How long the tethered specimen has to haul on the line before it tears, and the in-progress
+	///flag that stops a second drag starting another attempt.
+	var/tug_time = 3 SECONDS
+	var/tugging = FALSE
 	///Half the flicker cycle; the pair of animate() calls loops as twice this.
 	var/flicker_time = 2 SECONDS
 	var/flicker_alpha = 255
@@ -63,6 +67,8 @@
 	. += span_notice("Tethered to [tethered].")
 	. += span_notice("Tension: [round(tension)]%. Distance and closed doors both raise it.")
 	. += span_warning("Past [break_range] tiles it tears loose outright.")
+	. += span_warning("[tethered] can tear it off from their end by hauling on the line for \
+		[DisplayTimeText(tug_time)] without moving.")
 
 ///Shared gate for both ways of getting the loop on: by hand and cast from range.
 /obj/item/qliphoth_lasso/proc/CanLasso(mob/living/simple_animal/hostile/limbus_abno/target, mob/user)
@@ -165,6 +171,11 @@
 	var/mob/holder = get(src, /mob)
 	return holder || src
 
+///TRUE when the spool has ended up inside the specimen it is earthed to - swallowed, most likely.
+///The beam hangs off whoever holds it, so from in there range and sight can never fail again.
+/obj/item/qliphoth_lasso/proc/HeldByTethered()
+	return tethered && (BeamOrigin() == tethered)
+
 /obj/item/qliphoth_lasso/proc/RefreshBeam()
 	if(QDELETED(tethered))
 		return
@@ -180,6 +191,9 @@
 //change hands.
 /obj/item/qliphoth_lasso/Moved(atom/OldLoc, Dir, Forced = FALSE)
 	. = ..()
+	if(HeldByTethered())
+		Snap()
+		return
 	RefreshBeam()
 
 /obj/item/qliphoth_lasso/proc/StartVisuals()
@@ -219,6 +233,9 @@
 /obj/item/qliphoth_lasso/process(delta_time)
 	if(QDELETED(tethered) || tethered.stat >= DEAD)
 		Release()
+		return
+	if(HeldByTethered()) //Backstop for any route in that does not go through Moved().
+		Snap()
 		return
 	var/turf/mine = get_turf(src)
 	var/turf/theirs = get_turf(tethered)
@@ -291,11 +308,29 @@
 		return
 	return ..()
 
-//...nor drag it around after itself.
+//...nor drag it around after itself. Hauling on the line is what that gets them instead.
 /obj/item/qliphoth_lasso/can_be_pulled(user, grab_state, force)
 	if(user == tethered)
+		INVOKE_ASYNC(src, PROC_REF(TugFree), tethered)
 		return FALSE
 	return ..()
+
+///The way out from the specimen's own end: haul on the line without moving for tug_time and the
+///cable tears. The lasso is the do_after target, so either end moving drops the attempt.
+/obj/item/qliphoth_lasso/proc/TugFree(mob/living/simple_animal/hostile/limbus_abno/puller)
+	if(tugging || tethered != puller)
+		return
+	tugging = TRUE
+	puller.visible_message(span_boldwarning("[puller] starts hauling against [src]!"), \
+		span_notice("You set yourself against the line and pull. Hold still and keep at it."))
+	if(do_after(puller, tug_time, src) && tethered == puller)
+		playsound(puller, 'sound/effects/snap.ogg', 70, TRUE)
+		puller.visible_message(span_boldwarning("[puller] tears [src] loose!"), \
+			span_nicegreen("The cable gives, and the weight comes back. You are yourself again."))
+		Release(silent = TRUE)
+	else
+		to_chat(puller, span_warning("The line goes slack, and settles again. It is still on you."))
+	tugging = FALSE
 
 /obj/effect/lce_lasso_glow
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT

--- a/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno.dm
+++ b/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno.dm
@@ -127,7 +127,7 @@
 	breach_overlay.transform = matrix() * breach_overlay_scale
 	if(SSmaptype.maptype == "limbus_labs") //If for some reason they spawn outside the limbus map, we're not giving them a healspot since it's designed for their starting cell.
 		limbus_map = TRUE
-		for(var/turf/open/T in range(3, src)) // Covers most of the cell in healing spots for the abno.
+		for(var/turf/open/T in CellTurfs()) // Covers the cell in healing spots for the abno.
 			var/obj/effect/abno_heal_spot/heal_spot = new(T)
 			heal_spot.abno = src
 
@@ -199,6 +199,29 @@
 		to_chat(get_ghost(TRUE, TRUE), span_notice("Your shell will split open in [left]. Return to it then."))
 	mind = null //We make it repossessable again so the abno at least has the opportunity of being played if someone gets bored of it. Doesn't include logout.
 
+//A specimen is not an /abnormality mob, so the drag path's type check would refuse all of them.
+/mob/living/simple_animal/hostile/limbus_abno/CanGhostDragPossess()
+	return TRUE
+
+///Whether this body is spoken for. Subtypes that can step out of themselves also answer TRUE
+///off the projection itself, so a missed possession_locked can never leave the body open.
+/mob/living/simple_animal/hostile/limbus_abno/proc/PossessionLocked()
+	return possession_locked
+
+///The open turfs of the cell this specimen woke up in. Cells are areas of their own, so this
+///stays in step with a cell whatever size it is redrawn at; a square around the spawn does not.
+/mob/living/simple_animal/hostile/limbus_abno/proc/CellTurfs(fallback_range = 3)
+	var/list/turfs = list()
+	var/area/lce/containment/cell = get_area(src)
+	if(istype(cell) && cell.specimen_cell)
+		for(var/turf/open/T in cell)
+			turfs += T
+		return turfs
+	//Somewhere that is not a cell - an admin drop, a test room. Back to a square around us.
+	for(var/turf/open/T in range(fallback_range, src))
+		turfs += T
+	return turfs
+
 ///Due to how repression works in LCL, we need to account for most source of damage inflicted by players, but abnos beating each other up shouldn't count by default.
 ///Ideally, we want even abnos that like repression to get pissed off if they get too close to death, to not encourage accidental killing during repression work.
 ///This doesn't include stuff like special damage effects like non projectiles or attacks, but I'm too lazy to code it better and account for every edge case.
@@ -228,6 +251,8 @@
 
 /mob/living/simple_animal/hostile/limbus_abno/Life()
 	. = ..()
+	if(stat >= DEAD) //A shell has no needs, and draining them breached the corpse.
+		return
 	if(hunger_cooldown < world.time)
 		Hungrier(hunger_loss, FALSE)
 		hunger_cooldown = world.time + hunger_cooldown_time
@@ -689,11 +714,15 @@
 		abno_user.AdjustCounter(abno_user.max_counter)
 	StartCooldown()
 
-///Abno heal spot
+///Abno heal spot. Bookkeeping laid over a cell floor, so it gets a landmark's treatment: nothing
+///can examine it, drag it out of the cell or shut it in a crate.
 /obj/effect/abno_heal_spot
 	name = "Abno heal spot"
 	desc = "Where an abno can heal. You shouldn't be able to read this."
 	opacity = FALSE
+	anchored = TRUE
+	invisibility = INVISIBILITY_ABSTRACT
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	var/mob/living/simple_animal/hostile/limbus_abno/abno
 
 ///Desire (mood) HUD bar. One updating alert instead of five: the face (mood1..mood9) plus a red->green tint show how the abno feels at a glance.

--- a/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_highsec/lcl_despair_knight.dm
+++ b/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_highsec/lcl_despair_knight.dm
@@ -265,6 +265,10 @@
 	possession_locked = TRUE //The crystal is not vacant, whatever a ghost sees.
 	mind.transfer_to(manifest)
 
+//The crystal is never vacant while she is out in the manifest, flag or no flag.
+/mob/living/simple_animal/hostile/limbus_abno/despair_knight/PossessionLocked()
+	return ..() || !QDELETED(manifest) || crystallized
+
 //Cannot commune through EGO while manifested (and vice versa - manifest is blocked above).
 /mob/living/simple_animal/hostile/limbus_abno/despair_knight/CommuneMenu()
 	if(manifest || crystallized)
@@ -280,7 +284,11 @@
 	//stranded in the player's client pointing at a deleted mob.
 	manifest.ClearImage()
 	if(manifest.mind)
-		manifest.mind.transfer_to(src)
+		if(CanReturnTo(src, manifest))
+			manifest.mind.transfer_to(src)
+		else //Someone else got in. Moving a mind into an occupied mob drops their client.
+			to_chat(manifest, span_userdanger("Something else is wearing your body. There is nothing to go back to."))
+			manifest.ghostize(FALSE)
 	QDEL_NULL(manifest)
 	possession_locked = FALSE
 	Crystallize(FALSE)

--- a/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_highsec/lcl_hatred_queen.dm
+++ b/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_highsec/lcl_hatred_queen.dm
@@ -777,6 +777,10 @@
 		return TRUE
 	return (villainy >= marker_villainy_req) || (desire_bar >= marker_desire_req)
 
+// The marker holding her mind is itself proof the body is not free, flag or no flag.
+/mob/living/simple_animal/hostile/limbus_abno/hatred_queen/PossessionLocked()
+	return ..() || !QDELETED(marker)
+
 // First press projects the reticle, second recalls it and teleports her body to it.
 /mob/living/simple_animal/hostile/limbus_abno/hatred_queen/proc/ProjectMarker()
 	if(marker || hysteric || !mind || !can_act)
@@ -804,9 +808,9 @@
 	recalling_marker = TRUE
 	var/turf/destination = get_turf(marker)
 	if(marker.mind)
-		if(QDELETED(src))
-			// Called from Destroy(): the body is already going away, so pushing a player
-			// into it would strand them in a deleting mob. Ghost them out instead.
+		if(!CanReturnTo(src, marker))
+			if(!QDELETED(src))
+				to_chat(marker, span_userdanger("Something else is wearing your body. There is nothing to go back to."))
 			marker.ghostize(FALSE)
 		else
 			marker.mind.transfer_to(src)

--- a/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_highsec/lcl_mountain.dm
+++ b/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_highsec/lcl_mountain.dm
@@ -61,6 +61,8 @@
 	var/list/protected_words = list("clean", "cook", "fight")
 	var/list/growls_low = list("Grgh", "Ghhrg", "Krrgh")
 	var/list/growls_high = list("Krrrrh", "Grr… Ghrrrgh", "Ghrrr", "KHAAA")
+	///Whether the one monkey it wakes up to has already been handed over this round.
+	var/first_meal_given = FALSE
 
 /mob/living/simple_animal/hostile/limbus_abno/mountain/funpet(mob/living/petter)
 	. = ..()
@@ -79,13 +81,14 @@
 
 /mob/living/simple_animal/hostile/limbus_abno/mountain/Login()
 	. = ..()
-	icon_living = "mosb_breach"
-	icon_state = icon_living
+	if(first_meal_given || stat >= DEAD)
+		return
+	first_meal_given = TRUE
 	new /mob/living/carbon/human/species/monkey(get_turf(src))
 
 //We don't really swap phases when mountain dies like the original, instead we make it change phases depending on its HP after updating health.
 /mob/living/simple_animal/hostile/limbus_abno/mountain/updatehealth()
-	if(!breached)
+	if(!breached || stat >= DEAD)
 		return ..()
 	var/phase_threshold = maxHealth * 0.3
 
@@ -104,6 +107,31 @@
 	if(spitting || !spit_ready)
 		return FALSE
 	Spit(target)
+
+/mob/living/simple_animal/hostile/limbus_abno/mountain/Rebirth()
+	breached = FALSE
+	unstable = FALSE
+	phase = 1
+	body_count = 0
+	spit_ready = FALSE
+	spitting = FALSE
+	ranged = FALSE
+	maxHealth = phase_one_health
+	melee_damage_lower = initial(melee_damage_lower)
+	melee_damage_upper = initial(melee_damage_upper)
+	max_starving_patience = initial(max_starving_patience)
+	starving_patience = max_starving_patience
+	satiated = FALSE //Set, not RegularHunger() - that narrates a meal the shell never had.
+	hunger_cooldown_time = initial(hunger_cooldown_time)
+	RemoveBreachEffect()
+	. = ..()
+	icon = original_abno.icon
+	icon_living = OriginalLivingState()
+	icon_state = icon_living
+	pixel_x = initial(pixel_x)
+	base_pixel_x = initial(base_pixel_x)
+	pixel_y = initial(pixel_y)
+	base_pixel_y = initial(base_pixel_y)
 
 ///If increase is TRUE, we move up a phase, if FALSE, go down.
 /mob/living/simple_animal/hostile/limbus_abno/mountain/proc/ChangePhase(increase = TRUE)

--- a/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_highsec/lcl_queen_bee.dm
+++ b/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_highsec/lcl_queen_bee.dm
@@ -146,6 +146,8 @@
 	faction = list("neutral") //Their AI lobotomy should prevent friendly attack, but better safe than sorry.
 	created_bee_type = /mob/living/simple_animal/hostile/worker_bee/lcl_bee
 	var/mob/living/simple_animal/hostile/limbus_abno/queen_bee/queen
+	///Whose hive body is parked while this worker is being ridden. Only that player gets it back.
+	var/rider_ckey
 
 /mob/living/simple_animal/hostile/worker_bee/lcl_bee/Initialize()
 	. = ..()
@@ -156,15 +158,41 @@
 	var/datum/action/cooldown/bee_scavenge/beenge = new() //I'm kinda pushing it with that one.
 	beenge.Grant(src)
 
+//Ghost-playable on purpose - that is what the spawn message is for. It is not a way into the hive.
+/mob/living/simple_animal/hostile/worker_bee/lcl_bee/CanGhostDragPossess()
+	return TRUE
+
 /mob/living/simple_animal/hostile/worker_bee/lcl_bee/death()
-	if(queen)
-		//Swatted while she was riding it. Unlock first, or the body she is being sent back to
-		//stays flagged as occupied-elsewhere for the rest of the round.
-		queen.possession_locked = FALSE
-		if(mind)
-			mind.transfer_to(queen)
-		queen = null
+	ReturnRider()
 	..()
+
+/mob/living/simple_animal/hostile/worker_bee/lcl_bee/Destroy()
+	ReturnRider()
+	return ..()
+
+///Whether the player in this worker is the queen who stepped out of the hive to ride it. Anybody
+///else in here is a passenger, and sending them home would throw her out of her own mob.
+/mob/living/simple_animal/hostile/worker_bee/lcl_bee/proc/CanRideBack()
+	if(!rider_ckey || ckey != rider_ckey)
+		return FALSE
+	return CanReturnTo(queen, src)
+
+///The ride is over: swatted, gibbed, or walked out of by hand. The hive unlocks whatever the
+///reason, and the player only moves if the hive is theirs to move into.
+/mob/living/simple_animal/hostile/worker_bee/lcl_bee/proc/ReturnRider()
+	var/mob/living/simple_animal/hostile/limbus_abno/queen_bee/hive = queen
+	var/returning = rider_ckey
+	var/riding_home = CanRideBack()
+	queen = null
+	rider_ckey = null
+	if(QDELETED(hive))
+		return FALSE
+	hive.possession_locked = FALSE //Unlocked first, or it stays flagged for the rest of the round.
+	if(!riding_home)
+		return FALSE
+	mind = null //The throwaway mind Login() made here. Hers is still parked on the hive.
+	hive.ckey = returning
+	return TRUE
 
 /datum/action/cooldown/bee_scavenge
 	name = "Scavenge for meat."
@@ -199,28 +227,43 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	var/mob/living/simple_animal/hostile/worker_bee/lcl_bee/user_bee
 	if(istype(owner, /mob/living/simple_animal/hostile/worker_bee/lcl_bee))
-		user_bee = owner
-		if(user_bee.queen)
-			user_bee.queen.possession_locked = FALSE //She is home; the hive body is hers again.
-			user_bee.queen.ckey = user_bee.ckey
-			user_bee.mind = null
-			user_bee.queen = null
-			qdel(src)
-			return
+		return ReturnToHive(owner)
+	return RideWorker()
 
+///Back out of a worker and into the hive body.
+/datum/action/cooldown/bee_swap/proc/ReturnToHive(mob/living/simple_animal/hostile/worker_bee/lcl_bee/user_bee)
+	if(QDELETED(user_bee.queen))
+		to_chat(user_bee, span_warning("There is no hive left to go back to."))
+		return FALSE
+	if(!user_bee.CanRideBack())
+		to_chat(user_bee, span_warning("The hive body is not yours. You are a worker, and only that."))
+		return FALSE
+	user_bee.ReturnRider()
+	qdel(src)
+	return TRUE
+
+///Out of the hive body and into ONE worker that nobody is home in. The loop used to run to the
+///end of the list, handing every free bee a button that led back into her body.
+/datum/action/cooldown/bee_swap/proc/RideWorker()
+	var/mob/living/simple_animal/hostile/limbus_abno/queen_bee/queen = owner
+	var/rider = queen.ckey
+	if(!rider)
+		return FALSE
 	for(var/mob/living/simple_animal/hostile/worker_bee/lcl_bee/bee in GLOB.alive_mob_list)
-		if(!bee.mind && !bee.ckey)
-			var/mob/living/simple_animal/hostile/limbus_abno/queen_bee/queen = owner
-			//Held before the ckey moves. Her body is about to look unoccupied to every ghost.
-			if(istype(queen))
-				queen.possession_locked = TRUE
-			bee.ckey = owner.ckey //We don't use transfer_to because it creates possession issues.
-			var/datum/action/cooldown/bee_swap/bs = new /datum/action/cooldown/bee_swap()
-			bs.Grant(bee)
-			bee.queen = owner
-			StartCooldown()
+		if(bee.mind || bee.ckey || bee.queen)
+			continue
+		//Held before the ckey moves. Her body is about to look unoccupied to every ghost.
+		queen.possession_locked = TRUE
+		bee.queen = queen
+		bee.rider_ckey = rider
+		bee.ckey = rider //We don't use transfer_to because it creates possession issues.
+		var/datum/action/cooldown/bee_swap/bs = new()
+		bs.Grant(bee)
+		StartCooldown()
+		return TRUE
+	to_chat(queen, span_warning("None of your workers are empty enough to slip into."))
+	return FALSE
 
 /datum/action/cooldown/bee_speech
 	name = "Hivemind Speech"

--- a/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_highsec/lcl_queen_bee.dm
+++ b/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_highsec/lcl_queen_bee.dm
@@ -32,6 +32,8 @@
 
 	attunement_family = "hornet"
 	ego_list = list(/datum/ego_datum/armor/lce/hornet)
+	var/list/brood = list()
+	var/max_brood = 5
 
 /mob/living/simple_animal/hostile/limbus_abno/queen_bee/Initialize(mapload)
 	. = ..()
@@ -39,6 +41,22 @@
 
 /mob/living/simple_animal/hostile/limbus_abno/queen_bee/Move()
 	return FALSE
+
+//The brood points back at her to free its slots, so those references cannot outlive the hive.
+/mob/living/simple_animal/hostile/limbus_abno/queen_bee/Destroy()
+	for(var/atom/child in brood.Copy()) //LeaveBrood shortens the list we would be walking.
+		LeaveBrood(child)
+	return ..()
+
+///One egg or worker leaves the count, freeing a slot for the next one she lays.
+/mob/living/simple_animal/hostile/limbus_abno/queen_bee/proc/LeaveBrood(atom/child)
+	brood -= child
+	if(isliving(child))
+		var/mob/living/simple_animal/hostile/worker_bee/lcl_bee/worker = child
+		worker.mother = null
+		return
+	var/obj/item/food/bee_egg/egg = child
+	egg.mother = null
 
 ///More or less the same spores as the original queen bee, with the main difference that it creates the special controllable bees.
 /mob/living/simple_animal/hostile/limbus_abno/queen_bee/proc/EmitSpores(forced = FALSE)
@@ -97,7 +115,7 @@
 
 /datum/action/cooldown/limbus_abno_action/bee_egg
 	name = "Birth Worker"
-	desc = "Make an egg that will eventually grow into a worker bee who will fight and search for food. Costs nearly all your hunger to use. Severely increases your mood."
+	desc = "Make an egg that will eventually grow into a worker bee who will fight and search for food. Costs nearly all your hunger to use. Severely increases your mood. You can only keep five of your own workers at a time, eggs included."
 	button_icon = 'ModularLobotomy/_Lobotomyicons/lcl_abno_actions.dmi'
 	background_icon_state = "bg_qbee"
 	icon_icon = 'icons/obj/food/food.dmi'
@@ -111,14 +129,20 @@
 		return FALSE
 	if(abno_user.hunger_bar < 70)
 		return FALSE
+	var/mob/living/simple_animal/hostile/limbus_abno/queen_bee/queen = abno_user
+	if(length(queen.brood) >= queen.max_brood)
+		return FALSE
 	return TRUE
 
 /datum/action/cooldown/limbus_abno_action/bee_egg/Trigger()
 	. = ..()
 	if(!.)
 		return FALSE
-	var/turf/T = get_turf(abno_user)
-	new /obj/item/food/bee_egg(T)
+	var/mob/living/simple_animal/hostile/limbus_abno/queen_bee/queen = abno_user
+	var/turf/T = get_turf(queen)
+	var/obj/item/food/bee_egg/egg = new(T)
+	egg.mother = queen
+	queen.brood += egg
 	playsound(T, 'sound/effects/splat.ogg', 50, TRUE)
 	StartCooldown()
 	abno_user.AdjustHunger(-70) //Creating eggs like this is supposed to be very inefficient, living hosts are better.
@@ -133,14 +157,25 @@
 	microwaved_type = /obj/item/food/boiledegg //Don't think about it.
 	foodtypes = MEAT
 	w_class = WEIGHT_CLASS_TINY
+	///The queen who laid this, so the worker it becomes keeps taking up her slot.
+	var/mob/living/simple_animal/hostile/limbus_abno/queen_bee/mother
 
 /obj/item/food/bee_egg/Initialize()
 	. = ..()
 	addtimer(CALLBACK(src, PROC_REF(hatch_bee)), 2 MINUTES)
 
+//Eaten, microwaved, or squashed before it hatched. Either way she is short one heir.
+/obj/item/food/bee_egg/Destroy()
+	if(mother)
+		mother.LeaveBrood(src)
+	return ..()
+
 /obj/item/food/bee_egg/proc/hatch_bee()
-	new /mob/living/simple_animal/hostile/worker_bee/lcl_bee(get_turf(src))
-	qdel(src)
+	var/mob/living/simple_animal/hostile/worker_bee/lcl_bee/hatchling = new(get_turf(src))
+	if(mother)
+		hatchling.mother = mother
+		mother.brood += hatchling
+	qdel(src) //Hands the slot over to the worker rather than freeing it.
 
 /mob/living/simple_animal/hostile/worker_bee/lcl_bee
 	faction = list("neutral") //Their AI lobotomy should prevent friendly attack, but better safe than sorry.
@@ -150,6 +185,8 @@
 	var/rider_ckey
 	///The way back into the hive, handed out for one ride and taken away when that ride ends.
 	var/datum/action/cooldown/bee_swap/ride_button
+	///The queen who laid the egg this hatched from, if any. Set only on her own brood.
+	var/mob/living/simple_animal/hostile/limbus_abno/queen_bee/mother
 
 /mob/living/simple_animal/hostile/worker_bee/lcl_bee/Initialize()
 	. = ..()
@@ -181,6 +218,8 @@
 
 /mob/living/simple_animal/hostile/worker_bee/lcl_bee/Destroy()
 	ReturnRider()
+	if(mother)
+		mother.LeaveBrood(src) //Her count is of living workers, so this one stops holding a slot.
 	return ..()
 
 ///Whether the player in this worker is the queen who stepped out of the hive to ride it. Anybody

--- a/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_highsec/lcl_queen_bee.dm
+++ b/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_highsec/lcl_queen_bee.dm
@@ -162,6 +162,13 @@
 /mob/living/simple_animal/hostile/worker_bee/lcl_bee/CanGhostDragPossess()
 	return TRUE
 
+//A worker somebody got bored of goes back in the pool. Login() leaves a throwaway mind behind,
+//and a worker with one is invisible to both the next ghost and the queen's own swap.
+/mob/living/simple_animal/hostile/worker_bee/lcl_bee/ghost()
+	. = ..()
+	if(!rider_ckey) //She is out riding this one. Her return runs off the mind, so leave it alone.
+		mind = null
+
 /mob/living/simple_animal/hostile/worker_bee/lcl_bee/death()
 	ReturnRider()
 	..()

--- a/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_highsec/lcl_queen_bee.dm
+++ b/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_highsec/lcl_queen_bee.dm
@@ -148,6 +148,8 @@
 	var/mob/living/simple_animal/hostile/limbus_abno/queen_bee/queen
 	///Whose hive body is parked while this worker is being ridden. Only that player gets it back.
 	var/rider_ckey
+	///The way back into the hive, handed out for one ride and taken away when that ride ends.
+	var/datum/action/cooldown/bee_swap/ride_button
 
 /mob/living/simple_animal/hostile/worker_bee/lcl_bee/Initialize()
 	. = ..()
@@ -166,8 +168,12 @@
 //and a worker with one is invisible to both the next ghost and the queen's own swap.
 /mob/living/simple_animal/hostile/worker_bee/lcl_bee/ghost()
 	. = ..()
-	if(!rider_ckey) //She is out riding this one. Her return runs off the mind, so leave it alone.
-		mind = null
+	var/mob/living/simple_animal/hostile/limbus_abno/queen_bee/hive = queen
+	var/was_ridden = rider_ckey //ReturnRider clears it, and the client is already gone by now.
+	ReturnRider()
+	mind = null
+	if(was_ridden && !QDELETED(hive))
+		hive.mind = null
 
 /mob/living/simple_animal/hostile/worker_bee/lcl_bee/death()
 	ReturnRider()
@@ -192,6 +198,7 @@
 	var/riding_home = CanRideBack()
 	queen = null
 	rider_ckey = null
+	QDEL_NULL(ride_button) //However the ride ended, the button that started it does not outlive it.
 	if(QDELETED(hive))
 		return FALSE
 	hive.possession_locked = FALSE //Unlocked first, or it stays flagged for the rest of the round.
@@ -246,8 +253,7 @@
 	if(!user_bee.CanRideBack())
 		to_chat(user_bee, span_warning("The hive body is not yours. You are a worker, and only that."))
 		return FALSE
-	user_bee.ReturnRider()
-	qdel(src)
+	user_bee.ReturnRider() //Takes this button with it.
 	return TRUE
 
 ///Out of the hive body and into ONE worker that nobody is home in. The loop used to run to the
@@ -265,8 +271,8 @@
 		bee.queen = queen
 		bee.rider_ckey = rider
 		bee.ckey = rider //We don't use transfer_to because it creates possession issues.
-		var/datum/action/cooldown/bee_swap/bs = new()
-		bs.Grant(bee)
+		bee.ride_button = new /datum/action/cooldown/bee_swap()
+		bee.ride_button.Grant(bee)
 		StartCooldown()
 		return TRUE
 	to_chat(queen, span_warning("None of your workers are empty enough to slip into."))

--- a/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_lowsec/lcl_helper.dm
+++ b/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_lowsec/lcl_helper.dm
@@ -288,6 +288,14 @@
 	if(clean_mode)
 		A.wash(CLEAN_WASH)
 
+/mob/living/simple_animal/hostile/limbus_abno/helper/death(gibbed)
+	StopCharge()
+	..()
+
+/mob/living/simple_animal/hostile/limbus_abno/helper/proc/StopCharge()
+	charging = FALSE
+	hit_targets = list()
+
 /mob/living/simple_animal/hostile/limbus_abno/helper/proc/SpinCharge(atom/target)
 	charging = TRUE
 	dir_to_target = get_dir(get_turf(src), get_turf(target))
@@ -300,10 +308,13 @@
 
 //I had to remove a lot of stuff that shouldn't be relevant in an LCL gamemode from the original helper dash. If you use an LCL mob outside LCL, I'm not responsible.
 /mob/living/simple_animal/hostile/limbus_abno/helper/proc/ActiveSpinCharge()
+	if(stat >= DEAD)
+		StopCharge()
+		return
 	var/stop_charge = FALSE
 	var/turf/T = get_step(get_turf(src), dir_to_target)
 	if(!T)
-		charging = FALSE
+		StopCharge()
 		return
 	if(T.density)
 		stop_charge = TRUE
@@ -319,9 +330,7 @@
 			INVOKE_ASYNC(D, TYPE_PROC_REF(/obj/machinery/door, open), 2)
 	if(stop_charge)
 		playsound(src, 'sound/abnormalities/helper/disable.ogg', 75, 1)
-		SLEEP_CHECK_DEATH(3 SECONDS)
-		charging = FALSE
-		hit_targets = list()
+		addtimer(CALLBACK(src, PROC_REF(StopCharge)), 3 SECONDS) //Timered, so dying while dazed still frees us.
 		return
 
 	forceMove(T)

--- a/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_lowsec/lcl_pisc_mermaid.dm
+++ b/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_lowsec/lcl_pisc_mermaid.dm
@@ -15,7 +15,8 @@
 	If you breach, the only thing that can bring you back to your senses is the immediate threat of death. Otherwise, your lover will sink into the depths with you."
 	original_abno = /mob/living/simple_animal/hostile/abnormality/pisc_mermaid
 	attack_action_types = list(/datum/action/cooldown/limbus_abno_action/mermaid_chokehold, /datum/action/cooldown/limbus_abno_action/mermaid_telepathy, /datum/action/cooldown/limbus_abno_action/dive_dash)
-	diet_list = list(/obj/item/food/freshfish, /obj/item/food/cake, /obj/item/food/cakeslice, /obj/item/food/chocolatebar) //Sweets and fish.
+	//Sweets and fish. carpmeat's subtypes are the carp fillet, the imitation and the fish fillet.
+	diet_list = list(/obj/item/food/freshfish, /obj/item/food/carpmeat, /obj/item/food/cake, /obj/item/food/cakeslice, /obj/item/food/chocolatebar)
 	hunger_cooldown_time =  2 MINUTES
 	diet_value = 50
 	kickstart_timer = 10 MINUTES //Same reason as mountain, she drops too fast early on and needs some time to get to know people.
@@ -49,7 +50,9 @@
 	. = ..()
 	if(!limbus_map)
 		return
-	for(var/turf/open/T in range(2, src)) // Fill her cell with safe water
+	for(var/turf/open/T in CellTurfs(2)) // Fill her cell with safe water, corner to corner
+		if(istype(T, /turf/open/water))
+			continue
 		T.TerraformTurf(/turf/open/water/deep/saltwater/safe, T)
 
 /mob/living/simple_animal/hostile/limbus_abno/pisc_mermaid/Life()

--- a/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_lowsec/lcl_simple_smile.dm
+++ b/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_lowsec/lcl_simple_smile.dm
@@ -69,6 +69,12 @@
 		return FALSE
 	if((object.resistance_flags & INDESTRUCTIBLE) || object.anchored) //Letting it eat nearly anything is 100% going to bite me in the ass somehow but fuck it, it's funny.
 		return FALSE
+	//Its own leash is not food, same as it cannot pick one up or drag one around.
+	if(istype(object, /obj/item/qliphoth_lasso))
+		var/obj/item/qliphoth_lasso/lasso = object
+		if(lasso.tethered == src)
+			to_chat(src, span_warning("Your teeth will not close on it. It is earthed to you."))
+			return FALSE
 
 	. = ..()
 	if(!.)

--- a/ModularLobotomy/misc_procs.dm
+++ b/ModularLobotomy/misc_procs.dm
@@ -9,7 +9,42 @@
 ///TRUE if this body is only temporarily vacant because its player stepped out of it.
 /proc/IsPossessionLocked(mob/abnormality)
 	var/mob/living/simple_animal/hostile/limbus_abno/LA = abnormality
-	return istype(LA) && LA.possession_locked
+	return istype(LA) && LA.PossessionLocked()
+
+///The one gate on taking a body, shared by the Possess verb and the ghost-drag path. The drag
+///path used to ask for a ckey and nothing else, which is not the same thing as a free body.
+/proc/IsGhostPossessable(mob/living/target)
+	if(!isliving(target) || QDELETED(target))
+		return FALSE
+	if(!get_turf(target))
+		return FALSE
+	if(target.do_not_possess)
+		return FALSE
+	if(target.ckey || target.mind || (target in GLOB.player_list)) //Home, or on the way back.
+		return FALSE
+	if(IsPossessionLocked(target))
+		return FALSE
+	if(ismegafauna(target))
+		return FALSE
+	if(istype(target, /mob/living/simple_animal/hostile/der_freis_portal)) //Portals are not for stealing.
+		return FALSE
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		if(istype(H, /mob/living/carbon/human/dummy) || H.sanity_lost) //Haha no.
+			return FALSE
+	return TRUE
+
+///TRUE when a body is safe to push a player back into. Evicting a client that is already in there
+///drops it out from under them rather than swapping them out.
+/proc/CanReturnTo(mob/body, mob/returning)
+	if(QDELETED(body))
+		return FALSE
+	return !body.ckey || (body.ckey == returning?.ckey)
+
+///Whether a ghost dragged onto this is attempting possession at all, rather than misclicking.
+///Narrower than IsGhostPossessable(): the drag path only ever meant to reach abnormalities.
+/mob/living/proc/CanGhostDragPossess()
+	return isabnormalitymob(src)
 
 /datum/proc/try_take_abnormality(mob/dead/observer/possessing_player, mob/abnormality)
 	if(!SSlobotomy_corp.enable_possession) // uhhhh, how did you even access this proc?
@@ -20,13 +55,9 @@
 		to_chat(possessing_player, span_userdanger("You dont have a valid ckey, this should not show up!"))
 		return
 
-	if(abnormality.ckey)
-		to_chat(possessing_player, span_userdanger("This abnormality already has a ghost in control of it, you can't possess it!"))
-		return
-
 	//An empty body is not always a free one. LCL specimens can step out of themselves - into a
 	//worker bee, a scouting marker, a manifestation - and the body they left behind keeps no ckey.
-	if(IsPossessionLocked(abnormality))
+	if(!IsGhostPossessable(abnormality))
 		to_chat(possessing_player, span_userdanger("Something still occupies this one, even if it looks empty. You can't possess it!"))
 		return
 
@@ -40,7 +71,7 @@
 	if(!possessing_player || !abnormality) //make sure the mobs didnt get deleted while we waited for a response, else this could end badly
 		return
 
-	if(abnormality.ckey) // and then make sure someone wasnt faster than you
+	if(!IsGhostPossessable(abnormality)) // and then make sure someone wasnt faster than you
 		to_chat(possessing_player, span_userdanger("This abnormality already has a ghost in control of it, seems like you were too slow!"))
 		return
 

--- a/ModularLobotomy/misc_procs.dm
+++ b/ModularLobotomy/misc_procs.dm
@@ -88,6 +88,10 @@
 					continue
 				A.current.AbnoRadio()
 
+	if(!IsGhostPossessable(abnormality))
+		to_chat(possessing_player, span_userdanger("Something took hold of it before you could. You can't possess it!"))
+		return
+
 	abnormality.key = possessing_player.key
 	abnormality.client?.init_verbs()
 	qdel(possessing_player)

--- a/_maps/map_files/Event/laboratory.dmm
+++ b/_maps/map_files/Event/laboratory.dmm
@@ -1051,6 +1051,7 @@
 	},
 /obj/item/ego_weapon/ranged/city/udjat,
 /obj/item/ego_weapon/city/udjat_limbus,
+/obj/item/clothing/mask/udjat,
 /turf/open/floor/lce/plate/dark,
 /area/lce/security/udjat_quarters)
 "gh" = (
@@ -1769,7 +1770,7 @@
 /obj/item/ego_weapon/ranged/city/udjat,
 /obj/item/ego_weapon/city/udjat_limbus,
 /obj/item/clothing/suit/armor/ego_gear/city/udjat_limbus,
-/obj/item/clothing/head/udjat,
+/obj/item/clothing/mask/udjat,
 /turf/open/floor/lce/plate/dark,
 /area/lce/security/udjat_armoury)
 "kE" = (

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -648,24 +648,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	for(var/mob/living/L in GLOB.alive_mob_list)
 		if(!is_centcom_level(L.z))
 			continue
-		// LOBOTOMYCORPORATION ADDITION START
-		if(isabnormalitymob(L))
-			var/mob/living/simple_animal/hostile/abnormality/abnormality = L
-			if(abnormality.do_not_possess)
-				continue
-		if(!get_turf(L))
+		// LOBOTOMYCORPORATION EDIT -- one shared gate, see ModularLobotomy/misc_procs.dm
+		if(!IsGhostPossessable(L))
 			continue
-		if(istype(L, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = L
-			if(istype(H, /mob/living/carbon/human/dummy) || H.sanity_lost) //Haha no.
-				continue
-
-		if(istype(L, /mob/living/simple_animal/hostile/der_freis_portal) || !get_turf(L)) //We don't want portals to be stolen...
-			continue
-		// LOBOTOMYCORPORATION ADDITION END
-
-		if(!(L in GLOB.player_list) && !L.mind)
-			possessible += L
+		possessible += L
 
 	var/mob/living/target = input("Your new life begins today!", "Possess Mob", null, null) as null|anything in sortNames(possessible)
 
@@ -731,11 +717,19 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		to_chat(usr, span_userdanger("Abnormality possession is not enabled!"))
 		return ..()
 
-	if(isabnormalitymob(over))
-		var/mob/living/simple_animal/hostile/abnormality/abnormality = over
-		if(abnormality.do_not_possess)
-			to_chat(usr, span_userdanger("This abnormality is blacklisted from being possessed!"))
-			return ..()
+	var/mob/living/target = over
+
+	if(target.do_not_possess)
+		to_chat(usr, span_userdanger("This abnormality is blacklisted from being possessed!"))
+		return ..()
+
+	if(!target.CanGhostDragPossess()) // we want them to ONLY be able to possess abnormalities
+		to_chat(usr, span_userdanger("You can only possess abnormalities!"))
+		return ..()
+
+	if(!IsGhostPossessable(target)) // empty is not the same as free
+		to_chat(usr, span_userdanger("Something still occupies this one. You can't possess it!"))
+		return ..()
 
 	if(possession_cooldown >= world.time)
 		to_chat(src, span_userdanger("You are under a cooldown for possessing for [(possession_cooldown - world.time) / 10] more seconds!"))
@@ -745,11 +739,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		to_chat(usr, span_userdanger("You dont exist, so you cant possess!"))
 		return ..()
 
-	if(!isabnormalitymob(over) && !SSmaptype.maptype == "limbus_labs") // we want them to ONLY be able to possess abnormalities
-		to_chat(usr, span_userdanger("You can only possess abnormalities!"))
-		return ..()
-
-	try_take_abnormality(src, over)
+	try_take_abnormality(src, target)
 	return ..()
 	//LOBOTOMYCORPORATION ADDITION END
 

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -196,3 +196,6 @@
 
 	/// Index used to interact with the moblist of the area they are currently in.
 	var/area_index = MOB_LIVING_INDEX
+
+	/// If a ghost should never be allowed to take this body, even where possession is enabled.
+	var/do_not_possess = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -95,8 +95,7 @@
 	var/core_icon = ""
 	var/core_enabled = TRUE
 
-	/// If an abnormality should not be possessed even if possessibles are enabled, mainly for admins.
-	var/do_not_possess = FALSE
+	//do_not_possess lives on /mob/living now, so the flag blacklists any mob a ghost can reach.
 
 	// secret skin variables ahead
 


### PR DESCRIPTION
## About The Pull Request

A batch of LCL bug fixes from recent round reports, plus one gear slot change.

**Ghost possession.** A specimen's body reads as completely free while its player is out of it - the Queen of Hatred scouting through her marker, the Knight of Despair out in her manifest, and the Queen Bee riding a worker all leave a body with no ckey and no mind behind them.

* Neither the Possess verb nor the ghost-drag path checked for that properly, so a ghost could walk in and take the body out from under them. Both routes now go through a single IsGhostPossessable() gate, and QoH and KoD report themselves locked off the projection existing rather than off a flag being set.
* The Queen Bee made it worse: her Worker Possession handed *every* idle worker a button that led back into her body, and pressing it crashed whoever was in it. One worker per use now, and only the queen who left can ride back - nothing ever pushes a player into a body that already holds a client.
* The "abnormalities only" rule on the drag path had been dead on every map thanks to an operator precedence bug (`!SSmaptype.maptype == "limbus_labs"`), letting ghosts into any empty mob. Fixed, with worker bees staying drag-possessable on purpose, since that is the only way to play one.

**Everything else.**

* Simple Smile can no longer swallow the lasso it is wearing and leash itself into a softlock, and a lassoed specimen can now haul on the line for 3 seconds to tear it off.
* Piscine Mermaid's water and the cell heal spots are laid over the cell area instead of a radius around the spawn point, so they stop being misaligned after the cell resize - and she will eat a carp fillet.
* Heal spots also stop being examinable, draggable out of the cell and crateable.
* Dead specimens no longer tick their needs, which is what was breaching Mountain of Smiling Bodies' corpse and wiping its egg sprite. Mountain also stops handing a monkey to everyone who steps into its shell, and hatches back as a clean phase one.
* The Udjat mask moves to the mask slot, map updated to match.

## Why It's Good For The Game

The possession fixes close a hole that let any ghost take a live player's body out from under them and crash their client, which is about as bad as an LCL bug gets, while keeping worker bees ghost-playable. The rest are round-ruining bugs on individual specimens: a softlocked Simple Smile, a Mountain whose death state looked broken and fed anyone who kept re-entering it, and cell dressing that no longer drifts the next time a cell is resized.

### Did you test this PR?

* [X] This PR compiles
* [ ] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

## Changelog
:cl:
fix: Ghosts can no longer possess a specimen's body while its player is out of it - a Queen of Hatred scouting through her marker, a Knight of Despair out in her manifest, or a Queen Bee riding a worker.
fix: Dragging your ghost onto something only works on abnormalities again. It had been letting ghosts into any empty mob, on any map. Worker bees are still fair game.
fix: The Queen Bee's Worker Possession no longer leaves every idle worker holding a button that leads into the queen's body, and only the queen who left it can use it.
fix: A worker bee somebody stopped playing goes back to being possessable, instead of sitting unusable for the rest of the round.
fix: Gone with a Simple Smile can no longer swallow the lasso it is wearing and leash its
add: A lassoed specimen can now haul on the line for 3 seconds without moving to tear it off.
fix: Piscine Mermaid's cell floods corner to corner again, and she will eat a carp fillet
fix: Heal spots cover the whole of a specimen's cell, and can no longer be examined, dragged out of it or shut in a crate.
fix: Dead specimens no longer starve, lose their mood or breach while they are still an e
fix: Mountain of Smiling Bodies' egg no longer turns invisible, no longer hands out a monkey to everyone who steps into it, and hatches back as a fresh first phase.
tweak: The Udjat mask is worn on the mask slot instead of the head slot, and there is a ts.
/:cl:                                                                                                                                                                                                           