### PR TITLE
Watchman Update

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/watchman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/watchman.dm
@@ -125,7 +125,7 @@
 /mob/living/simple_animal/hostile/abnormality/watchman/Life()
 	. = ..()
 	if(beneficial)
-		for(var/mob/living/carbon/human/H in view(8, get_turf(src))
+		for(var/mob/living/carbon/human/H in view(8, get_turf(src)))
 			H.apply_lc_black_strength(4)
 			H.adjustSanityLoss(-2)
 
@@ -141,7 +141,7 @@
 /// ======================SPEECH CODE======================
 /mob/living/simple_animal/hostile/abnormality/watchman/attacked_by(obj/item/I, mob/living/user)
 	. = ..()
-	if(is_human(user))
+	if(ishuman(user))
 		beneficial = FALSE
 	user.apply_lc_fragile(3)
 	if(speak_chance)

--- a/code/modules/mob/living/simple_animal/abnormality/he/watchman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/watchman.dm
@@ -24,9 +24,9 @@
 	threat_level = HE_LEVEL
 	start_qliphoth = 3
 	work_chances = list(
-		ABNORMALITY_WORK_INSTINCT = 40,
+		ABNORMALITY_WORK_INSTINCT = 45,
 		ABNORMALITY_WORK_INSIGHT = 60,
-		ABNORMALITY_WORK_ATTACHMENT = 40,
+		ABNORMALITY_WORK_ATTACHMENT = 45,
 		ABNORMALITY_WORK_REPRESSION = 10,
 	)
 	work_damage_amount = 7
@@ -93,6 +93,9 @@
 		"Never should have come here!",
 		"This darkness is not for you and you alone, monster!",
 	)
+
+	var/beneficial = TRUE
+
 	// Breached Abno tracker.
 	// Remembers enemies by their tag.
 	var/list/dangers = list()
@@ -123,9 +126,29 @@
 	set_light(30)	//Makes everything around it really dark, That's all it does lol
 
 
+
+//Applies buffs if he's breached and you're near him
+/mob/living/simple_animal/hostile/abnormality/watchman/Life()
+	. = ..()
+	if(beneficial)
+		for(var/mob/living/carbon/human/H in view(8, get_turf(src))
+			H.apply_lc_black_strength(4)
+			H.adjustSanityLoss(-2)
+
+
+
+/mob/living/simple_animal/hostile/abnormality/watchman/bullet_act(obj/projectile/Proj)
+	..()
+	if(!ishuman(Proj.firer))
+		return
+	beneficial = FALSE
+
+
 /// ======================SPEECH CODE======================
 /mob/living/simple_animal/hostile/abnormality/watchman/attacked_by(obj/item/I, mob/living/user)
 	. = ..()
+	if(is_human(user))
+		beneficial = FALSE
 	user.apply_lc_fragile(3)
 	if(speak_chance)
 		if(prob(speak_chance*2))

--- a/code/modules/mob/living/simple_animal/abnormality/he/watchman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/watchman.dm
@@ -24,9 +24,9 @@
 	threat_level = HE_LEVEL
 	start_qliphoth = 3
 	work_chances = list(
-		ABNORMALITY_WORK_INSTINCT = 45,
-		ABNORMALITY_WORK_INSIGHT = 60,
-		ABNORMALITY_WORK_ATTACHMENT = 45,
+		ABNORMALITY_WORK_INSTINCT = 35,
+		ABNORMALITY_WORK_INSIGHT = 50,
+		ABNORMALITY_WORK_ATTACHMENT = 35,
 		ABNORMALITY_WORK_REPRESSION = 10,
 	)
 	work_damage_amount = 7
@@ -110,12 +110,6 @@
 	if(prob(30))
 		datum_reference.qliphoth_change(-1)
 	return
-
-/mob/living/simple_animal/hostile/abnormality/watchman/WorkChance(mob/living/carbon/human/user, chance)
-	if(get_attribute_level(user, TEMPERANCE_ATTRIBUTE) >= 60)
-		var/newchance = chance - 20 //You suck, die. I hate you
-		return newchance
-	return chance
 
 /mob/living/simple_animal/hostile/abnormality/watchman/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	user.hallucination += 20	//You're gonna be hallucinating for a while

--- a/code/modules/paperwork/records/info/he.dm
+++ b/code/modules/paperwork/records/info/he.dm
@@ -225,8 +225,8 @@
 	abno_info = list(
 		"When the work result was Bad, the Qliphoth Counter decreased.",
 		"When the work result was Neutral, the Qliphoth Counter lowered with a moderate probability.",
-		"When employees with Temperance Level 3 or higher worked on The Watchman, the work rates were reduced.",
-		"While breached, The Watchman flooded the surrounding area with darkness. This darkness had the same propogation characteristics as light.")
+		"While breached, O-01-132 flooded the surrounding area with darkness. This darkness had the same propogation characteristics as light.",
+		"Until attacked by a human, accidentally or not, O-01-132 would assist humans in combat.")
 	abno_breach_damage_type = "None"
 	abno_breach_damage_count = "None"
 


### PR DESCRIPTION
## About The Pull Request
Watchman work rates decreased to 35/50/35/10
Watchman Negative Work on high Temperance has been removed.
Watchman applies buffs to humans in it's darkness.
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I feel like the high temp punishment was for a much different time.
This is no longer that time, and I want to see players maybe fight in the dark
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Did you test this PR?

* [x] This PR compiles
* [ ] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
balance: Rebalanced Watchman,
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
