### PR TITLE
Breathing: The Nerfening

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -80,6 +80,8 @@
 /// Absolute MAXIMUM oxyloss that can be dealt by any individual source for each breath-tick. They can stack, but this number is the guideline for all others (as it represents missing your lungs entirely.)
 #define HUMAN_MAX_OXYLOSS_RATE		(5 * TICKS_PER_BREATH)
 #define HUMAN_HIGH_OXYLOSS_RATE		(4 * TICKS_PER_BREATH)
+/// This one is specifically used for the amount of oxygen regenerated per successful breath.
+#define HUMAN_BREATHING_OXYLOSS_RATE (3 * TICKS_PER_BREATH)
 #define HUMAN_MEDIUM_OXYLOSS_RATE	(2 * TICKS_PER_BREATH)
 #define HUMAN_LOW_OXYLOSS_RATE		(1 * TICKS_PER_BREATH)
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -86,14 +86,20 @@
 					losebreath += HUMAN_MEDIUM_OXYLOSS_RATE  // You are struggling a lot to breathe
 				if(SOFT_CRIT)
 					losebreath += HUMAN_LOW_OXYLOSS_RATE  // You are struggling a bit to breathe
+		// Note: I'm not sure what this elif is accomplishing. We only access this if we have Epinephrine, but only deal the damage if we don't have the NOCRITDAMAGE trait.
+		// ...which Epinephrine gives us, so... uh, I don't know.
 		else if(!(HAS_TRAIT(src, TRAIT_NOCRITDAMAGE)))
 			adjustBruteLoss(TICKS_PER_BREATH)
 
 	// Breathe!
 	if(losebreath <= 0)
+		// Alert is cleared here to avoid having the alert get stuck in some rare edge cases.
+		// This does cause one list access and one IF check on breaths that otherwise might not need them, but that's, like, not even that bad, still leagues ahead of the old atmos-breathing.
+		// The only better way I can think of handling clearing this alert is having a signal be sent whenever oxygen damage is changed or set, and if it's at 0 or above, clear the alert.
+		// The problem is that... that doesn't account for losebreath, lung failure, etc. So, you could still be suffocating but not have the alert then!
+		clear_alert("not_enough_oxy", /atom/movable/screen/alert/not_enough_oxy)
 		if(oxyloss && !non_breathler) // If any of the conditions above is true, we cannot breathe on our own, even if we are not actively suffocating, so we will not recover oxyloss naturally.
-			clear_alert("not_enough_oxy", /atom/movable/screen/alert/not_enough_oxy)
-			adjustOxyLoss(-(HUMAN_HIGH_OXYLOSS_RATE))
+			adjustOxyLoss(-(HUMAN_BREATHING_OXYLOSS_RATE))
 		losebreath = 0
 		return TRUE
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -697,7 +697,7 @@
 	else if(admin_revive)
 		updatehealth()
 		get_up(TRUE)
-
+	update_blindness() // Gets rid of an annoying bug with revivals that leave your vision monochrome.
 
 /mob/living/proc/remove_CC()
 	SetStun(0)

--- a/code/modules/mob/status_procs.dm
+++ b/code/modules/mob/status_procs.dm
@@ -67,7 +67,8 @@
 	else
 		clear_alert("blind")
 		clear_fullscreen("blind")
-		remove_client_colour(/datum/client_colour/monochrome/blind)
+		for(var/datum/client_colour/monochrome/blind/why_are_there_multiple in src.client_colours) // ??? i guess we can have multiple of the same for some reason?
+			remove_client_colour(/datum/client_colour/monochrome/blind)
 
 
 /**


### PR DESCRIPTION
## About The Pull Request
- Oxygen damage regeneration 16 -> 12 per breath 
(A breath happens every 4 ticks. A tick happens every 2 seconds. Thus, Oxy healing 2/s -> 1.5/s)

- Fixed the persistent oxygen alert even after you're fine
  - Sadly I have to make it check on every breath, sorry Eidos I know you'd hate it.
There's no better solution that doesn't ignore some mechanics (we can make it check when oxy damage is being dealt/set, but that ignores Losebreath and thus the actual purpose of the alert)

- Fixed monochrome after admin revivals

# NOTE:
I found something very strange while testing, if you take an amount of oxygen damage that should put you in soft crit with no other damage taken, you get stuck as 'unconscious' but not in crit, and never die to crit damage, but also never breathe so you never get back up. Extremely weird edge case, just thought it was worth a mention. Any damage taken in that state does make you start taking crit damage though.
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfixes
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Put your cool images here

<!-- If you have any images or showcases of this PR, put them here. The easiest way is to copy the image as a file and then paste it in.
How to add a collapsible:
<details>
    <summary>Click me!</summary>
    Hello World!
</details>
-->

### Did you test this PR?

* [X] This PR compiles
* [X] This PR runs fine in a local test
* [X] This PR does not produce runtimes
* [X] This PR works as intended
* [ ] Other people have completed the above too

<!-- Put an X inside the brackets if you did this step, like so: [X] -->

## Attribution

<!-- If this PR includes work by other authors, please include their name and/or a link to the original PR you are porting here. -->

## Changelog
:cl:
balance: Breathing oxygen damage regeneration 16 -> 12 per breath (2/s -> 1.5/s).
fix: Being revived (such as by AHeal or a revival wand) should properly remove monochrome vision.
fix: Will always check to clear the Not Enough Oxygen alert when breathing.
/:cl:
<!--
Tags:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
-->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
