### PR TITLE
Stops Agents from going into PE superdebt to buy 500 ALEPH EGO

### DIFF
--- a/ModularLobotomy/lc13_obj/lc13_computers/abnormality_ego.dm
+++ b/ModularLobotomy/lc13_obj/lc13_computers/abnormality_ego.dm
@@ -121,9 +121,7 @@
 	var/ego_cost = chosen_datum.cost * mult
 
 	// Reject the purchase if we're short on PE
-	if(abno_datum.stored_boxes < (ego_cost))
-		to_chat(user, span_warning("Not enough PE boxes stored for this operation."))
-		playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
+	if(!EnkephalinCheck(user, abno_datum, ego_cost))
 		return FALSE
 
 	// Stop if we're doing something weird by moving away from the console
@@ -171,6 +169,10 @@
 	if(!user.Adjacent(adjacency_check_turf))
 		return
 
+	// Uh oh, let's not let people print 5000000 EGOs by input stacking...
+	if(!EnkephalinCheck(user, abno_datum, ego_cost))
+		return
+
 	// DeliverEgo will handle logic for instant spawn/drop pod/conveyor belt arrival.
 	INVOKE_ASYNC(src, PROC_REF(DeliverEgo), ego_path, user, target)
 
@@ -193,6 +195,15 @@
 	updateUsrDialog()
 
 	SSlobotomy_corp.ego_purchase_logs += list(new_log)
+
+/obj/machinery/computer/ego_purchase/proc/EnkephalinCheck(mob/user, datum/abnormality/abno_datum, cost = 0)
+	if(!abno_datum)
+		return FALSE
+	if(abno_datum.stored_boxes < cost)
+		to_chat(user, span_warning("Not enough PE boxes stored for this operation."))
+		playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
+		return FALSE
+	return TRUE
 
 // Handles actually delivering purchased E.G.O. - EOs get it immediately, everyone else has to wait a while and then it'll use ShipOut to determine where it lands.
 /obj/machinery/computer/ego_purchase/proc/DeliverEgo(ego_path, mob/living/user, turf/delivery_target)


### PR DESCRIPTION
## About The Pull Request
The usual input stacking exploit strikes again, I failed to find it when I was refactoring the EO tablet. It's fixed now.
(You were able to queue up multiple dialogs if you had PE available, and then even if you only had PE for one EGO, the remainder of the purchases could go through regardless)
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This will help the economy and protect the trout population
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
fix: You can no longer input-stack the EO tablet EGO extraction to go into debt and purchase a potentially unlimited amount of EGO.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
