### PR TITLE
Reworks Tears of the Tarnished Blood, Et in Arcadia Ego and Judge

### DIFF
--- a/ModularLobotomy/ego_weapons/ranged/aleph.dm
+++ b/ModularLobotomy/ego_weapons/ranged/aleph.dm
@@ -263,10 +263,11 @@
 	desc = "With the waxing of the sun, humanity wanes."
 	icon_state = "arcadia"
 	inhand_icon_state = "arcadia"
-	special = "Use in hand to load bullets."
+	special = "Firing this weapon when below half health will increase damage by 50%."
 	force = 56
 	projectile_path = /obj/projectile/ego_bullet/arcadia
 	weapon_weight = WEAPON_HEAVY
+	knockback = KNOCKBACK_LIGHT
 	spread = 5
 	recoil = 1.5
 	fire_sound = 'sound/weapons/gun/rifle/shot_atelier.ogg'
@@ -286,6 +287,15 @@
 	reloadtime = 0.5 SECONDS
 	roundsreload = TRUE
 
+/obj/item/ego_weapon/ranged/arcadia/fire_projectile(atom/target, mob/living/user, params, distro, quiet, zone_override, spread, atom/fired_from, temporary_damage_multiplier)
+	if(!ishuman(user))
+		return ..()
+
+	var/mob/living/carbon/human/H = user
+	if(user.health < user.maxHealth * 0.5)
+		temporary_damage_multiplier = 1.5 // HP below half will increase damage by 1.5x
+	return ..()
+
 /obj/item/ego_weapon/ranged/arcadia/judge
 	name = "Judge"
 	desc = "You will be judged; as I have."
@@ -294,6 +304,7 @@
 	force = 56
 	damtype = WHITE_DAMAGE
 	weapon_weight = WEAPON_MEDIUM	//Cannot be dual wielded
+	knockback = FALSE	//Only the big gun has knockback
 	recoil = 2
 	fire_sound_volume = 30
 	fire_delay = 3	//FAN THE HAMMER

--- a/ModularLobotomy/ego_weapons/ranged/aleph.dm
+++ b/ModularLobotomy/ego_weapons/ranged/aleph.dm
@@ -292,7 +292,7 @@
 		return ..()
 
 	var/mob/living/carbon/human/H = user
-	if(user.health < user.maxHealth * 0.5)
+	if(H.health < H.maxHealth * 0.5)
 		temporary_damage_multiplier = 1.5 // HP below half will increase damage by 1.5x
 	return ..()
 
@@ -936,7 +936,7 @@
 
 	alternate_fire_name = "Flower Burying Pin"
 	alternate_pellets = 1
-	alternate_shotsleft = 3
+	alternate_shotsleft = 5
 	alternate_info = "This weapon fires a levinfall pin. Hitting a target will cause Red damage to the firer."
 	alternate_reload_type = RANGEDEGO_ALTERNATEFIRE_RELOADTYPE_SHARED_RELOAD
 	alternate_projectile_path = /obj/projectile/ego_bullet/tarnished_pin

--- a/ModularLobotomy/ego_weapons/ranged/aleph.dm
+++ b/ModularLobotomy/ego_weapons/ranged/aleph.dm
@@ -895,6 +895,8 @@
 	animate(src.get_filter("motionblur"), y = 0, time = travel_time, flags = ANIMATION_PARALLEL)
 	animate(src, pixel_z = -1 * abs(sin(rotation))*4, pixel_x = (sin(rotation) * 20), time = travel_time, easing = LINEAR_EASING, flags = ANIMATION_PARALLEL)
 
+
+
 /obj/item/ego_weapon/ranged/pistol/tarnished
 	name = "Tears of the Tarnished Blood"
 	desc = "With contemplation, I shall darken the clear skies above; with my sacrifice, I shall exsanguinate my carnal blood upon this earth."
@@ -902,7 +904,7 @@
 	inhand_icon_state = "tarnished"
 	special = ""
 
-	force = 50
+	force = 40
 	damtype = PALE_DAMAGE
 	attack_speed = 1.0
 	swingstyle = WEAPONSWING_LARGESWEEP
@@ -924,7 +926,7 @@
 	alternate_fire_name = "Flower Burying Pin"
 	alternate_pellets = 1
 	alternate_shotsleft = 3
-	alternate_info = "This weapon fires a levinfall pin."
+	alternate_info = "This weapon fires a levinfall pin. Hitting a target will cause Red damage to the firer."
 	alternate_reload_type = RANGEDEGO_ALTERNATEFIRE_RELOADTYPE_SHARED_RELOAD
 	alternate_projectile_path = /obj/projectile/ego_bullet/tarnished_pin
 	alternate_fire_sound = 'sound/weapons/bowfire.ogg'

--- a/ModularLobotomy/ego_weapons/ranged/ego_bullets/aleph.dm
+++ b/ModularLobotomy/ego_weapons/ranged/ego_bullets/aleph.dm
@@ -343,9 +343,13 @@
 	speed = 1.3
 	damage_type = WHITE_DAMAGE
 	var/lightning_damage = 50
+	var/user_damage = 15
 
 /obj/projectile/ego_bullet/tarnished_pin/on_hit(atom/target, blocked, pierce_hit)
 	..()
+	if(isliving(firer))
+		firer.deal_damage(user, RED_DAMAGE, firer, attack_type = (ATTACK_TYPE_SPECIAL))
+		new /obj/effect/temp_visual/dir_setting/bloodsplatter(get_turf(firer), pick(GLOB.alldirs))
 	sleep(10)
 	if(!isliving(target))
 		return

--- a/ModularLobotomy/ego_weapons/ranged/ego_bullets/aleph.dm
+++ b/ModularLobotomy/ego_weapons/ranged/ego_bullets/aleph.dm
@@ -342,6 +342,8 @@
 	damage = 10
 	speed = 1.3
 	damage_type = WHITE_DAMAGE
+	projectile_piercing = PASSMOB
+	projectile_phasing = (ALL & (~PASSMOB) & (~PASSCLOSEDTURF))
 	var/lightning_damage = 50
 	var/user_damage = 15
 

--- a/ModularLobotomy/ego_weapons/ranged/ego_bullets/aleph.dm
+++ b/ModularLobotomy/ego_weapons/ranged/ego_bullets/aleph.dm
@@ -346,10 +346,10 @@
 	var/user_damage = 15
 
 /obj/projectile/ego_bullet/tarnished_pin/on_hit(atom/target, blocked, pierce_hit)
-	..()
 	if(isliving(firer))
-		firer.deal_damage(user, RED_DAMAGE, firer, attack_type = (ATTACK_TYPE_SPECIAL))
-		new /obj/effect/temp_visual/dir_setting/bloodsplatter(get_turf(firer), pick(GLOB.alldirs))
+		var/mob/living/L = firer
+		L.deal_damage(L, RED_DAMAGE, firer, attack_type = (ATTACK_TYPE_SPECIAL))
+		new /obj/effect/temp_visual/dir_setting/bloodsplatter(get_turf(L), pick(GLOB.alldirs))
 	sleep(10)
 	if(!isliving(target))
 		return
@@ -357,4 +357,5 @@
 	new /obj/effect/temp_visual/tbirdlightning (get_turf(L))
 	L.deal_damage(lightning_damage, WHITE_DAMAGE, firer, attack_type = (ATTACK_TYPE_SPECIAL))
 	playsound(src, 'sound/effects/impact_thunder.ogg', 50, FALSE, 40, falloff_distance = 10)
+	..()
 

--- a/ModularLobotomy/ego_weapons/ranged/ego_bullets/aleph.dm
+++ b/ModularLobotomy/ego_weapons/ranged/ego_bullets/aleph.dm
@@ -343,7 +343,6 @@
 	speed = 1.3
 	damage_type = WHITE_DAMAGE
 	projectile_piercing = PASSMOB
-	projectile_phasing = (ALL & (~PASSMOB) & (~PASSCLOSEDTURF))
 	var/lightning_damage = 50
 	var/user_damage = 15
 


### PR DESCRIPTION
## About The Pull Request
--Tears of the Tarnished Blood--
Melee damage decreased from 50 > 40 Pale
Hitting a target with Levinfall Pins deals 15 Red to the user. This can be blocked by armor.
Alternate Ammo increased 3 > 5

--Et in Arcadia Ego and Judge--
Both gain a 1.5x damage multiplier when the user is below half health.

--Et in Arcadia Ego--
Gains knockback on melee hit
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Tears of the Tarnished blood was fucking wild and Et in Arcadia Ego/Judge is not good enough.
These changes should help both be more on par.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Did you test this PR?

* [x] This PR compiles
* [ ] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
balance: rebalanced Tarnished Blood and Black Sun weapons.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
