### PR TITLE
Adjust some Realization armor Stats and added some missing datums

### DIFF
--- a/code/datums/abnormality/_ego_datum/realized.dm
+++ b/code/datums/abnormality/_ego_datum/realized.dm
@@ -179,10 +179,15 @@ Note: I chose to tag these Realizations based on their own active and passive ab
 /datum/ego_datum/armor/realized/nest
 	item_path = /obj/item/clothing/suit/armor/ego_gear/realization/nest
 	ego_tags = list(EGO_TAG_SUMMONER, EGO_TAG_DEBUFFER)
-
 /// Awe - Contempt, Awe (Spiral of Contempt)
 /datum/ego_datum/armor/realized/awe
 	item_path = /obj/item/clothing/suit/armor/ego_gear/realization/awe
+/// Sole Focus - Heaven (Burrowing Heaven)
+/datum/ego_datum/armor/realized/sole_focus
+	item_path = /obj/item/clothing/suit/armor/ego_gear/realization/sole_focus
+/// Dreaming - Ecstacy (Dreaming Current)
+/datum/ego_datum/armor/realized/dreaming
+	item_path = /obj/item/clothing/suit/armor/ego_gear/realization/dreaming
 
 /* ------------------ ALEPH Realizations ------------------*/
 

--- a/code/datums/abnormality/_ego_datum/realized.dm
+++ b/code/datums/abnormality/_ego_datum/realized.dm
@@ -36,7 +36,9 @@ Note: I chose to tag these Realizations based on their own active and passive ab
 /// Broken Crown - Bucket (Wishing Well)
 /datum/ego_datum/armor/realized/brokencrown
 	item_path = /obj/item/clothing/suit/armor/ego_gear/realization/brokencrown
-
+///Energy Conversion (We Can Change Anything)
+/datum/ego_datum/armor/realized/energyconversion
+	item_path = /obj/item/clothing/suit/armor/ego_gear/realization/energyconversion
 /* ------------------ TETH Realizations ------------------*/
 
 /// Mouth of God - Beak (Punishing Bird)
@@ -113,7 +115,9 @@ Note: I chose to tag these Realizations based on their own active and passive ab
 /datum/ego_datum/armor/realized/experimentation
 	item_path = /obj/item/clothing/suit/armor/ego_gear/realization/experimentation
 	ego_tags = list(EGO_TAG_SUSTAIN, EGO_TAG_AOE_RADIAL, EGO_TAG_SUPPORT, EGO_TAG_HAZARDOUS)
-
+/// Gift - Funny Prank (Laeitia)
+/datum/ego_datum/armor/realized/gift
+	item_path = /obj/item/clothing/suit/armor/ego_gear/realization/gift
 /// Rhythm - Rhythm (Singing Machine)
 /datum/ego_datum/armor/realized/rhythm
 	item_path = /obj/item/clothing/suit/armor/ego_gear/realization/rhythm

--- a/code/modules/clothing/suits/ego_gear/realized.dm
+++ b/code/modules/clothing/suits/ego_gear/realized.dm
@@ -487,7 +487,7 @@ This empowered state makes them arc lightning to all nearby foes when taking dam
 	name = "rhythm"
 	desc = "To satisfy people, a product of despair and suffering of someone else is needed."
 	icon_state = "rhythm"
-	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 70, BLACK_DAMAGE = 40, PALE_DAMAGE = 40)          //Empowers EGO Weapon Rhythm
+	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 70, BLACK_DAMAGE = 40, PALE_DAMAGE = 50)          //Empowers EGO Weapon Rhythm
 
 /* WAW Realizations */
 
@@ -977,7 +977,7 @@ If you land the killing blow on that enemy, you get a buff and a heal.
 	name = "for whom the bell tolls"
 	desc = "I suppose if a man has something once, always something of it remains."
 	icon_state = "thirteen"
-	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 50, BLACK_DAMAGE = 80, PALE_DAMAGE = 70)		//No Ability
+	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 50, BLACK_DAMAGE = 70, PALE_DAMAGE = 80)		//No Ability
 
 /obj/item/clothing/suit/armor/ego_gear/realization/capitalism
 	name = "capitalism"
@@ -1049,6 +1049,14 @@ If you land the killing blow on that enemy, you get a buff and a heal.
 	desc = "She's always watching. Do not forget who it was that sprung the project to the skies."
 	icon_state = "sole_focus"
 	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 80, BLACK_DAMAGE = 80, PALE_DAMAGE = 40) //Two slashes allows for free ranting in the files, so... first, sprites made by Monoman335, basically it's heaven's stats boosted, the 50 is for Red resist and 40 for pale because the weapon does Red and I think it fits. Also no ability. Yet.
+
+/obj/item/clothing/suit/armor/ego_gear/realization/dreaming
+	name = "dreaming"
+	desc = "A dream to be free."
+	icon_state = "dreaming"
+	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 80, BLACK_DAMAGE = 30, PALE_DAMAGE = 50)
+	assimilation_ability = /obj/effect/proc_holder/ability/ego_assimilation/dreaming
+
 
 /* ALEPH Realizations */
 
@@ -1156,10 +1164,3 @@ If you land the killing blow on that enemy, you get a buff and a heal.
 	icon_state = "gasharpoon"
 	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 70, BLACK_DAMAGE = 20, PALE_DAMAGE = 80)//230, required for the corresponding weapon abilities
 	assimilation_ability = /obj/effect/proc_holder/ability/ego_assimilation/gasharpoon
-
-/obj/item/clothing/suit/armor/ego_gear/realization/dreaming
-	name = "dreaming"
-	desc = "A dream to be free."
-	icon_state = "dreaming"
-	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 80, BLACK_DAMAGE = 60, PALE_DAMAGE = 70)
-	assimilation_ability = /obj/effect/proc_holder/ability/ego_assimilation/dreaming

--- a/code/modules/clothing/suits/ego_gear/realized.dm
+++ b/code/modules/clothing/suits/ego_gear/realized.dm
@@ -1134,7 +1134,7 @@ If you land the killing blow on that enemy, you get a buff and a heal.
 	name = "farmwatch"
 	desc = "Haha. You're right, the calf doesn't recognize me."
 	icon_state = "farmwatch"
-	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 70, BLACK_DAMAGE = 40, PALE_DAMAGE = 60)
+	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 80, BLACK_DAMAGE = 40, PALE_DAMAGE = 60)
 	hat = /obj/item/clothing/head/ego_hat/farmwatch_hat
 	assimilation_ability = /obj/effect/proc_holder/ability/ego_assimilation/farmwatch
 
@@ -1147,7 +1147,7 @@ If you land the killing blow on that enemy, you get a buff and a heal.
 	name = "spicebush"
 	desc = "I've always wished to be a bud. Soon to bloom, bearing a scent within."
 	icon_state = "spicebush"
-	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 70, BLACK_DAMAGE = 70, PALE_DAMAGE = 60)
+	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 70, BLACK_DAMAGE = 70, PALE_DAMAGE = 60)
 	assimilation_ability = /obj/effect/proc_holder/ability/ego_assimilation/spicebush
 
 /obj/item/clothing/suit/armor/ego_gear/realization/desperation


### PR DESCRIPTION
## About The Pull Request
Makes Dreaming and Harmony Realization have the proper armor stats, adjusts Bell Tolls stats, and added some missing realized datums, along with moving some code to the proper spot.
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The armor values fit better, and some fixes are good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [ ] This PR runs fine in a local test
* [ ] This PR does not produce runtimes
* [ ] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
balance: rebalanced realized armor values
fix: fixed some missing datums and some code placement
/:cl:
<!--
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
