### PR TITLE
Minor TGUI Update: Fixing Scaling/Dragging for Laptop users

### DIFF
--- a/tgui/packages/tgui/drag.js
+++ b/tgui/packages/tgui/drag.js
@@ -20,30 +20,44 @@ let resizeMatrix;
 let initialSize;
 let size;
 
+// BYOND reports window pos/size in physical pixels, while the browser reports
+// screen, window and mouse coordinates in CSS pixels. The two only agree at
+// 100% display scaling, so convert at every boundary between them.
+const pixelRatio = window.devicePixelRatio || 1;
+
+/** Converts a vector of CSS pixels into BYOND's physical pixels. */
+const toByondPixels = vec => vecScale(vec, pixelRatio);
+
 export const setWindowKey = key => {
   windowKey = key;
 };
 
-export const getWindowPosition = () => [
+export const getWindowPosition = () => toByondPixels([
   window.screenLeft,
   window.screenTop,
-];
+]);
 
-export const getWindowSize = () => [
+export const getWindowSize = () => toByondPixels([
   window.innerWidth,
   window.innerHeight,
-];
+]);
+
+/** Position of the mouse cursor in BYOND's physical pixels. */
+const getMousePosition = event => toByondPixels([
+  event.screenX,
+  event.screenY,
+]);
 
 export const setWindowPosition = vec => {
   const byondPos = vecAdd(vec, screenOffset);
   return Byond.winset(window.__windowId__, {
-    pos: byondPos[0] + ',' + byondPos[1],
+    pos: Math.round(byondPos[0]) + ',' + Math.round(byondPos[1]),
   });
 };
 
 export const setWindowSize = vec => {
   return Byond.winset(window.__windowId__, {
-    size: vec[0] + 'x' + vec[1],
+    size: Math.round(vec[0]) + 'x' + Math.round(vec[1]),
   });
 };
 
@@ -52,10 +66,10 @@ export const getScreenPosition = () => [
   0 - screenOffset[1],
 ];
 
-export const getScreenSize = () => [
+export const getScreenSize = () => toByondPixels([
   window.screen.availWidth,
   window.screen.availHeight,
-];
+]);
 
 /**
  * Moves an item to the top of the recents array, and keeps its length
@@ -110,10 +124,7 @@ export const recallWindowGeometry = async (options = {}) => {
   let size = options.size;
   // Wait until screen offset gets resolved
   await screenOffsetPromise;
-  const areaAvailable = [
-    window.screen.availWidth,
-    window.screen.availHeight,
-  ];
+  const areaAvailable = getScreenSize();
   // Set window size
   if (size) {
     // Constraint size to not exceed available screen area.
@@ -144,12 +155,21 @@ export const recallWindowGeometry = async (options = {}) => {
 export const setupDrag = async () => {
   // Calculate screen offset caused by the windows taskbar
   screenOffsetPromise = Byond.winget(window.__windowId__, 'pos')
-    .then(pos => [
-      pos.x - window.screenLeft,
-      pos.y - window.screenTop,
-    ]);
+    .then(pos => vecAdd(
+      [pos.x, pos.y],
+      vecInverse(getWindowPosition())));
   screenOffset = await screenOffsetPromise;
   logger.debug('screen offset', screenOffset);
+  // TEMPORARY PROBE: reports whether BYOND and the browser agree on pixel
+  // units. Remove once the DPI behaviour is confirmed.
+  const byondSize = await Byond.winget(window.__windowId__, 'size');
+  logger.info('geometry probe',
+    'devicePixelRatio=' + pixelRatio,
+    'byondSize=' + JSON.stringify(byondSize),
+    'browserSize=' + window.innerWidth + 'x' + window.innerHeight,
+    'screenAvail=' + window.screen.availWidth
+      + 'x' + window.screen.availHeight,
+    'screenOffset=' + screenOffset[0] + ',' + screenOffset[1]);
 };
 
 /**
@@ -179,10 +199,9 @@ const constraintPosition = (pos, size) => {
 export const dragStartHandler = event => {
   logger.log('drag start');
   dragging = true;
-  dragPointOffset = [
-    window.screenLeft - event.screenX,
-    window.screenTop - event.screenY,
-  ];
+  dragPointOffset = vecAdd(
+    getWindowPosition(),
+    vecInverse(getMousePosition(event)));
   // Focus click target
   event.target?.focus();
   document.addEventListener('mousemove', dragMoveHandler);
@@ -205,7 +224,7 @@ const dragMoveHandler = event => {
   }
   event.preventDefault();
   setWindowPosition(vecAdd(
-    [event.screenX, event.screenY],
+    getMousePosition(event),
     dragPointOffset));
 };
 
@@ -213,14 +232,10 @@ export const resizeStartHandler = (x, y) => event => {
   resizeMatrix = [x, y];
   logger.log('resize start', resizeMatrix);
   resizing = true;
-  dragPointOffset = [
-    window.screenLeft - event.screenX,
-    window.screenTop - event.screenY,
-  ];
-  initialSize = [
-    window.innerWidth,
-    window.innerHeight,
-  ];
+  dragPointOffset = vecAdd(
+    getWindowPosition(),
+    vecInverse(getMousePosition(event)));
+  initialSize = getWindowSize();
   // Focus click target
   event.target?.focus();
   document.addEventListener('mousemove', resizeMoveHandler);
@@ -243,8 +258,8 @@ const resizeMoveHandler = event => {
   }
   event.preventDefault();
   size = vecAdd(initialSize, vecMultiply(resizeMatrix, vecAdd(
-    [event.screenX, event.screenY],
-    vecInverse([window.screenLeft, window.screenTop]),
+    getMousePosition(event),
+    vecInverse(getWindowPosition()),
     dragPointOffset,
     [1, 1])));
   // Sane window size values

--- a/tgui/packages/tgui/drag.js
+++ b/tgui/packages/tgui/drag.js
@@ -160,16 +160,6 @@ export const setupDrag = async () => {
       vecInverse(getWindowPosition())));
   screenOffset = await screenOffsetPromise;
   logger.debug('screen offset', screenOffset);
-  // TEMPORARY PROBE: reports whether BYOND and the browser agree on pixel
-  // units. Remove once the DPI behaviour is confirmed.
-  const byondSize = await Byond.winget(window.__windowId__, 'size');
-  logger.info('geometry probe',
-    'devicePixelRatio=' + pixelRatio,
-    'byondSize=' + JSON.stringify(byondSize),
-    'browserSize=' + window.innerWidth + 'x' + window.innerHeight,
-    'screenAvail=' + window.screen.availWidth
-      + 'x' + window.screen.availHeight,
-    'screenOffset=' + screenOffset[0] + ',' + screenOffset[1]);
 };
 
 /**

--- a/tgui/packages/tgui/interfaces/EnkephalinGridStation.js
+++ b/tgui/packages/tgui/interfaces/EnkephalinGridStation.js
@@ -4,7 +4,10 @@ import {
 } from '../components';
 import { Window } from '../layouts';
 
+// MAP_SIZE is the SVG coordinate space, not a pixel size. The rendered map
+// scales to its container, so all the toScreenX/Y math stays in these units.
 const MAP_SIZE = 300;
+const MAP_MIN_HEIGHT = 160;
 const GRID_ZONE_CELL_SIZE = 10;
 
 export const EnkephalinGridStation = (props, context) => {
@@ -75,11 +78,17 @@ export const EnkephalinGridStation = (props, context) => {
       height={700}>
       <Window.Content>
         <Stack fill>
-          <Stack.Item basis="340px">
-            <Stack vertical fill>
-              <Stack.Item grow>
+          {/* Sections below have fixed heights and can outgrow a laptop
+              screen, so the whole column scrolls instead of clipping. */}
+          <Stack.Item
+            basis="340px"
+            style={{
+              'overflow-y': 'auto',
+              'overflow-x': 'hidden',
+            }}>
+            <Stack vertical>
+              <Stack.Item>
                 <Section
-                  fill
                   title={(
                     <Box>
                       <Icon name="map" mr={1} />
@@ -390,18 +399,27 @@ const GridMap = props => {
   return (
     <Box
       style={{
-        position: 'relative',
-        width: MAP_SIZE + 'px',
-        height: MAP_SIZE + 'px',
-        backgroundColor: '#1a1a2e',
-        border: '2px solid #444',
-        borderRadius: '4px',
-        overflow: 'hidden',
+        'position': 'relative',
+        'width': '100%',
+        // Height tracks the window, so a short window gets a short map.
+        'height': '34vh',
+        'min-height': MAP_MIN_HEIGHT + 'px',
+        'max-height': MAP_SIZE + 'px',
+        'background-color': '#1a1a2e',
+        'border': '2px solid #444',
+        'border-radius': '4px',
+        'overflow': 'hidden',
       }}>
       <svg
-        width={MAP_SIZE}
-        height={MAP_SIZE}
-        style={{ position: 'absolute', top: 0, left: 0 }}>
+        viewBox={'0 0 ' + MAP_SIZE + ' ' + MAP_SIZE}
+        preserveAspectRatio="xMidYMid meet"
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+        }}>
         <defs>
           <style>
             {`
@@ -562,28 +580,26 @@ const GridMap = props => {
           stroke="#00ff00"
           strokeWidth={1}
           strokeDasharray="2,2" />
-      </svg>
 
-      {Math.abs(focus_x) < viewRadius && Math.abs(focus_y) < viewRadius && (
-        <Box
-          style={{
-            position: 'absolute',
-            left: toScreenX(0) - 10 + 'px',
-            top: toScreenY(0) - 10 + 'px',
-            color: '#666',
-            fontSize: '10px',
-          }}>
-          (0,0)
-        </Box>
-      )}
+        {/* Drawn inside the svg so it scales with the rest of the map. */}
+        {Math.abs(focus_x) < viewRadius && Math.abs(focus_y) < viewRadius && (
+          <text
+            x={toScreenX(0) + 6}
+            y={toScreenY(0) - 6}
+            fill="#666"
+            font-size="10">
+            (0,0)
+          </text>
+        )}
+      </svg>
 
       <Box
         style={{
-          position: 'absolute',
-          bottom: '4px',
-          left: '4px',
-          fontSize: '9px',
-          color: '#888',
+          'position': 'absolute',
+          'bottom': '4px',
+          'left': '4px',
+          'font-size': '9px',
+          'color': '#888',
         }}>
         <Icon name="circle" color="#00ff00" /> You
         {' | '}


### PR DESCRIPTION
## About The Pull Request

- **`drag.js`** — BYOND reports window `pos`/`size` in physical pixels, while the browser reports screen, window and mouse coordinates in CSS pixels. The two only agree at 100% display scaling, so every read now converts through `devicePixelRatio`. This fixes dragging, resizing and initial window sizing for *all* tgui windows, not just this one.
- **`EnkephalinGridStation.js`** — the left column now scrolls instead of silently clipping, and the grid map scales with the window through an SVG `viewBox` rather than a hardcoded 300px box.
- Also corrected some camelCase keys inside `Box` `style={{}}` objects — tgui concatenates those into a CSS string verbatim, so they were invalid and silently dropped. The map's background colour and rounded border render for the first time as a result.

## Why It's Good For The Game

- On a laptop at 125–150% scaling, tgui windows jumped toward the top of the screen the moment you pressed the mouse, and could never be fully moved or resized — every fresh mousedown shrank them further.
- The grid crafting station pushed its movement controls off the bottom of the window with no scrollbar, making the interface impossible to use at that resolution.

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

## Changelog
:cl:
fix: tgui windows can now be moved and resized properly on displays using Windows scaling above 100%.
fix: The grid crafting station no longer cuts off its movement controls on smaller screens.
tweak: The grid crafting station's grid map now scales with the window instead of staying a fixed size.
/:cl: