### PR TITLE
turning off being_tested for wayward passenger

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/wayward_passenger.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/wayward_passenger.dm
@@ -39,7 +39,6 @@
 	max_boxes = 16
 	base_pixel_x = -8
 	pixel_x = -8
-	being_tested = TRUE
 
 	ego_list = list(
 		/datum/ego_datum/weapon/warp,


### PR DESCRIPTION
## About The Pull Request

<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! --> dimripper buff had being_tested var set to TRUE, this removes being_tested = TRUE

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [x] This PR compiles
* [ ] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
code: CHANGEME
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
