### PR TITLE
Fixes Mountain not breaching when counter reaches zero

### DIFF
--- a/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno.dm
+++ b/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno.dm
@@ -526,13 +526,13 @@
 	return desire_amount
 
 /mob/living/simple_animal/hostile/limbus_abno/proc/AdjustCounter(counter_amount)
-	if(counter_amount == 0)
-		if(can_breach)
-			Breach()
-		return FALSE
 	var/original_counter = counter
 	var/pos_counter = 0 < counter_amount ? TRUE : FALSE
 	counter = clamp(counter + counter_amount, 0, max_counter)
+	if(counter == 0)
+		if(can_breach)
+			Breach()
+		return FALSE
 	UpdateBars()
 	update_action_buttons()
 


### PR DESCRIPTION
## About The Pull Request
I made a mistake while coding a variable to automatically breach at zero quibolith 
I fixed it now and tested it. Mountain should breach now when their counter reaches zero.

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [x] This PR compiles
* [x] This PR runs fine in a local test
* [x] This PR does not produce runtimes
* [x] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
fix: LCL mountain not breaching
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
