### PR TITLE
Adjusting Little Red and Funeral's starting instructions to include important changes.

### DIFF
--- a/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_highsec/lcl_red_riding_mercenary.dm
+++ b/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_highsec/lcl_red_riding_mercenary.dm
@@ -37,12 +37,14 @@
 
 	//LCL unique Variables
 	original_abno = /mob/living/simple_animal/hostile/abnormality/red_hood
-	abno_additional_instructions = "You like insight and higher level instinct, \
+	abno_additional_instructions = "You like insight, repression, and higher level instinct, \
 	You are a supernatural mercenary for hire. Your jobs tend to be hunting \
 	your fellow abnormalities with little care for whoever gets in the way. \
 	You hold a burning hatred for the Big Bad Wolf. \
 	Your monies are used for attacks, -30 for hollowpoint & -10 for throwing \
-	knife. You can gain more monies if researchers use ahn on you. Its good business."
+	knife. You can gain more monies if researchers use ahn on you. Its good business. \
+	Your patience for Repression work is significantly lower than other abnormalities, \
+	you will start to lose desire when attacked at around 75% of your max health."
 
 	//Was going to make her eat money but i dont know if money exists in LCL
 	diet_list = list( // a lot of pastries to reference stuff she might've carried in her basket in some versions of the tale

--- a/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_lowsec/lcl_funeral.dm
+++ b/ModularLobotomy/limbus_labs/limbus_abnos/lcl_abno_lowsec/lcl_funeral.dm
@@ -23,7 +23,7 @@
 
 	//LCL unique Variables
 	original_abno = /mob/living/simple_animal/hostile/abnormality/funeral
-	abno_additional_instructions = "You like insight work, \
+	abno_additional_instructions = "You like insight, repression, and instinct work, \
 	Before these scientists trapped you, you came here to bring \
 	peaceful death to the poor souls trapped here."
 


### PR DESCRIPTION
## About The Pull Request

I forgot to do this in the other PR

## Why It's Good For The Game

knowing how your stuff works is pretty important, actually.

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [ ] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
tweak: Changed instructions given to Funeral of the Dead Butterflies and Little Red Riding Hooded Mercenary.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
